### PR TITLE
Replace cases of ContainsKey/indexer with TryGetValue

### DIFF
--- a/neo/Consensus/ConsensusService.cs
+++ b/neo/Consensus/ConsensusService.cs
@@ -258,8 +258,7 @@ namespace Neo.Consensus
             Dictionary<UInt256, Transaction> mempool = LocalNode.GetMemoryPool().ToDictionary(p => p.Hash);
             foreach (UInt256 hash in context.TransactionHashes.Skip(1))
             {
-                Transaction tx;
-                if (mempool.TryGetValue(hash, out tx))
+                if (mempool.TryGetValue(hash, out Transaction tx))
                     if (!AddTransaction(tx, false))
                         return;
             }

--- a/neo/Consensus/ConsensusService.cs
+++ b/neo/Consensus/ConsensusService.cs
@@ -257,9 +257,12 @@ namespace Neo.Consensus
             context.Signatures[payload.ValidatorIndex] = message.Signature;
             Dictionary<UInt256, Transaction> mempool = LocalNode.GetMemoryPool().ToDictionary(p => p.Hash);
             foreach (UInt256 hash in context.TransactionHashes.Skip(1))
-                if (mempool.ContainsKey(hash))
-                    if (!AddTransaction(mempool[hash], false))
+            {
+                Transaction tx;
+                if (mempool.TryGetValue(hash, out tx))
+                    if (!AddTransaction(tx, false))
                         return;
+            }
             if (!AddTransaction(message.MinerTransaction, true)) return;
             LocalNode.AllowHashes(context.TransactionHashes.Except(context.Transactions.Keys));
             if (context.Transactions.Count < context.TransactionHashes.Length)

--- a/neo/Core/AssetState.cs
+++ b/neo/Core/AssetState.cs
@@ -112,19 +112,22 @@ namespace Neo.Core
                     _names = ((JArray)JObject.Parse(Name)).ToDictionary(p => new CultureInfo(p["lang"].AsString()), p => p["name"].AsString());
             }
             if (culture == null) culture = CultureInfo.CurrentCulture;
-            if (_names.ContainsKey(culture))
+            string name;
+            if (_names.TryGetValue(culture, out name))
             {
-                return _names[culture];
+                return name;
             }
-            else if (_names.ContainsKey(new CultureInfo("en")))
+            else if (_names.TryGetValue(en, out name))
             {
-                return _names[new CultureInfo("en")];
+                return name;
             }
             else
             {
                 return _names.Values.First();
             }
         }
+
+        private static readonly CultureInfo en = new CultureInfo("en");
 
         public override void Serialize(BinaryWriter writer)
         {

--- a/neo/Core/AssetState.cs
+++ b/neo/Core/AssetState.cs
@@ -112,8 +112,7 @@ namespace Neo.Core
                     _names = ((JArray)JObject.Parse(Name)).ToDictionary(p => new CultureInfo(p["lang"].AsString()), p => p["name"].AsString());
             }
             if (culture == null) culture = CultureInfo.CurrentCulture;
-            string name;
-            if (_names.TryGetValue(culture, out name))
+            if (_names.TryGetValue(culture, out string name))
             {
                 return name;
             }

--- a/neo/Core/Blockchain.cs
+++ b/neo/Core/Blockchain.cs
@@ -168,8 +168,7 @@ namespace Neo.Core
                         throw new ArgumentException();
                 foreach (CoinReference claim in group)
                 {
-                    SpentCoin claimed;
-                    if (!claimable.TryGetValue(claim.PrevIndex, out claimed))
+                    if (!claimable.TryGetValue(claim.PrevIndex, out SpentCoin claimed))
                         if (ignoreClaimed)
                             continue;
                         else

--- a/neo/Core/Blockchain.cs
+++ b/neo/Core/Blockchain.cs
@@ -32,7 +32,7 @@ namespace Neo.Core
         /// <summary>
         /// 后备记账人列表
         /// </summary>
-        public static readonly ECPoint[] StandbyValidators = Settings.Default.StandbyValidators.OfType<string>().Select(p => ECPoint.DecodePoint(p.HexToBytes(), ECCurve.Secp256r1)).ToArray();
+        public static readonly ECPoint[] StandbyValidators = Settings.Default.StandbyValidators.Select(p => ECPoint.DecodePoint(p.HexToBytes(), ECCurve.Secp256r1)).ToArray();
 
 #pragma warning disable CS0612
         public static readonly RegisterTransaction SystemShare = new RegisterTransaction
@@ -168,12 +168,13 @@ namespace Neo.Core
                         throw new ArgumentException();
                 foreach (CoinReference claim in group)
                 {
-                    if (!claimable.ContainsKey(claim.PrevIndex))
+                    SpentCoin claimed;
+                    if (!claimable.TryGetValue(claim.PrevIndex, out claimed))
                         if (ignoreClaimed)
                             continue;
                         else
                             throw new ArgumentException();
-                    unclaimed.Add(claimable[claim.PrevIndex]);
+                    unclaimed.Add(claimed);
                 }
             }
             return CalculateBonusInternal(unclaimed);

