### PR TITLE
Proper Locking During Block Persistence and Increase Performance while Syncing the Chain

### DIFF
--- a/neo/Core/Blockchain.cs
+++ b/neo/Core/Blockchain.cs
@@ -7,6 +7,7 @@ using Neo.VM;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 
 namespace Neo.Core
 {
@@ -16,6 +17,9 @@ namespace Neo.Core
     public abstract class Blockchain : IDisposable, IScriptTable
     {
         public static event EventHandler<Block> PersistCompleted;
+
+        public CancellationTokenSource VerificationCancellationToken { get; protected set; } = new CancellationTokenSource();
+        public object PersistLock { get; } = new object();
 
         /// <summary>
         /// 产生每个区块的时间间隔，已秒为单位

--- a/neo/Implementations/Blockchains/LevelDB/LevelDBBlockchain.cs
+++ b/neo/Implementations/Blockchains/LevelDB/LevelDBBlockchain.cs
@@ -113,6 +113,7 @@ namespace Neo.Implementations.Blockchains.LevelDB
             }
             thread_persistence = new Thread(PersistBlocks);
             thread_persistence.Name = "LevelDBBlockchain.PersistBlocks";
+            thread_persistence.Priority = ThreadPriority.AboveNormal;
             thread_persistence.Start();
         }
 
@@ -647,8 +648,16 @@ namespace Neo.Implementations.Blockchains.LevelDB
                         if (!block_cache.TryGetValue(hash, out block))
                             break;
                     }
-                    Persist(block);
-                    OnPersistCompleted(block);
+
+                    VerificationCancellationToken.Cancel();
+                    lock (PersistLock)
+                    {
+                        Persist(block);
+                        OnPersistCompleted(block);
+                        // Reset cancellation token.
+                        VerificationCancellationToken = new CancellationTokenSource();
+                    }
+
                     lock (block_cache)
                     {
                         block_cache.Remove(hash);

--- a/neo/Implementations/Blockchains/LevelDB/LevelDBBlockchain.cs
+++ b/neo/Implementations/Blockchains/LevelDB/LevelDBBlockchain.cs
@@ -152,8 +152,12 @@ namespace Neo.Implementations.Blockchains.LevelDB
                 OnAddHeader(block.Header, batch);
                 db.Write(WriteOptions.Default, batch);
             }
-            Persist(block);
-            OnPersistCompleted(block);
+
+            lock (PersistLock)
+            {
+                Persist(block);
+                OnPersistCompleted(block);
+            }
         }
 
         protected internal override void AddHeaders(IEnumerable<Header> headers)

--- a/neo/Network/LocalNode.cs
+++ b/neo/Network/LocalNode.cs
@@ -116,13 +116,16 @@ namespace Neo.Network
         private static bool AddTransaction(Transaction tx)
         {
             if (Blockchain.Default == null) return false;
-            lock (mem_pool)
+            lock (Blockchain.Default.PersistLock)
             {
-                if (mem_pool.ContainsKey(tx.Hash)) return false;
-                if (Blockchain.Default.ContainsTransaction(tx.Hash)) return false;
-                if (!tx.Verify(mem_pool.Values)) return false;
-                mem_pool.Add(tx.Hash, tx);
-                CheckMemPool();
+                lock (mem_pool)
+                {
+                    if (mem_pool.ContainsKey(tx.Hash)) return false;
+                    if (Blockchain.Default.ContainsTransaction(tx.Hash)) return false;
+                    if (!tx.Verify(mem_pool.Values)) return false;
+                        mem_pool.Add(tx.Hash, tx);
+                    CheckMemPool();
+                }
             }
             return true;
         }
@@ -140,25 +143,47 @@ namespace Neo.Network
                     temp_pool.Clear();
                 }
                 ConcurrentBag<Transaction> verified = new ConcurrentBag<Transaction>();
-                lock (mem_pool)
+                lock (Blockchain.Default.PersistLock)
                 {
-                    transactions = transactions.Where(p => !mem_pool.ContainsKey(p.Hash) && !Blockchain.Default.ContainsTransaction(p.Hash)).ToArray();
-                    if (transactions.Length == 0) continue;
-
-                    Transaction[] tmpool = mem_pool.Values.Concat(transactions).ToArray();
-
-                    transactions.AsParallel().ForAll(tx =>
+                    lock (mem_pool)
                     {
-                        if (tx.Verify(tmpool))
-                            verified.Add(tx);
-                    });
+                        transactions = transactions.Where(p => !mem_pool.ContainsKey(p.Hash) && !Blockchain.Default.ContainsTransaction(p.Hash)).ToArray();
 
-                    if (verified.Count == 0) continue;
+                        if (transactions.Length == 0)
+                            continue;
 
-                    foreach (Transaction tx in verified)
-                        mem_pool.Add(tx.Hash, tx);
+                        Transaction[] tmpool = mem_pool.Values.Concat(transactions).ToArray();
 
-                    CheckMemPool();
+                        ParallelOptions po = new ParallelOptions();
+                        po.CancellationToken = Blockchain.Default.VerificationCancellationToken.Token;
+                        po.MaxDegreeOfParallelism = System.Environment.ProcessorCount;
+
+                        try
+                        {
+                            Parallel.ForEach(transactions.AsParallel(), po, tx =>
+                            {
+                                if (tx.Verify(tmpool))
+                                    verified.Add(tx);
+                            });
+                        }
+                        catch (OperationCanceledException)
+                        {
+                            lock (temp_pool)
+                            {
+                                foreach (Transaction tx in transactions)
+                                    temp_pool.Add(tx);
+                            }
+
+                            continue;
+                        }
+
+                        if (verified.Count == 0) continue;
+
+                        foreach (Transaction tx in verified)
+                            mem_pool.Add(tx.Hash, tx);
+
+                        CheckMemPool();
+                    }
                 }
                 RelayDirectly(verified);
                 if (InventoryReceived != null)
@@ -437,9 +462,14 @@ namespace Neo.Network
                         nodes = connectedPeers.ToArray();
                     }
                     Task.WaitAll(nodes.Select(p => Task.Run(() => p.Disconnect(false))).ToArray());
+
                     new_tx_event.Set();
                     if (poolThread?.ThreadState.HasFlag(ThreadState.Unstarted) == false)
                         poolThread.Join();
+                    
+                    // Need to ensure any outstanding calls to Blockchain_PersistCompleted are not in progress.
+                    // TODO: could add locking instead of using an arbitrarily long sleep here.
+                    Thread.Sleep(3000);
                     new_tx_event.Dispose();
                 }
             }


### PR DESCRIPTION
This change insures consistency of the mem_pool upon accepting and persisting a new block and it improves performance of block persistence. Performance is especially improved when syncing the chain in the case that there are a high number number of future transactions hanging around in the mem_pool.

Syncing from a recent chain.acc.zip file has been almost required in the past since syncing could get very slow without this fix if the chain file is rather old. This is because contention on the mem_pool lock from the AddTransactionLoop would block the block persistence thread when LocalNode.Blockchain_PersistCompleted is invoked.

This change will cancel transaction verification each time a new block is received and persisted. I tested syncing the chain, and observed significant performance improvement using these changes. Testing was performed on 2 cores of an Intel(R) Xeon(R) CPU E5-2676 v3 @ 2.40GHz using a disk provisioned at 300 minimum IOPS.

This pull request was originally here (https://github.com/neo-project/neo/pull/218), but I'm submitting again freshly from a new branch: