### PR TITLE
prevent index out of bounds exception

### DIFF
--- a/neo/SmartContract/ContractParametersContext.cs
+++ b/neo/SmartContract/ContractParametersContext.cs
@@ -156,6 +156,12 @@ namespace Neo.SmartContract
                             throw new NotSupportedException();
                         else
                             index = i;
+
+                if(index == -1) {
+                    // unable to find ContractParameterType.Signature in contract.ParameterList 
+                    // return now to prevent array index out of bounds exception
+                    return false;
+                }
                 return Add(contract, index, signature);
             }
         }


### PR DESCRIPTION
contract addresses that do not have a signature parameter type defined will throw an array index out of bounds exception when Add() attempts to access index -1

issue report: #85 