### PR TITLE
Proper Locking During Block Persistence and Increase Performance of Persisting Blocks (especially while syncing the chain)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,0 @@
-theme: jekyll-theme-minimal

--- a/neo/Implementations/Blockchains/LevelDB/LevelDBBlockchain.cs
+++ b/neo/Implementations/Blockchains/LevelDB/LevelDBBlockchain.cs
@@ -591,7 +591,6 @@ namespace Neo.Implementations.Blockchains.LevelDB
                         }
                         break;
                 }
-
                 foreach (UInt160 hash in tx.Outputs.Select(p => p.ScriptHash).Distinct())
                 {
                     ContractState contract = contracts.TryGet(hash);

--- a/neo/Network/LocalNode.cs
+++ b/neo/Network/LocalNode.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Neo.Core;
+using Neo.IO;
 using Neo.IO.Caching;
 using Neo.Network.Payloads;
 using System;
@@ -131,13 +132,16 @@ namespace Neo.Network
 
         private void AddTransactionLoop()
         {
-            int lastTransactionCount = 0;
-            uint lastBlockHeight = 0;
-            
             while (!cancellationTokenSource.IsCancellationRequested)
             {
                 new_tx_event.WaitOne();
-
+                Transaction[] transactions;
+                lock (temp_pool)
+                {
+                    if (temp_pool.Count == 0) continue;
+                    transactions = temp_pool.ToArray();
+                    temp_pool.Clear();
+                }
                 ConcurrentBag<Transaction> verified = new ConcurrentBag<Transaction>();
                 lock (Blockchain.Default.PersistLock)
                 {


### PR DESCRIPTION
This change insures consistency of the mem_pool upon accepting and persisting a new block and it improves performance of block persistence. Performance is especially improved when syncing the chain in the case that there are a high number number of future transactions hanging around in the mem_pool.

Syncing from a recent chain.acc.zip file has been almost required in the past since syncing could get very slow without this fix if the chain file is rather old. This is because contention on the mem_pool lock from the AddTransactionLoop would block the block persistence thread when LocalNode.Blockchain_PersistCompleted is invoked.

This change will cancel transaction verification each time a new block is received and persisted. I tested syncing the chain, and observed significant performance improvement using these changes. Testing was performed on 2 cores of an Intel(R) Xeon(R) CPU E5-2676 v3 @ 2.40GHz using a disk provisioned at 300 minimum IOPS.

This pull request was originally here (https://github.com/neo-project/neo/pull/218), but I'm submitting again freshly from a new branch: