### PR TITLE
Add Linux and OSX continuous integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: csharp
+
+os:
+ - linux
+ - osx
+
+mono: none
+dotnet: 1.0.4
+dist: trusty
+before_script: cd neo.UnitTests
+
+script:
+ - dotnet restore
+ - dotnet test


### PR DESCRIPTION
This enables initial CI testing in Linux and OSX using travis.

@erikzhang for a private working example see (https://github.com/canesin/neosecurity/pull/4)

There is two steps that are needed.

1. Enable travis on the repository (enter in https://travis-ci.org ):
![image](https://user-images.githubusercontent.com/353648/28236283-4540dd82-68f0-11e7-86bb-ec537a02fa2e.png)

2. Protect master to only accept PRs that have passed testing:
![image](https://user-images.githubusercontent.com/353648/28236274-df1160ea-68ef-11e7-91a8-ef73be2bebd1.png)


