### PR TITLE
Extracting hardcoded seconds per block to the protocol.json file

### DIFF
--- a/neo/Core/Blockchain.cs
+++ b/neo/Core/Blockchain.cs
@@ -20,7 +20,7 @@ namespace Neo.Core
         /// <summary>
         /// 产生每个区块的时间间隔，已秒为单位
         /// </summary>
-        public static uint SecondsPerBlock = Settings.Default.SecondsPerBlock;
+        public static readonly uint SecondsPerBlock = Settings.Default.SecondsPerBlock;
         public const uint DecrementInterval = 2000000;
         public const uint MaxValidators = 1024;
         public static readonly uint[] GenerationAmount = { 8, 7, 6, 5, 4, 3, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 };

--- a/neo/Core/Blockchain.cs
+++ b/neo/Core/Blockchain.cs
@@ -20,7 +20,7 @@ namespace Neo.Core
         /// <summary>
         /// 产生每个区块的时间间隔，已秒为单位
         /// </summary>
-        public const uint SecondsPerBlock = 15;
+        public static uint SecondsPerBlock = Settings.Default.SecondsPerBlock;
         public const uint DecrementInterval = 2000000;
         public const uint MaxValidators = 1024;
         public static readonly uint[] GenerationAmount = { 8, 7, 6, 5, 4, 3, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 };

--- a/neo/Settings.cs
+++ b/neo/Settings.cs
@@ -8,7 +8,6 @@ namespace Neo
 {
     internal class Settings
     {
-       
         public uint Magic { get; private set; }
         public byte AddressVersion { get; private set; }
         public int MaxTransactionsPerBlock { get; private set; }
@@ -16,7 +15,6 @@ namespace Neo
         public string[] SeedList { get; private set; }
         public IReadOnlyDictionary<TransactionType, Fixed8> SystemFee { get; private set; }
         public uint SecondsPerBlock { get; private set; }
-        public IConfigurationSection ConfigurationSection { get; set; }
 
         public static Settings Default { get; private set; }
 
@@ -34,8 +32,7 @@ namespace Neo
             this.StandbyValidators = section.GetSection("StandbyValidators").GetChildren().Select(p => p.Value).ToArray();
             this.SeedList = section.GetSection("SeedList").GetChildren().Select(p => p.Value).ToArray();
             this.SystemFee = section.GetSection("SystemFee").GetChildren().ToDictionary(p => (TransactionType)Enum.Parse(typeof(TransactionType), p.Key, true), p => Fixed8.Parse(p.Value));
-            var secondsPerBlockSection = section.GetSection("SecondsPerBlock");
-            this.SecondsPerBlock = secondsPerBlockSection.Value == null ? 15 : uint.Parse(secondsPerBlockSection.Value);
+            this.SecondsPerBlock = GetValueOrDefault(section.GetSection("SecondsPerBlock"), 15u, p => uint.Parse(p));
         }
 
         public T GetValueOrDefault<T>(IConfigurationSection section, T defaultValue, Func<string, T> selector)

--- a/neo/Settings.cs
+++ b/neo/Settings.cs
@@ -8,12 +8,15 @@ namespace Neo
 {
     internal class Settings
     {
+       
         public uint Magic { get; private set; }
         public byte AddressVersion { get; private set; }
         public int MaxTransactionsPerBlock { get; private set; }
         public string[] StandbyValidators { get; private set; }
         public string[] SeedList { get; private set; }
         public IReadOnlyDictionary<TransactionType, Fixed8> SystemFee { get; private set; }
+        public uint SecondsPerBlock { get; private set; }
+        public IConfigurationSection ConfigurationSection { get; set; }
 
         public static Settings Default { get; private set; }
 
@@ -31,6 +34,8 @@ namespace Neo
             this.StandbyValidators = section.GetSection("StandbyValidators").GetChildren().Select(p => p.Value).ToArray();
             this.SeedList = section.GetSection("SeedList").GetChildren().Select(p => p.Value).ToArray();
             this.SystemFee = section.GetSection("SystemFee").GetChildren().ToDictionary(p => (TransactionType)Enum.Parse(typeof(TransactionType), p.Key, true), p => Fixed8.Parse(p.Value));
+            var secondsPerBlockSection = section.GetSection("SecondsPerBlock");
+            this.SecondsPerBlock = secondsPerBlockSection.Value == null ? 15 : uint.Parse(secondsPerBlockSection.Value);
         }
 
         public T GetValueOrDefault<T>(IConfigurationSection section, T defaultValue, Func<string, T> selector)

--- a/neo/protocol.json
+++ b/neo/protocol.json
@@ -3,6 +3,7 @@
     "Magic": 7630401,
     "AddressVersion": 23,
     "MaxTransactionsPerBlock": 500,
+    "SecondsPerBlock":  15, 
     "StandbyValidators": [
       "03b209fd4f53a7170ea4444e0cb0a6bb6a53c2bd016926989cf85f9b0fba17a70c",
       "02df48f60e8f3e01c48ff40b9b7f1310d7a8b2a193188befe1c2e3df740e895093",

--- a/neo/protocol.json
+++ b/neo/protocol.json
@@ -3,7 +3,7 @@
     "Magic": 7630401,
     "AddressVersion": 23,
     "MaxTransactionsPerBlock": 500,
-    "SecondsPerBlock":  15, 
+    "SecondsPerBlock": 15, 
     "StandbyValidators": [
       "03b209fd4f53a7170ea4444e0cb0a6bb6a53c2bd016926989cf85f9b0fba17a70c",
       "02df48f60e8f3e01c48ff40b9b7f1310d7a8b2a193188befe1c2e3df740e895093",


### PR DESCRIPTION
Having the seconds per block configurable would allow for simplified adjustments going forward instead of new code having to be compiled if the timing is ever changed in the future.

For setting up a private net for local development. Setting this to be low (i.e. 1-5 seconds) would speed up development time considerably. 