### PR TITLE
Adding Neo.Runtime.GetTime and Neo.Runtime.GetCurrentBlock

### DIFF
--- a/neo.UnitTests/TestBlockchain.cs
+++ b/neo.UnitTests/TestBlockchain.cs
@@ -23,6 +23,14 @@ namespace Neo.UnitTests
 
         public override uint Height => throw new NotImplementedException();
 
+        public override Block CurrentBlock
+        {
+            get
+            {
+                return GetBlock(Height);
+            }
+        }
+
         public override bool AddBlock(Block block)
         {
             throw new NotImplementedException();

--- a/neo/Core/Blockchain.cs
+++ b/neo/Core/Blockchain.cs
@@ -119,6 +119,12 @@ namespace Neo.Core
         /// 当前最新区块散列值
         /// </summary>
         public abstract UInt256 CurrentBlockHash { get; }
+
+        /// <summary>
+        /// Gets highest block
+        /// </summary>
+        public abstract Block CurrentBlock { get; }
+
         /// <summary>
         /// 当前最新区块头的散列值
         /// </summary>

--- a/neo/Implementations/Blockchains/LevelDB/LevelDBBlockchain.cs
+++ b/neo/Implementations/Blockchains/LevelDB/LevelDBBlockchain.cs
@@ -22,6 +22,8 @@ namespace Neo.Implementations.Blockchains.LevelDB
         private Dictionary<UInt256, Block> block_cache = new Dictionary<UInt256, Block>();
         private uint current_block_height = 0;
         private uint stored_header_count = 0;
+        private Block persisting_block;
+
         private AutoResetEvent new_block_event = new AutoResetEvent(false);
         private bool disposed = false;
 
@@ -104,6 +106,18 @@ namespace Neo.Implementations.Blockchains.LevelDB
             thread_persistence = new Thread(PersistBlocks);
             thread_persistence.Name = "LevelDBBlockchain.PersistBlocks";
             thread_persistence.Start();
+        }
+
+        public override Block CurrentBlock
+        {
+            get
+            {
+                if (persisting_block != null)
+                {
+                    return persisting_block;
+                }
+                return GetBlock(Height);
+            }
         }
 
         public override bool AddBlock(Block block)
@@ -439,6 +453,7 @@ namespace Neo.Implementations.Blockchains.LevelDB
 
         private void Persist(Block block)
         {
+            persisting_block = block;
             WriteBatch batch = new WriteBatch();
             DbCache<UInt160, AccountState> accounts = new DbCache<UInt160, AccountState>(db, DataEntryPrefix.ST_Account);
             DbCache<UInt256, UnspentCoinState> unspentcoins = new DbCache<UInt256, UnspentCoinState>(db, DataEntryPrefix.ST_Coin);
@@ -581,6 +596,7 @@ namespace Neo.Implementations.Blockchains.LevelDB
             batch.Put(SliceBuilder.Begin(DataEntryPrefix.SYS_CurrentBlock), SliceBuilder.Begin().Add(block.Hash).Add(block.Index));
             db.Write(WriteOptions.Default, batch);
             current_block_height = block.Index;
+            persisting_block = null;
         }
 
         private void PersistBlocks()

--- a/neo/SmartContract/ApplicationEngine.cs
+++ b/neo/SmartContract/ApplicationEngine.cs
@@ -308,7 +308,10 @@ namespace Neo.SmartContract
                     return 100;
                 case "Neo.Blockchain.GetBlock":
                 case "AntShares.Blockchain.GetBlock":
+                case "Neo.Runtime.GetCurrentBlock":                    
                     return 200;
+                case "Neo.Runtime.GetTime":
+                    return 100;
                 case "Neo.Blockchain.GetTransaction":
                 case "AntShares.Blockchain.GetTransaction":
                     return 100;

--- a/neo/SmartContract/ApplicationEngine.cs
+++ b/neo/SmartContract/ApplicationEngine.cs
@@ -308,7 +308,6 @@ namespace Neo.SmartContract
                     return 100;
                 case "Neo.Blockchain.GetBlock":
                 case "AntShares.Blockchain.GetBlock":
-                case "Neo.Runtime.GetCurrentBlock":                    
                     return 200;
                 case "Neo.Runtime.GetTime":
                     return 100;

--- a/neo/SmartContract/StateReader.cs
+++ b/neo/SmartContract/StateReader.cs
@@ -21,6 +21,8 @@ namespace Neo.SmartContract
             Register("Neo.Runtime.CheckWitness", Runtime_CheckWitness);
             Register("Neo.Runtime.Notify", Runtime_Notify);
             Register("Neo.Runtime.Log", Runtime_Log);
+            Register("Neo.Runtime.GetCurrentBlock", Runtime_GetCurrentBlock);
+            Register("Neo.Runtime.GetTime", Runtime_GetCurrentTime);
             Register("Neo.Blockchain.GetHeight", Blockchain_GetHeight);
             Register("Neo.Blockchain.GetHeader", Blockchain_GetHeader);
             Register("Neo.Blockchain.GetBlock", Blockchain_GetBlock);
@@ -162,6 +164,33 @@ namespace Neo.SmartContract
         {
             string message = Encoding.UTF8.GetString(engine.EvaluationStack.Pop().GetByteArray());
             Log?.Invoke(this, new LogEventArgs(engine.ScriptContainer, new UInt160(engine.CurrentContext.ScriptHash), message));
+            return true;
+        }
+
+        protected virtual bool Runtime_GetCurrentBlock(ExecutionEngine engine)
+        {
+            if (Blockchain.Default == null)
+                engine.EvaluationStack.Push(StackItem.FromInterface(Blockchain.GenesisBlock));
+            else
+            {
+                // current block returns the currently persisting block if this is an Application Trigger
+                // otherwise it returns the most recent block
+                engine.EvaluationStack.Push(StackItem.FromInterface(Blockchain.Default.CurrentBlock));
+            }
+            return true;
+        }
+
+        protected virtual bool Runtime_GetCurrentTime(ExecutionEngine engine)
+        {
+            if (Blockchain.Default == null)
+                engine.EvaluationStack.Push(Blockchain.GenesisBlock.Timestamp);
+            else
+            {
+                // current block returns the currently persisting block time if this is an Application Trigger
+                // otherwise it returns the time of the most recent block
+                Block block = Blockchain.Default.CurrentBlock;
+                engine.EvaluationStack.Push(block.Timestamp);
+            }
             return true;
         }
 


### PR DESCRIPTION
for issue #114 

- adds `Neo.Runtime.GetTime`
- adds `Neo.Runtime.GetCurrentBlock`
- adds property `CurrentBlock` to `Blockchain`.  This retrieves the currently persisting block if a block is currently being persisted, otherwise it returns the highest block

If either of these API are called during `TriggerType.Verification`, the most recent blockchain on the block is returned.  If it is called during `TriggerType.Application`, it will be the currently persisting block.
