### PR TITLE
Adding method to get system fee by block to rpc server

### DIFF
--- a/neo/Network/RPC/RpcServer.cs
+++ b/neo/Network/RPC/RpcServer.cs
@@ -104,7 +104,26 @@ namespace Neo.Network.RPC
                 case "getblockhash":
                     {
                         uint height = (uint)_params[0].AsNumber();
-                        return Blockchain.Default.GetBlockHash(height).ToString();
+                        if (height >= 0 && height <= Blockchain.Default.Height)
+                        {
+                            return Blockchain.Default.GetBlockHash(height).ToString();
+                        }
+                        else
+                        {
+                            throw new RpcException(-100, "Invalid Height");
+                        }
+                    }
+                case "getblocksysfee":
+                    {
+                        uint height = (uint)_params[0].AsNumber();
+                        if (height >= 0 && height <= Blockchain.Default.Height)
+                        {
+                            return Blockchain.Default.GetSysFeeAmount(height).ToString();
+                        }
+                        else
+                        {
+                            throw new RpcException(-100, "Invalid Height");
+                        }
                     }
                 case "getconnectioncount":
                     return LocalNode.RemoteNodeCount;


### PR DESCRIPTION
Also added a check for a valid block height for `getblocksysfee` and `getblockhash` cases

This is for the light wallet and any other applications that need to calculate claim transaction amounts in order use `sendrawtransaction` to make a claim.

usage: send a block height (example 204651)
send > `{"jsonrpc": "2.0", "method": "getblocksysfee", "params": [204651], "id": 4}`
receive back > `{"jsonrpc":"2.0","id":4,"result":"1470"}`_
