### PR TITLE
Confusing spacing in RPC switch statement

### DIFF
--- a/neo/Network/RPC/RpcServer.cs
+++ b/neo/Network/RPC/RpcServer.cs
@@ -287,10 +287,10 @@ namespace Neo.Network.RPC
                         }
 
                         return json;
-					}
-				case "getversion":
-					{
-						JObject json = new JObject();
+                    }
+                case "getversion":
+                    {
+                        JObject json = new JObject();
                         json["port"] = LocalNode.Port;
                         json["nonce"] = LocalNode.Nonce;
                         json["useragent"] = LocalNode.UserAgent;


### PR DESCRIPTION
### Problem

There is inconsistent formatting in the large main switch statement, that drives the processing logic for any RPC call.

### Solution

Make the formatting consistent.