### PR TITLE
Add min fee of .001 gas for any invocation

### DIFF
--- a/neo/SmartContract/ApplicationEngine.cs
+++ b/neo/SmartContract/ApplicationEngine.cs
@@ -34,7 +34,7 @@ namespace Neo.SmartContract
 
         private const long ratio = 100000;
         private const long gas_free = 10 * 100000000;
-        private const long min_gas = 100000;
+        private const long min_gas = 1000;
 
         private readonly long gas_amount;
         private long gas_consumed = 0;

--- a/neo/SmartContract/ApplicationEngine.cs
+++ b/neo/SmartContract/ApplicationEngine.cs
@@ -34,6 +34,8 @@ namespace Neo.SmartContract
 
         private const long ratio = 100000;
         private const long gas_free = 10 * 100000000;
+        private const long min_gas = 100000;
+
         private readonly long gas_amount;
         private long gas_consumed = 0;
         private readonly bool testMode;
@@ -253,6 +255,10 @@ namespace Neo.SmartContract
 
         public new bool Execute()
         {
+            if(!testMode && gas_amount < min_gas)
+            {
+                return false;
+            }
             try
             {
                 while (!State.HasFlag(VMState.HALT) && !State.HasFlag(VMState.FAULT))

--- a/neo/neo.csproj
+++ b/neo/neo.csproj
@@ -37,6 +37,7 @@
     <PackageReference Include="Microsoft.AspNetCore.WebSockets" Version="2.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.0.0" />
+    <PackageReference Include="Neo.VM" Version="2.0.4" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net47' ">
@@ -44,11 +45,9 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net47'">
-    <PackageReference Include="Replicon.Cryptography.SCrypt" Version="1.1.6.13">
+    <PackageReference Include="Replicon.Cryptography.SCrypt">
+      <Version>1.1.6.13</Version>
     </PackageReference>
   </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\neo-vm\src\neo-vm\neo-vm.csproj" />
-  </ItemGroup>
 </Project>

--- a/neo/neo.csproj
+++ b/neo/neo.csproj
@@ -37,7 +37,6 @@
     <PackageReference Include="Microsoft.AspNetCore.WebSockets" Version="2.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.0.0" />
-    <PackageReference Include="Neo.VM" Version="2.0.4" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net47' ">
@@ -45,9 +44,11 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net47'">
-    <PackageReference Include="Replicon.Cryptography.SCrypt">
-      <Version>1.1.6.13</Version>
+    <PackageReference Include="Replicon.Cryptography.SCrypt" Version="1.1.6.13">
     </PackageReference>
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\..\neo-vm\src\neo-vm\neo-vm.csproj" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
There is currently a network vulnerability that allows anyone to send invocation transactions that cost 9.9999 Gas worth of computation for free.

This could be used to spam the network and slow things down.

This pull request adds a minimum fee of .001 Gas for all contract invocations in order to prevent this.