### PR TITLE
fixed return type ff in deploy contract

### DIFF
--- a/neo/SmartContract/StateMachine.cs
+++ b/neo/SmartContract/StateMachine.cs
@@ -140,7 +140,9 @@ namespace Neo.SmartContract
             if (script.Length > 1024 * 1024) return false;
             ContractParameterType[] parameter_list = engine.EvaluationStack.Pop().GetByteArray().Select(p => (ContractParameterType)p).ToArray();
             if (parameter_list.Length > 252) return false;
-            ContractParameterType return_type = (ContractParameterType)(byte)engine.EvaluationStack.Pop().GetBigInteger();
+            byte[] retbyte = engine.EvaluationStack.Pop().GetByteArray();
+            if (retbyte.Length != 1) return false;
+            ContractParameterType return_type = (ContractParameterType)retbyte[0];
             ContractPropertyState contract_properties = (ContractPropertyState)(byte)engine.EvaluationStack.Pop().GetBigInteger();
             if (engine.EvaluationStack.Peek().GetByteArray().Length > 252) return false;
             string name = Encoding.UTF8.GetString(engine.EvaluationStack.Pop().GetByteArray());


### PR DESCRIPTION
The current code Pops the return type from EvaluationStack (expecting a single byte value), converts it BigInteger and then casts it to "byte" (then ContractParameterType). That works for all types except Void (ff), because the conversion to BigInteger turns into "-1", and the casting fails to byte type. The function fails without returning true or false (default is false I hope, in case of exception).
Another error could happen if multiple bytes are pushed on stack, that is why it's safer to get the result as byte[], check the Length == 1, and then take the first byte as the return type.
It's safer and it resolves the problem of Void return.