### PR TITLE
Fix for Murmur3

### DIFF
--- a/neo/Cryptography/Murmur3.cs
+++ b/neo/Cryptography/Murmur3.cs
@@ -4,7 +4,7 @@ using System.Security.Cryptography;
 
 namespace Neo.Cryptography
 {
-    public class Murmur3 : HashAlgorithm
+    public sealed class Murmur3 : HashAlgorithm
     {
         private const uint c1 = 0xcc9e2d51;
         private const uint c2 = 0x1b873593;
@@ -22,6 +22,7 @@ namespace Neo.Cryptography
         public Murmur3(uint seed)
         {
             this.seed = seed;
+            Initialize();
         }
 
         protected override void HashCore(byte[] array, int ibStart, int cbSize)


### PR DESCRIPTION
Fixed an issue with the Murmur3 implementation. The "life-cycle" of the HashAlgorithm is: Constructor, HashCore, HashFinal and than Initialize. If it's reused, the cycle will continue with HashCore. Your code was assuming Initialize is called first, which it isn't. The hash was never initialized with the seed, thus returning different results as the "real" Murmur3 implementation. The fix is to call Initialize() from the constructor, needing the class to be sealed, OR you could just set the length / hash from there.