### PR TITLE
Feature verification state machine

### DIFF
--- a/neo/Core/Helper.cs
+++ b/neo/Core/Helper.cs
@@ -147,22 +147,6 @@ namespace Neo.Core
                 // and a transfer of assets will occur
                 if (engine.EvaluationStack.Count != 1 || !engine.EvaluationStack.Pop().GetBoolean()) return false;
 
-
-                if( ! is_standard ) {
-
-                    // we will allow verification contracts the ability to alter the storages states
-                    // so that, for example, a verification contract could look up an address in storage
-                    // and determine if it can withdraw from an account
-                    // after that operation, the verification code will need to write back to storage
-                    // to indicate that, for example, account A has withdrawn X amount
-
-                    // this will not occur if the verification script returns false
-                    // if that is the case, the transfer did not succeed, and we should
-                    // not need to place anything into storage, or alter storage
-                    StateMachine machine = state_reader as StateMachine;
-                    machine.CommitStorages();
-                }
-
             }
             return true;
         }

--- a/neo/Core/Helper.cs
+++ b/neo/Core/Helper.cs
@@ -3,7 +3,7 @@ using Neo.Implementations.Blockchains.LevelDB;
 using Neo.SmartContract;
 using Neo.VM;
 using Neo.IO.Caching;
-using Neo.Cryptography.ECC
+using Neo.Cryptography.ECC;
 using Neo.Wallets;
 using System;
 using System.IO;

--- a/neo/Core/Helper.cs
+++ b/neo/Core/Helper.cs
@@ -1,5 +1,4 @@
 ﻿using Neo.Cryptography;
-using Neo.Implementations.Blockchains.LevelDB;
 using Neo.SmartContract;
 using Neo.VM;
 using Neo.IO.Caching;

--- a/neo/SmartContract/StateMachine.cs
+++ b/neo/SmartContract/StateMachine.cs
@@ -71,7 +71,6 @@ namespace Neo.SmartContract
             storages.Commit();
         }
 
-
         public void CommitStorages()
         {
             storages.Commit();

--- a/neo/SmartContract/StateMachine.cs
+++ b/neo/SmartContract/StateMachine.cs
@@ -71,6 +71,12 @@ namespace Neo.SmartContract
             storages.Commit();
         }
 
+
+        public void CommitStorages()
+        {
+            storages.Commit();
+        }
+
         private void StateMachine_Notify(object sender, NotifyEventArgs e)
         {
             notifications.Add(e);

--- a/neo/SmartContract/StateMachine.cs
+++ b/neo/SmartContract/StateMachine.cs
@@ -71,11 +71,6 @@ namespace Neo.SmartContract
             storages.Commit();
         }
 
-        public void CommitStorages()
-        {
-            storages.Commit();
-        }
-
         private void StateMachine_Notify(object sender, NotifyEventArgs e)
         {
             notifications.Add(e);


### PR DESCRIPTION
**What is this change?**

This PR changes the core `IVerifiable.VerifyScripts()` method which is implemented in `neo/Core/Helper.cs`, and makes a small change to the smart contract `StateMachine` so that it can optionally commit only storage api data.

**What does it fix?**

Currently, there is no way for a smart contract to _send_ assets ( Neo or NeoGas, for example) to another address other than through the `Runtime.Notify` observer mechanism.  An ideal solution for this is to allow addresses to attempt to withdraw assets from a smart contract address.  The mechanism which verifies whether an address can _withdraw_ is currently implemented in the `VerifyScripts()` method mentioned above.

The current issue with the above approach is that a smart contract has no access to blockchain data or storage api data while performing the verification routine, so a smart contract similar to the following would not work:

```        
       public static Object Main(string operation, params object[] args)
        {

            if (Runtime.Trigger == TriggerType.Verification)
            {

                Transaction tx = (Transaction)ExecutionEngine.ScriptContainer;
                TransactionOutput[] outputs = tx.GetOutputs();
                ulong value = 0;
                byte[] receiver = ExecutionEngine.ExecutingScriptHash;

                foreach (TransactionOutput output in outputs)
                {
                    if (output.ScriptHash == receiver)
                    {
                        value += (ulong)output.Value;
                    }
                }

                StorageContext context = Storage.CurrentContext;

                BigInteger receivable = Storage.Get(context, receiver).AsBigInteger();

                if ( value <= receivable)
                {
                    BigInteger new_balance = receivable - value;
                    Storage.Put(context, receiver, new_balance);
                      
                    return true;
                }

                return false;
            }
     }
```

The purpose of this change-set is to allow for an example similar to the above to work.


**Considerations**

- Performance is a consideration when adding the ability to allow verification contracts to access blockchain related data.  Due to this, this proposed implementation only gives access to blockchain related date when the verification script that is being executed is not a standard verification script.  The current determination of whether a verification script is standard is based on length.
- Backwards compatibility is maintained
- No major changes to the current implementation should be necessary to allow this.

**Details**

- Allow Verification contracts read-access to blockchain related account, asset, validator, contract, and storage data. 
- Allow Verification contracts write access to storage data
- Only 'non-standard' verification scripts are given access to blockchain read/write data.