--- a/neo/Core/Blockchain.cs
+++ b/neo/Core/Blockchain.cs
@@ -32,7 +32,7 @@ namespace Neo.Core
         /// <summary>
         /// 后备记账人列表
         /// </summary>
-        public static readonly ECPoint[] StandbyValidators = Settings.Default.StandbyValidators.Select(p => ECPoint.DecodePoint(p.HexToBytes(), ECCurve.Secp256r1)).ToArray();
+        public static readonly ECPoint[] StandbyValidators = Settings.Default.StandbyValidators.OfType<string>().Select(p => ECPoint.DecodePoint(p.HexToBytes(), ECCurve.Secp256r1)).ToArray();
 
 #pragma warning disable CS0612
         public static readonly RegisterTransaction SystemShare = new RegisterTransaction

--- a/neo/Core/Transaction.cs
+++ b/neo/Core/Transaction.cs
@@ -110,14 +110,7 @@ namespace Neo.Core
         /// <summary>
         /// 系统费用
         /// </summary>
-        public virtual Fixed8 SystemFee
-        {
-            get
-            {
-                Fixed8 fee;
-                return Settings.Default.SystemFee.TryGetValue(Type, out fee) ? fee : Fixed8.Zero;
-            }
-        }
+        public virtual Fixed8 SystemFee => Settings.Default.SystemFee.TryGetValue(Type, out Fixed8 fee) ? fee : Fixed8.Zero;
 
         /// <summary>
         /// 用指定的类型初始化Transaction对象

--- a/neo/Core/Transaction.cs
+++ b/neo/Core/Transaction.cs
@@ -114,9 +114,8 @@ namespace Neo.Core
         {
             get
             {
-                if (Settings.Default.SystemFee.ContainsKey(Type))
-                    return Settings.Default.SystemFee[Type];
-                return Fixed8.Zero;
+                Fixed8 fee;
+                return Settings.Default.SystemFee.TryGetValue(Type, out fee) ? fee : Fixed8.Zero;
             }
         }
 

