### PR TITLE
Fix OSX CI on dotnet restore

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,10 @@ os:
 mono: none
 dotnet: 1.0.4
 dist: trusty
-before_script: cd neo.UnitTests
+
+before_install:
+  - cd neo.UnitTests
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ulimit -n 2048; fi
 
 script:
  - dotnet restore


### PR DESCRIPTION
When performing "dotnet restore" the default limit of open files on OSX can be overcome, this fix it.