### PR TITLE
Fix stalls when syncing blockchain. Fix intermittent crash on LocalNode.Dispose.

### DIFF
--- a/neo/Implementations/Blockchains/LevelDB/LevelDBBlockchain.cs
+++ b/neo/Implementations/Blockchains/LevelDB/LevelDBBlockchain.cs
@@ -112,6 +112,7 @@ namespace Neo.Implementations.Blockchains.LevelDB
             }
             thread_persistence = new Thread(PersistBlocks);
             thread_persistence.Name = "LevelDBBlockchain.PersistBlocks";
+            thread_persistence.Priority = ThreadPriority.AboveNormal;
             thread_persistence.Start();
         }
 


### PR DESCRIPTION
Increased the priority of the thread performing block persistence to ensure processing received blocks is prioritized above receiving additional incoming blocks.

When attempting to stop the daemon by using LocalNode.Dispose() I experienced intermittent crashes in `Blockchain_PersistCompleted(object sender, Block block)` since it calls `new_tx_event.Set();` and new_tx_event gets disposed when LocalNode.Dispose() runs. Event though LocalNode.Dispose() de-registers the event by `Blockchain.PersistCompleted -= Blockchain_PersistCompleted;`, more must be done to ensure that Blockchain_PersistCompleted is not currently still in progress before disposing new_tx_event.

To remedy the issue I added a rather generous sleep before disposing new_tx_event. Some other synchronization primitive could be used to be more efficient, but since the code only runs on shutdown, it doesn't seem like it's worth doing something exceedingly fancy.