### PR TITLE
GzipCompression over RPC

### DIFF
--- a/neo/Network/RPC/RpcServer.cs
+++ b/neo/Network/RPC/RpcServer.cs
@@ -411,7 +411,7 @@ namespace Neo.Network.RPC
             {
                 services.AddResponseCompression(options =>
                 {
-                    options.EnableForHttps = true;
+                    // options.EnableForHttps = false;
                     options.Providers.Add<GzipCompressionProvider>();
                     options.MimeTypes = ResponseCompressionDefaults.MimeTypes.Concat(new[] { "application/json-rpc" });
                 });

--- a/neo/Network/RPC/RpcServer.cs
+++ b/neo/Network/RPC/RpcServer.cs
@@ -1,6 +1,8 @@
 ﻿using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.ResponseCompression;
+using Microsoft.Extensions.DependencyInjection;
 using Neo.Core;
 using Neo.IO;
 using Neo.IO.Json;
@@ -9,6 +11,7 @@ using Neo.VM;
 using Neo.Wallets;
 using System;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
 using System.Net;
 using System.Text;
@@ -364,7 +367,7 @@ namespace Neo.Network.RPC
             }
             if (response == null || (response as JArray)?.Count == 0) return;
             context.Response.ContentType = "application/json-rpc";
-            await context.Response.WriteAsync(response.ToString());
+            await context.Response.WriteAsync(response.ToString(), Encoding.UTF8);
         }
 
         private JObject ProcessRequest(JObject request)
@@ -398,7 +401,28 @@ namespace Neo.Network.RPC
             {
                 if (!string.IsNullOrEmpty(sslCert))
                     listenOptions.UseHttps(sslCert, password);
-            })).Configure(app => app.Run(ProcessAsync)).Build();
+            }))
+            .Configure(app =>
+            {
+                app.UseResponseCompression();
+                app.Run(ProcessAsync);
+            })
+            .ConfigureServices(services =>
+            {
+                services.AddResponseCompression(options =>
+                {
+                    options.EnableForHttps = true;
+                    options.Providers.Add<GzipCompressionProvider>();
+                    options.MimeTypes = ResponseCompressionDefaults.MimeTypes.Concat(new[] { "application/json-rpc" });
+                });
+
+                services.Configure<GzipCompressionProviderOptions>(options =>
+                {
+                    options.Level = CompressionLevel.Fastest;
+                });
+            })
+            .Build();
+
             host.Start();
         }
     }

--- a/neo/neo.csproj
+++ b/neo/neo.csproj
@@ -32,11 +32,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Https" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.WebSockets" Version="2.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.ResponseCompression" Version="2.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Https" Version="2.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.WebSockets" Version="2.0.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.0.1" />
     <PackageReference Include="Neo.VM" Version="2.1.0" />
   </ItemGroup>
 


### PR DESCRIPTION
https://docs.microsoft.com/en-us/aspnet/core/performance/response-compression?tabs=aspnetcore2x

This optimization could save a lot of bytes with heavy calls like this one

```
POST / HTTP/1.1
Host: 127.0.0.1:10332
Accept-Encoding: gzip
Connection: close
Content-Length: 75

{"jsonrpc": "2.0", "method": "getblock", "params":
[ 
513754
], "id": 1}
```

![image](https://user-images.githubusercontent.com/3167973/37671271-a71596e4-2c6b-11e8-9fef-9d28e800fbae.png)

* CozTestnet