### PR TITLE
Update ContractParameter.cs

### DIFF
--- a/neo/SmartContract/ContractParameter.cs
+++ b/neo/SmartContract/ContractParameter.cs
@@ -165,7 +165,7 @@ namespace Neo.SmartContract
                 case byte[] data:
                     return data.ToHexString();
                 case UIntBase data:
-                    return $"0x{data}";
+                    return $"{data}";
                 case IList<ContractParameter> data:
                     StringBuilder sb = new StringBuilder();
                     sb.Append('[');


### PR DESCRIPTION
UIntBase has override method ToString(), and it looks like
public override string ToString()
 {
       return "0x" + data_bytes.Reverse().ToHexString();
 }
so it's not necessary to add "0x" here again.