### PR TITLE
Improve peering logic to ensure a LocalNode stays connected to peers.

### DIFF
--- a/neo/Network/LocalNode.cs
+++ b/neo/Network/LocalNode.cs
@@ -233,10 +233,9 @@ namespace Neo.Network
                 mem_pool.Remove(hash);
         }
 
-        public async Task<IPEndPoint> GetIPEndpointFromHostPort(string hostNameOrAddress, int port)
+        public async Task<IPEndPoint> GetIPEndpointFromHostPortAsync(string hostNameOrAddress, int port)
         {
-            IPAddress ipAddress;
-            if (IPAddress.TryParse(hostNameOrAddress, out ipAddress))
+            if (IPAddress.TryParse(hostNameOrAddress, out IPAddress ipAddress))
             {
                 ipAddress = ipAddress.MapToIPv6();
             }
@@ -257,11 +256,11 @@ namespace Neo.Network
 
             return new IPEndPoint(ipAddress, port);
         }
-        
+
         public async Task ConnectToPeerAsync(string hostNameOrAddress, int port)
         {
-            IPEndPoint ipEndpoint = await GetIPEndpointFromHostPort(hostNameOrAddress, port);
-            
+            IPEndPoint ipEndpoint = await GetIPEndpointFromHostPortAsync(hostNameOrAddress, port);
+
             if (ipEndpoint == null) return;
             await ConnectToPeerAsync(ipEndpoint);
         }
@@ -285,7 +284,7 @@ namespace Neo.Network
             }
         }
 
