### PR TITLE
Equal time out as receive

### DIFF
--- a/neo/Network/TcpRemoteNode.cs
+++ b/neo/Network/TcpRemoteNode.cs
@@ -93,7 +93,7 @@ namespace Neo.Network
             if (!connected) throw new InvalidOperationException();
             if (disposed > 0) return false;
             byte[] buffer = message.ToArray();
-            CancellationTokenSource source = new CancellationTokenSource(10000);
+            CancellationTokenSource source = new CancellationTokenSource(30000);
             //Stream.WriteAsync doesn't support CancellationToken
             //see: https://stackoverflow.com/questions/20131434/cancel-networkstream-readasync-using-tcplistener
             source.Token.Register(() => Disconnect(false));


### PR DESCRIPTION
We have issues with heavy messages, because the node disconnect the client with this timeout

![image](https://user-images.githubusercontent.com/3167973/37356405-2c5723ee-26e6-11e8-927c-97de0fa266fd.png)
