### PR TITLE
SHL and SHR performance

### DIFF
--- a/neo/SmartContract/ApplicationEngine.cs
+++ b/neo/SmartContract/ApplicationEngine.cs
@@ -156,11 +156,29 @@ namespace Neo.SmartContract
             switch (nextInstruction)
             {
                 case OpCode.SHL:
-                case OpCode.SHR:
                     {
-                        BigInteger ishift = EvaluationStack.Peek().GetBigInteger();
+                        BigInteger ishift = EvaluationStack.Peek(0).GetBigInteger();
 
                         if ((ishift > Max_SHL_SHR || ishift < Min_SHL_SHR))
+                            return false;
+
+                        BigInteger x = EvaluationStack.Peek(1).GetBigInteger();
+
+                        if (!CheckBigInteger(x << (int)ishift))
+                            return false;
+
+                        break;
+                    }
+                case OpCode.SHR:
+                    {
+                        BigInteger ishift = EvaluationStack.Peek(0).GetBigInteger();
+
+                        if ((ishift > Max_SHL_SHR || ishift < Min_SHL_SHR))
+                            return false;
+
+                        BigInteger x = EvaluationStack.Peek(1).GetBigInteger();
+
+                        if (!CheckBigInteger(x >> (int)ishift))
                             return false;
 
                         break;

--- a/neo/SmartContract/ApplicationEngine.cs
+++ b/neo/SmartContract/ApplicationEngine.cs
@@ -18,7 +18,7 @@ namespace Neo.SmartContract
         /// <summary>
         /// Min value for SHL and SHR
         /// </summary>
-        private const int Min_SHL_SHR = short.MinValue;
+        private const int Min_SHL_SHR = -Max_SHL_SHR;
         /// <summary>
         /// Set the max size allowed size for BigInteger
         /// </summary>

--- a/neo/SmartContract/ApplicationEngine.cs
+++ b/neo/SmartContract/ApplicationEngine.cs
@@ -12,6 +12,14 @@ namespace Neo.SmartContract
     {
         #region Limits
         /// <summary>
+        /// Max value for SHL and SHR
+        /// </summary>
+        private const int Max_SHL_SHR = ushort.MaxValue;
+        /// <summary>
+        /// Min value for SHL and SHR
+        /// </summary>
+        private const int Min_SHL_SHR = short.MinValue;
+        /// <summary>
         /// Set the max size allowed size for BigInteger
         /// </summary>
         private const int MaxSizeForBigInteger = 32;
@@ -147,6 +155,16 @@ namespace Neo.SmartContract
         {
             switch (nextInstruction)
             {
+                case OpCode.SHL:
+                case OpCode.SHR:
+                    {
+                        BigInteger ishift = EvaluationStack.Peek().GetBigInteger();
+
+                        if ((ishift > Max_SHL_SHR || ishift < Min_SHL_SHR))
+                            return false;
+
+                        break;
+                    }
                 case OpCode.INC:
                     {
                         BigInteger x = EvaluationStack.Peek().GetBigInteger();


### PR DESCRIPTION
SHL and SHR have a very bad performance on BigInteger, with high numbers.

![image](https://user-images.githubusercontent.com/3167973/38452547-9f8e0756-3a46-11e8-8cce-bc95ff8264cd.png)

(capture from source at:  https://referencesource.microsoft.com/#System.Numerics/System/Numerics/BigInteger.cs,1402 )

You can test with this simple test:

![image](https://user-images.githubusercontent.com/3167973/38452558-d6d3e3b6-3a46-11e8-8d82-55ce1dce2564.png)