-        private IPEndPoint[] getIPEndPointsFromSeedList(int seedsToTake)
+        private IPEndPoint[] GetIPEndPointsFromSeedList(int seedsToTake)
         {
             Random rand = new Random();
             IPEndPoint[] endpoints = Settings.Default.SeedList
@@ -295,7 +294,7 @@ namespace Neo.Network
                 {
                     try
                     {
-                        return GetIPEndpointFromHostPort(p[0], int.Parse(p[1])).Result;
+                        return GetIPEndpointFromHostPortAsync(p[0], int.Parse(p[1])).Result;
                     }
                     catch (AggregateException)
                     {
@@ -305,7 +304,7 @@ namespace Neo.Network
                 .ToArray();
             return endpoints;
         }
-        
+
         private void ConnectToPeersLoop()
         {
             Dictionary<Task, IPAddress> tasksDict = new Dictionary<Task, IPAddress>();
@@ -357,7 +356,7 @@ namespace Neo.Network
 
                             if (lastSufficientPeersTimestamp < DateTime.UtcNow.AddSeconds(-180))
                             {
-                                IPEndPoint[] endpoints = getIPEndPointsFromSeedList(2);
+                                IPEndPoint[] endpoints = GetIPEndPointsFromSeedList(2);
                                 connectToPeers(endpoints);
                                 lastSufficientPeersTimestamp = DateTime.UtcNow;
                             }
@@ -369,11 +368,11 @@ namespace Neo.Network
                     }
                     else
                     {
-                        IPEndPoint[] endpoints = getIPEndPointsFromSeedList(5);
+                        IPEndPoint[] endpoints = GetIPEndPointsFromSeedList(5);
                         connectToPeers(endpoints);
                         lastSufficientPeersTimestamp = DateTime.UtcNow;
                     }
-                    
+
                     try
                     {
                         var tasksArray = tasksDict.Keys.ToArray();

--- a/neo/Network/LocalNode.cs
+++ b/neo/Network/LocalNode.cs
@@ -29,6 +29,7 @@ namespace Neo.Network
 
         public const uint ProtocolVersion = 0;
         private const int ConnectedMax = 10;
+        private const int DesiredAvailablePeers = (int)(ConnectedMax * 1.5);
         private const int UnconnectedMax = 1000;
         public const int MemoryPoolSize = 50000;
         internal static readonly TimeSpan HashesExpiration = TimeSpan.FromSeconds(30);
@@ -277,13 +278,15 @@ namespace Neo.Network
 
         private void ConnectToPeersLoop()
         {
+            List<Task> tasksList = new List<Task>();
+            DateTime lastSufficientPeersTimestamp = DateTime.UtcNow;
+
             while (!cancellationTokenSource.IsCancellationRequested)
             {
                 int connectedCount = connectedPeers.Count;
                 int unconnectedCount = unconnectedPeers.Count;
                 if (connectedCount < ConnectedMax)
                 {
-                    Task[] tasks = { };
                     if (unconnectedCount > 0)
                     {
                         IPEndPoint[] endpoints;
@@ -291,24 +294,61 @@ namespace Neo.Network
                         {
                             endpoints = unconnectedPeers.Take(ConnectedMax - connectedCount).ToArray();
                         }
-                        tasks = endpoints.Select(p => ConnectToPeerAsync(p)).ToArray();
+                        tasksList.AddRange(endpoints.Select(p => ConnectToPeerAsync(p)));
                     }
-                    else if (connectedCount > 0)
+
+                    if (connectedCount > 0)
                     {
-                        lock (connectedPeers)
+                        if (unconnectedCount + connectedCount < DesiredAvailablePeers)
                         {
-                            foreach (RemoteNode node in connectedPeers)
-                                node.RequestPeers();
+                            lock (connectedPeers)
+                            {
+                                foreach (RemoteNode node in connectedPeers)
+                                    node.RequestPeers();
+                            }
+
+                            if (lastSufficientPeersTimestamp < DateTime.UtcNow.AddSeconds(-180))
+                            {
+                                Random rand = new Random();
+                                tasksList.AddRange(Settings.Default.SeedList
+                                    .OrderBy(p => rand.Next()).Take(2)
+                                    .OfType<string>().Select(p => p.Split(':'))
+                                    .Select(p => ConnectToPeerAsync(p[0], int.Parse(p[1]))));
+                                
+                                // Reset this so we try to get more peers from the seed nodes before trying to connect
+                                // to seed nodes again.
+                                lastSufficientPeersTimestamp = DateTime.UtcNow;
+                            }
+                        }
+                        else
+                        {
+                            lastSufficientPeersTimestamp = DateTime.UtcNow;
                         }
                     }
                     else
                     {
                         Random rand = new Random();
-                        tasks = Settings.Default.SeedList.OrderBy(p => rand.Next()).Take(5).OfType<string>().Select(p => p.Split(':')).Select(p => ConnectToPeerAsync(p[0], int.Parse(p[1]))).ToArray();
+                        tasksList.AddRange(Settings.Default.SeedList
+                            .OrderBy(p => rand.Next()).Take(5)
+                            .OfType<string>().Select(p => p.Split(':'))
+                            .Select(p => ConnectToPeerAsync(p[0], int.Parse(p[1]))));
+			// Reset this since we have connected to seed nodes.
+                        lastSufficientPeersTimestamp = DateTime.UtcNow;
                     }
+                    
                     try
                     {
-                        Task.WaitAll(tasks, cancellationTokenSource.Token);
+                        var tasksArray = tasksList.ToArray();
+                        Task.WaitAny(tasksArray, 5000, cancellationTokenSource.Token);
+
+                        foreach (var task in tasksArray)
+                        {
+                            if (!task.IsCanceled && !task.IsCompleted && !task.IsFaulted) continue;
+                            
+                            // Clean-up task no longer running.
+                            tasksList.Remove(task);
+                            task.Dispose();
+                        }
                     }
                     catch (OperationCanceledException)
                     {

--- a/neo/Network/LocalNode.cs
+++ b/neo/Network/LocalNode.cs
@@ -284,25 +284,28 @@ namespace Neo.Network
             }
         }
 
-        private IPEndPoint[] GetIPEndPointsFromSeedList(int seedsToTake)
+        private IEnumerable<IPEndPoint> GetIPEndPointsFromSeedList(int seedsToTake)
         {
-            Random rand = new Random();
-            IPEndPoint[] endpoints = Settings.Default.SeedList
-                .OrderBy(p => rand.Next()).Take(seedsToTake)
-                .OfType<string>().Select(p => p.Split(':'))
-                .Select(p =>
+            if (seedsToTake > 0)
+            {
+                Random rand = new Random();
+                foreach (string hostAndPort in Settings.Default.SeedList.OrderBy(p => rand.Next()))
                 {
+                    if (seedsToTake == 0) break;
+                    string[] p = hostAndPort.Split(':');
+                    IPEndPoint seed;
                     try
                     {
-                        return GetIPEndpointFromHostPortAsync(p[0], int.Parse(p[1])).Result;
+                        seed = GetIPEndpointFromHostPortAsync(p[0], int.Parse(p[1])).Result;
                     }
                     catch (AggregateException)
                     {
-                        return null;
+                        continue;
                     }
-                })
-                .ToArray();
-            return endpoints;
+                    seedsToTake--;
+                    yield return seed;
+                }
+            }
         }
 
         private void ConnectToPeersLoop()
@@ -311,12 +314,12 @@ namespace Neo.Network
             DateTime lastSufficientPeersTimestamp = DateTime.UtcNow;
             Dictionary<IPAddress, Task> currentlyConnectingIPs = new Dictionary<IPAddress, Task>();
 
-            void connectToPeers(IPEndPoint[] ipEndPoints)
+            void connectToPeers(IEnumerable<IPEndPoint> ipEndPoints)
             {
                 foreach (var ipEndPoint in ipEndPoints)
                 {
                     // Protect from the case same IP is in the endpoint array twice
-                    if (ipEndPoint == null || currentlyConnectingIPs.ContainsKey(ipEndPoint.Address))
+                    if (currentlyConnectingIPs.ContainsKey(ipEndPoint.Address))
                         continue;
 
                     var connectTask = ConnectToPeerAsync(ipEndPoint);
@@ -356,7 +359,7 @@ namespace Neo.Network
 
                             if (lastSufficientPeersTimestamp < DateTime.UtcNow.AddSeconds(-180))
                             {
-                                IPEndPoint[] endpoints = GetIPEndPointsFromSeedList(2);
+                                IEnumerable<IPEndPoint> endpoints = GetIPEndPointsFromSeedList(2);
                                 connectToPeers(endpoints);
                                 lastSufficientPeersTimestamp = DateTime.UtcNow;
                             }
@@ -368,7 +371,7 @@ namespace Neo.Network
                     }
                     else
                     {
-                        IPEndPoint[] endpoints = GetIPEndPointsFromSeedList(5);
+                        IEnumerable<IPEndPoint> endpoints = GetIPEndPointsFromSeedList(5);
                         connectToPeers(endpoints);
                         lastSufficientPeersTimestamp = DateTime.UtcNow;
                     }


### PR DESCRIPTION
When running several of Aphelion Neo nodes, I experienced issues with the peering behaviour and traced the issues back to issues in the `ConnectToPeersLoop` implementation. Before this change the code would only try to add more peers to its list of `unconnectedPeers` if it lost *ALL* of its currently connected peers. This is definitely not desired behaviour if one wants a Node to stay connected to the network all the time. These changes ensure that there are enough peers in the unconnected peers list to stay connected to the desired amount of peers.

Also, this fixes what I consider a bug, that `Task.WaitAll` was being used before the loop would continue to connect to other peers. The effect is that a node would have to lose its connections to all peers before trying to reconnect to other peers in its set of `unconnectedPeers`. This fixes that by using `Tasks.WaitAny` so that if one task completes it will re-evaluate if it should connect to an additional peer in a relatively short amount of time.

The code has had a mild amount of testing with additional logging added without any issues found so far. I'll report here if any issues are discovered as the code continues to be employed.