### PR TITLE
Mention .Net Framework 4.7 Developer Pack to be installed in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ We will support the following platforms in the future:
 Development
 --------
 
-To start building peer applications for NEO on Windows, you need to download [Visual Studio 2017](https://www.visualstudio.com/products/visual-studio-community-vs) and install the [.NET Core SDK](https://www.microsoft.com/net/core).
+To start building peer applications for NEO on Windows, you need to download [Visual Studio 2017](https://www.visualstudio.com/products/visual-studio-community-vs), install the [.NET Framework 4.7 Developer Pack](https://www.microsoft.com/en-us/download/details.aspx?id=55168) and the [.NET Core SDK](https://www.microsoft.com/net/core).
 
 If you need to develop on Linux or macOS, just install the [.NET Core SDK](https://www.microsoft.com/net/core).
 


### PR DESCRIPTION
I followed the readme file and found I cannot compile Neo solution without .Net Framework 4.7 Developer Pack being installed on my machine. I think it should be mentioned in documentation.

OS: Win7x64