### PR TITLE
bugFix overflow of long type

### DIFF
--- a/neo/Fixed8.cs
+++ b/neo/Fixed8.cs
@@ -88,7 +88,7 @@ namespace Neo
             };
         }
 
-        public long GetData() => value;
+        public ulong GetData() => value;
 
         public override int GetHashCode()
         {


### PR DESCRIPTION
changed neo/Fixed8.cs "public long GetData() => value;" to ulong.