### PR TITLE
Use RNGCryptoServiceProvider for nonce

### DIFF
--- a/neo/Consensus/ConsensusService.cs
+++ b/neo/Consensus/ConsensusService.cs
@@ -8,6 +8,7 @@ using Neo.Wallets;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Security.Cryptography;
 using System.Threading;
 
 namespace Neo.Consensus
@@ -24,6 +25,8 @@ namespace Neo.Consensus
         private byte timer_view;
         private DateTime block_received_time;
         private bool started = false;
+
+        private static RNGCryptoServiceProvider rngProvider = new RNGCryptoServiceProvider();
 
         public ConsensusService(LocalNode localNode, Wallet wallet)
         {
@@ -139,8 +142,7 @@ namespace Neo.Consensus
         private static ulong GetNonce()
         {
             byte[] nonce = new byte[sizeof(ulong)];
-            Random rand = new Random();
-            rand.NextBytes(nonce);
+            rngProvider.GetBytes(nonce);
             return nonce.ToUInt64(0);
         }
 


### PR DESCRIPTION
... to provide a stronger nonce for blocks.

I'm not sure if we're using just `System.Random` for performance reasons, but it seems prudent to use a cryptographically secure RNG here.