--- a/neo/IO/Caching/Cache.cs
+++ b/neo/IO/Caching/Cache.cs
@@ -31,8 +31,8 @@ namespace Neo.IO.Caching
             {
                 lock (SyncRoot)
                 {
-                    if (!InnerDictionary.ContainsKey(key)) throw new KeyNotFoundException();
-                    CacheItem item = InnerDictionary[key];
+                    CacheItem item;
+                    if (!InnerDictionary.TryGetValue(key, out item)) throw new KeyNotFoundException();
                     OnAccess(item);
                     return item.Value;
                 }
@@ -74,9 +74,10 @@ namespace Neo.IO.Caching
 
         private void AddInternal(TKey key, TValue item)
         {
-            if (InnerDictionary.ContainsKey(key))
+            CacheItem cacheItem;
+            if (InnerDictionary.TryGetValue(key, out cacheItem))
             {
-                OnAccess(InnerDictionary[key]);
+                OnAccess(cacheItem);
             }
             else
             {
@@ -119,8 +120,9 @@ namespace Neo.IO.Caching
         {
             lock (SyncRoot)
             {
-                if (!InnerDictionary.ContainsKey(key)) return false;
-                OnAccess(InnerDictionary[key]);
+                CacheItem cacheItem;
+                if (!InnerDictionary.TryGetValue(key, out cacheItem)) return false;
+                OnAccess(cacheItem);
                 return true;
             }
         }
@@ -168,8 +170,9 @@ namespace Neo.IO.Caching
         {
             lock (SyncRoot)
             {
-                if (!InnerDictionary.ContainsKey(key)) return false;
-                RemoveInternal(InnerDictionary[key]);
+                CacheItem cacheItem;
+                if (!InnerDictionary.TryGetValue(key, out cacheItem)) return false;
+                RemoveInternal(cacheItem);
                 return true;
             }
         }
@@ -195,10 +198,11 @@ namespace Neo.IO.Caching
         {
             lock (SyncRoot)
             {
-                if (InnerDictionary.ContainsKey(key))
+                CacheItem cacheItem;
+                if (InnerDictionary.TryGetValue(key, out cacheItem))
                 {
-                    OnAccess(InnerDictionary[key]);
-                    item = InnerDictionary[key].Value;
+                    OnAccess(cacheItem);
+                    item = cacheItem.Value;
                     return true;
                 }
             }

--- a/neo/IO/Caching/Cache.cs
+++ b/neo/IO/Caching/Cache.cs
@@ -31,8 +31,7 @@ namespace Neo.IO.Caching
             {
                 lock (SyncRoot)
                 {
-                    CacheItem item;
-                    if (!InnerDictionary.TryGetValue(key, out item)) throw new KeyNotFoundException();
+                    if (!InnerDictionary.TryGetValue(key, out CacheItem item)) throw new KeyNotFoundException();
                     OnAccess(item);
                     return item.Value;
                 }
@@ -74,8 +73,7 @@ namespace Neo.IO.Caching
 
         private void AddInternal(TKey key, TValue item)
         {
-            CacheItem cacheItem;
-            if (InnerDictionary.TryGetValue(key, out cacheItem))
+            if (InnerDictionary.TryGetValue(key, out CacheItem cacheItem))
             {
                 OnAccess(cacheItem);
             }
@@ -120,8 +118,7 @@ namespace Neo.IO.Caching
         {
             lock (SyncRoot)
             {
-                CacheItem cacheItem;
-                if (!InnerDictionary.TryGetValue(key, out cacheItem)) return false;
+                if (!InnerDictionary.TryGetValue(key, out CacheItem cacheItem)) return false;
                 OnAccess(cacheItem);
                 return true;
             }
@@ -170,8 +167,7 @@ namespace Neo.IO.Caching
         {
             lock (SyncRoot)
             {
-                CacheItem cacheItem;
-                if (!InnerDictionary.TryGetValue(key, out cacheItem)) return false;
+                if (!InnerDictionary.TryGetValue(key, out CacheItem cacheItem)) return false;
                 RemoveInternal(cacheItem);
                 return true;
             }
@@ -198,8 +194,7 @@ namespace Neo.IO.Caching
         {
             lock (SyncRoot)
             {
-                CacheItem cacheItem;
-                if (InnerDictionary.TryGetValue(key, out cacheItem))
+                if (InnerDictionary.TryGetValue(key, out CacheItem cacheItem))
                 {
                     OnAccess(cacheItem);
                     item = cacheItem.Value;

--- a/neo/IO/Caching/DataCache.cs
+++ b/neo/IO/Caching/DataCache.cs
@@ -21,8 +21,7 @@ namespace Neo.IO.Caching
         {
             get
             {
-                Trackable trackable;
-                if (dictionary.TryGetValue(key, out trackable))
+                if (dictionary.TryGetValue(key, out Trackable trackable))
                 {
                     if (trackable.State == TrackState.Deleted)
                         throw new KeyNotFoundException();
@@ -43,8 +42,7 @@ namespace Neo.IO.Caching
 
         public void Add(TKey key, TValue value)
         {
-            Trackable trackable;
-            if (dictionary.TryGetValue(key, out trackable) && trackable.State != TrackState.Deleted)
+            if (dictionary.TryGetValue(key, out Trackable trackable) && trackable.State != TrackState.Deleted)
                 throw new ArgumentException();
             dictionary[key] = new Trackable
             {
@@ -100,8 +98,7 @@ namespace Neo.IO.Caching
 
         public TValue GetAndChange(TKey key, Func<TValue> factory = null)
         {
-            Trackable trackable;
-            if (dictionary.TryGetValue(key, out trackable))
+            if (dictionary.TryGetValue(key, out Trackable trackable))
             {
                 if (trackable.State == TrackState.Deleted)
                 {
@@ -138,8 +135,7 @@ namespace Neo.IO.Caching
 
         public TValue GetOrAdd(TKey key, Func<TValue> factory)
         {
-            Trackable trackable;
-            if (dictionary.TryGetValue(key, out trackable))
+            if (dictionary.TryGetValue(key, out Trackable trackable))
             {
                 if (trackable.State == TrackState.Deleted)
                 {
@@ -170,8 +166,7 @@ namespace Neo.IO.Caching
 
         public TValue TryGet(TKey key)
         {
-            Trackable trackable;
-            if (dictionary.TryGetValue(key, out trackable))
+            if (dictionary.TryGetValue(key, out Trackable trackable))
             {
                 if (trackable.State == TrackState.Deleted) return null;
                 return trackable.Item;

--- a/neo/IO/Json/JObject.cs
+++ b/neo/IO/Json/JObject.cs
@@ -14,8 +14,7 @@ namespace Neo.IO.Json
         {
             get
             {
-                JObject value;
-                properties.TryGetValue(name, out value);
+                properties.TryGetValue(name, out JObject value);
                 return value;
             }
             set

--- a/neo/IO/Json/JObject.cs
+++ b/neo/IO/Json/JObject.cs
@@ -14,9 +14,9 @@ namespace Neo.IO.Json
         {
             get
             {
-                if (!properties.ContainsKey(name))
-                    return null;
-                return properties[name];
+                JObject value;
+                properties.TryGetValue(name, out value);
+                return value;
             }
             set
             {

--- a/neo/Implementations/Blockchains/LevelDB/LevelDBBlockchain.cs
+++ b/neo/Implementations/Blockchains/LevelDB/LevelDBBlockchain.cs
@@ -249,8 +249,7 @@ namespace Neo.Implementations.Blockchains.LevelDB
         {
             lock (header_cache)
             {
-                Header header;
-                if (header_cache.TryGetValue(hash, out header))
+                if (header_cache.TryGetValue(hash, out Header header))
                     return header;
             }
             Slice value;
@@ -385,10 +384,8 @@ namespace Neo.Implementations.Blockchains.LevelDB
                 if (accounts.Length > 0)
                     foreach (AccountState account in accounts)
                     {
-                        Fixed8 value;
-                        Fixed8 balance = account.Balances.TryGetValue(SystemShare.Hash, out value) ? value : Fixed8.Zero;
-                        Fixed8 change;
-                        if (changes.TryGetValue(account.ScriptHash, out change))
+                        Fixed8 balance = account.Balances.TryGetValue(SystemShare.Hash, out Fixed8 value) ? value : Fixed8.Zero;
+                        if (changes.TryGetValue(account.ScriptHash, out Fixed8 change))
                             balance += change;
                         if (balance <= Fixed8.Zero) continue;
                         yield return new VoteState

--- a/neo/Implementations/Blockchains/LevelDB/LevelDBBlockchain.cs
+++ b/neo/Implementations/Blockchains/LevelDB/LevelDBBlockchain.cs
@@ -249,8 +249,9 @@ namespace Neo.Implementations.Blockchains.LevelDB
         {
             lock (header_cache)
             {
-                if (header_cache.ContainsKey(hash))
-                    return header_cache[hash];
+                Header header;
+                if (header_cache.TryGetValue(hash, out header))
+                    return header;
             }
             Slice value;
             if (!db.TryGet(ReadOptions.Default, SliceBuilder.Begin(DataEntryPrefix.DATA_Block).Add(hash), out value))
@@ -384,9 +385,11 @@ namespace Neo.Implementations.Blockchains.LevelDB
                 if (accounts.Length > 0)
                     foreach (AccountState account in accounts)
                     {
-                        Fixed8 balance = account.Balances.ContainsKey(SystemShare.Hash) ? account.Balances[SystemShare.Hash] : Fixed8.Zero;
-                        if (changes.ContainsKey(account.ScriptHash))
-                            balance += changes[account.ScriptHash];
+                        Fixed8 value;
+                        Fixed8 balance = account.Balances.TryGetValue(SystemShare.Hash, out value) ? value : Fixed8.Zero;
+                        Fixed8 change;
+                        if (changes.TryGetValue(account.ScriptHash, out change))
+                            balance += change;
                         if (balance <= Fixed8.Zero) continue;
                         yield return new VoteState
                         {

--- a/neo/Network/LocalNode.cs
+++ b/neo/Network/LocalNode.cs
@@ -340,8 +340,7 @@ namespace Neo.Network
         {
             lock (mem_pool)
             {
-                Transaction tx;
-                if (!mem_pool.TryGetValue(hash, out tx))
+                if (!mem_pool.TryGetValue(hash, out Transaction tx))
                     return null;
                 return tx;
             }

--- a/neo/SmartContract/StateMachine.cs
+++ b/neo/SmartContract/StateMachine.cs
@@ -100,8 +100,7 @@ namespace Neo.SmartContract
             if (votes.Length > 1024) return false;
             account = accounts[account.ScriptHash];
             if (account.IsFrozen) return false;
-            Fixed8 balance;
-            if ((!account.Balances.TryGetValue(Blockchain.SystemShare.Hash, out balance) || balance.Equals(Fixed8.Zero)) && votes.Length > 0)
+            if ((!account.Balances.TryGetValue(Blockchain.SystemShare.Hash, out Fixed8 balance) || balance.Equals(Fixed8.Zero)) && votes.Length > 0)
                 return false;
             if (!CheckWitness(engine, account.ScriptHash)) return false;
             account = accounts.GetAndChange(account.ScriptHash);
@@ -291,8 +290,7 @@ namespace Neo.SmartContract
         private bool Contract_GetStorageContext(ExecutionEngine engine)
         {
             ContractState contract = engine.EvaluationStack.Pop().GetInterface<ContractState>();
-            UInt160 created;
-            if (!contracts_created.TryGetValue(contract.ScriptHash, out created)) return false;
+            if (!contracts_created.TryGetValue(contract.ScriptHash, out UInt160 created)) return false;
             if (!created.Equals(new UInt160(engine.CurrentContext.ScriptHash))) return false;
             engine.EvaluationStack.Push(StackItem.FromInterface(new StorageContext
             {

--- a/neo/SmartContract/StateMachine.cs
+++ b/neo/SmartContract/StateMachine.cs
@@ -100,7 +100,8 @@ namespace Neo.SmartContract
             if (votes.Length > 1024) return false;
             account = accounts[account.ScriptHash];
             if (account.IsFrozen) return false;
-            if ((!account.Balances.ContainsKey(Blockchain.SystemShare.Hash) || account.Balances[Blockchain.SystemShare.Hash].Equals(Fixed8.Zero)) && votes.Length > 0)
+            Fixed8 balance;
+            if ((!account.Balances.TryGetValue(Blockchain.SystemShare.Hash, out balance) || balance.Equals(Fixed8.Zero)) && votes.Length > 0)
                 return false;
             if (!CheckWitness(engine, account.ScriptHash)) return false;
             account = accounts.GetAndChange(account.ScriptHash);
@@ -290,8 +291,9 @@ namespace Neo.SmartContract
         private bool Contract_GetStorageContext(ExecutionEngine engine)
         {
             ContractState contract = engine.EvaluationStack.Pop().GetInterface<ContractState>();
-            if (!contracts_created.ContainsKey(contract.ScriptHash)) return false;
-            if (!contracts_created[contract.ScriptHash].Equals(new UInt160(engine.CurrentContext.ScriptHash))) return false;
+            UInt160 created;
+            if (!contracts_created.TryGetValue(contract.ScriptHash, out created)) return false;
+            if (!created.Equals(new UInt160(engine.CurrentContext.ScriptHash))) return false;
             engine.EvaluationStack.Push(StackItem.FromInterface(new StorageContext
             {
                 ScriptHash = contract.ScriptHash

--- a/neo/SmartContract/StateReader.cs
+++ b/neo/SmartContract/StateReader.cs
@@ -492,8 +492,7 @@ namespace Neo.SmartContract
             AccountState account = engine.EvaluationStack.Pop().GetInterface<AccountState>();
             UInt256 asset_id = new UInt256(engine.EvaluationStack.Pop().GetByteArray());
             if (account == null) return false;
-            Fixed8 bal;
-            Fixed8 balance = account.Balances.TryGetValue(asset_id, out bal) ? bal : Fixed8.Zero;
+            Fixed8 balance = account.Balances.TryGetValue(asset_id, out Fixed8 value) ? value : Fixed8.Zero;
             engine.EvaluationStack.Push(balance.GetData());
             return true;
         }

--- a/neo/SmartContract/StateReader.cs
+++ b/neo/SmartContract/StateReader.cs
@@ -484,7 +484,8 @@ namespace Neo.SmartContract
             AccountState account = engine.EvaluationStack.Pop().GetInterface<AccountState>();
             UInt256 asset_id = new UInt256(engine.EvaluationStack.Pop().GetByteArray());
             if (account == null) return false;
-            Fixed8 balance = account.Balances.ContainsKey(asset_id) ? account.Balances[asset_id] : Fixed8.Zero;
+            Fixed8 bal;
+            Fixed8 balance = account.Balances.TryGetValue(asset_id, out bal) ? bal : Fixed8.Zero;
             engine.EvaluationStack.Push(balance.GetData());
             return true;
         }

--- a/neo/Wallets/Wallet.cs
+++ b/neo/Wallets/Wallet.cs
@@ -295,8 +295,9 @@ namespace Neo.Wallets
         {
             lock (keys)
             {
-                if (!keys.ContainsKey(publicKeyHash)) return null;
-                return keys[publicKeyHash];
+                KeyPair key;
+                keys.TryGetValue(publicKeyHash, out key);
+                return key;
             }
         }
 
@@ -305,8 +306,8 @@ namespace Neo.Wallets
             lock (keys)
                 lock (contracts)
                 {
-                    if (!contracts.ContainsKey(scriptHash)) return null;
-                    return keys[contracts[scriptHash].PublicKeyHash];
+                    Contract contract;
+                    return !contracts.TryGetValue(scriptHash, out contract) ? null : keys[contract.PublicKeyHash];
                 }
         }
 
@@ -366,8 +367,9 @@ namespace Neo.Wallets
         {
             lock (contracts)
             {
-                if (!contracts.ContainsKey(scriptHash)) return null;
-                return contracts[scriptHash];
+                Contract contract;
+                contracts.TryGetValue(scriptHash, out contract);
+                return contract;
             }
         }
 

--- a/neo/Wallets/Wallet.cs
+++ b/neo/Wallets/Wallet.cs
@@ -295,8 +295,7 @@ namespace Neo.Wallets
         {
             lock (keys)
             {
-                KeyPair key;
-                keys.TryGetValue(publicKeyHash, out key);
+                keys.TryGetValue(publicKeyHash, out KeyPair key);
                 return key;
             }
         }
@@ -306,8 +305,7 @@ namespace Neo.Wallets
             lock (keys)
                 lock (contracts)
                 {
-                    Contract contract;
-                    return !contracts.TryGetValue(scriptHash, out contract) ? null : keys[contract.PublicKeyHash];
+                    return !contracts.TryGetValue(scriptHash, out Contract contract) ? null : keys[contract.PublicKeyHash];
                 }
         }
 
@@ -367,8 +365,7 @@ namespace Neo.Wallets
         {
             lock (contracts)
             {
-                Contract contract;
-                contracts.TryGetValue(scriptHash, out contract);
+                contracts.TryGetValue(scriptHash, out Contract contract);
                 return contract;
             }
         }


### PR DESCRIPTION
Where possible, remove duplicate work where FindEntry is called first to check existence of item in dictionary, then again when indexer is invoked to retrieve the value, TryGetValue is closer to O(n) and in some cases easier to read.