### PR TITLE
Adding Neo.Transaction.GetUnspentCoins for issue #114

### DIFF
--- a/neo.UnitTests/TestBlockchain.cs
+++ b/neo.UnitTests/TestBlockchain.cs
@@ -133,6 +133,11 @@ namespace Neo.UnitTests
             throw new NotImplementedException();
         }
 
+        public override IEnumerable<TransactionOutput> GetUnspent(UInt256 hash)
+        {
+            throw new NotImplementedException();
+        }
+
         public override IEnumerable<VoteState> GetVotes(IEnumerable<Transaction> others)
         {
             VoteState vs = new VoteState() { Count = Fixed8.FromDecimal(1), PublicKeys = TestUtils.StandbyValidators};            

--- a/neo/Core/Blockchain.cs
+++ b/neo/Core/Blockchain.cs
@@ -425,6 +425,9 @@ namespace Neo.Core
         /// <returns>返回一个交易输出，表示一个未花费的资产</returns>
         public abstract TransactionOutput GetUnspent(UInt256 hash, ushort index);
 
+        public abstract IEnumerable<TransactionOutput> GetUnspent(UInt256 hash);
+
+
         /// <summary>
         /// 获取选票信息
         /// </summary>

--- a/neo/SmartContract/ApplicationEngine.cs
+++ b/neo/SmartContract/ApplicationEngine.cs
@@ -326,6 +326,7 @@ namespace Neo.SmartContract
                     return 100;
                 case "Neo.Transaction.GetReferences":
                 case "AntShares.Transaction.GetReferences":
+                case "Neo.Transaction.GetUnspentCoins":    
                     return 200;
                 case "Neo.Account.SetVotes":
                 case "AntShares.Account.SetVotes":

--- a/neo/SmartContract/StateReader.cs
+++ b/neo/SmartContract/StateReader.cs
@@ -45,6 +45,7 @@ namespace Neo.SmartContract
             Register("Neo.Transaction.GetInputs", Transaction_GetInputs);
             Register("Neo.Transaction.GetOutputs", Transaction_GetOutputs);
             Register("Neo.Transaction.GetReferences", Transaction_GetReferences);
+            Register("Neo.Transaction.GetUnspentCoins", Transaction_GetUnspentCoins);
             Register("Neo.Attribute.GetUsage", Attribute_GetUsage);
             Register("Neo.Attribute.GetData", Attribute_GetData);
             Register("Neo.Input.GetHash", Input_GetHash);
@@ -406,6 +407,14 @@ namespace Neo.SmartContract
             Transaction tx = engine.EvaluationStack.Pop().GetInterface<Transaction>();
             if (tx == null) return false;
             engine.EvaluationStack.Push(tx.Inputs.Select(p => StackItem.FromInterface(tx.References[p])).ToArray());
+            return true;
+        }
+
+        protected virtual bool Transaction_GetUnspentCoins(ExecutionEngine engine)
+        {
+            Transaction tx = engine.EvaluationStack.Pop().GetInterface<Transaction>();
+            if (tx == null) return false;
+            engine.EvaluationStack.Push(Blockchain.Default.GetUnspent(tx.Hash).Select(p => StackItem.FromInterface(p)).ToArray());
             return true;
         }
 


### PR DESCRIPTION
For #114 

Would we want to add a syscall `Neo.Output.GetIsSpent` that would return a `bool` whether the `TransactionOutput` has been spent?