### PR TITLE
Add support for exponent notation to Fixed8 and use invariant culture

### DIFF
--- a/neo.UnitTests/UT_Fixed8.cs
+++ b/neo.UnitTests/UT_Fixed8.cs
@@ -1,0 +1,25 @@
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Neo.UnitTests
+{
+    [TestClass]
+    public class UT_Fixed8
+    {
+        [TestMethod]
+        public void Basic_equality()
+        {
+            var a = Fixed8.FromDecimal(1.23456789m);
+            var b = Fixed8.Parse("1.23456789");
+            a.Should().Be(b);
+        }
+
+        [TestMethod]
+        public void Can_parse_exponent_notation()
+        {
+            Fixed8 expected = Fixed8.FromDecimal(1.23m);
+            Fixed8 actual = Fixed8.Parse("1.23E-0");
+            actual.Should().Be(expected);
+        }
+    }
+}

--- a/neo/Fixed8.cs
+++ b/neo/Fixed8.cs
@@ -1,5 +1,6 @@
 ﻿using Neo.IO;
 using System;
+using System.Globalization;
 using System.IO;
 
 namespace Neo
@@ -116,7 +117,7 @@ namespace Neo
 
         public static Fixed8 Parse(string s)
         {
-            return FromDecimal(decimal.Parse(s));
+            return FromDecimal(decimal.Parse(s, NumberStyles.Float, CultureInfo.InvariantCulture));
         }
 
         void ISerializable.Serialize(BinaryWriter writer)
@@ -126,7 +127,7 @@ namespace Neo
 
         public override string ToString()
         {
-            return ((decimal)this).ToString();
+            return ((decimal)this).ToString(CultureInfo.InvariantCulture);
         }
 
         public string ToString(string format)
@@ -142,7 +143,7 @@ namespace Neo
         public static bool TryParse(string s, out Fixed8 result)
         {
             decimal d;
-            if (!decimal.TryParse(s, out d))
+            if (!decimal.TryParse(s, NumberStyles.Float, CultureInfo.InvariantCulture, out d))
             {
                 result = default(Fixed8);
                 return false;


### PR DESCRIPTION
Added  ability to express Satoshis in exponent notation (such as when dealing with dust and exchanges), and made string operations culture invariant.