### PR TITLE
Reverify mem_pool on block persisted if not syncing the chain

### DIFF
--- a/neo/Consensus/ConsensusService.cs
+++ b/neo/Consensus/ConsensusService.cs
@@ -61,7 +61,7 @@ namespace Neo.Consensus
             return true;
         }
 
-        private void Blockchain_PersistCompleted(object sender, Block block)
+        private void Blockchain_PersistUnlocked(object sender, Block block)
         {
             Log($"persist block: {block.Hash}");
             block_received_time = DateTime.Now;
@@ -113,7 +113,7 @@ namespace Neo.Consensus
             if (timer != null) timer.Dispose();
             if (started)
             {
-                Blockchain.PersistCompleted -= Blockchain_PersistCompleted;
+                Blockchain.PersistUnlocked -= Blockchain_PersistUnlocked;
                 LocalNode.InventoryReceiving -= LocalNode_InventoryReceiving;
                 LocalNode.InventoryReceived -= LocalNode_InventoryReceived;
             }
@@ -390,7 +390,7 @@ namespace Neo.Consensus
         {
             Log("OnStart");
             started = true;
-            Blockchain.PersistCompleted += Blockchain_PersistCompleted;
+            Blockchain.PersistUnlocked += Blockchain_PersistUnlocked;
             LocalNode.InventoryReceiving += LocalNode_InventoryReceiving;
             LocalNode.InventoryReceived += LocalNode_InventoryReceived;
             InitializeConsensus(0);

--- a/neo/Core/Blockchain.cs
+++ b/neo/Core/Blockchain.cs
@@ -17,6 +17,7 @@ namespace Neo.Core
     public abstract class Blockchain : IDisposable, IScriptTable
     {
         public static event EventHandler<Block> PersistCompleted;
+        public static event EventHandler<Block> PersistUnlocked;
 
         public CancellationTokenSource VerificationCancellationToken { get; protected set; } = new CancellationTokenSource();
         public object PersistLock { get; } = new object();
@@ -524,11 +525,16 @@ namespace Neo.Core
         /// <param name="block">区块</param>
         protected void OnPersistCompleted(Block block)
         {
+            PersistCompleted?.Invoke(this, block);
+        }
+
+        protected void OnPersistUnlocked(Block block)
+        {
             lock (_validators)
             {
                 _validators.Clear();
             }
-            PersistCompleted?.Invoke(this, block);
+            PersistUnlocked?.Invoke(this, block);
         }
 
         protected void ProcessAccountStateDescriptor(StateDescriptor descriptor, DataCache<UInt160, AccountState> accounts, DataCache<ECPoint, ValidatorState> validators, MetaDataCache<ValidatorsCountState> validators_count)

--- a/neo/Implementations/Blockchains/LevelDB/LevelDBBlockchain.cs
+++ b/neo/Implementations/Blockchains/LevelDB/LevelDBBlockchain.cs
@@ -685,12 +685,13 @@ namespace Neo.Implementations.Blockchains.LevelDB
                         // Reset cancellation token.
                         VerificationCancellationToken = new CancellationTokenSource();
                     }
-                    OnPersistUnlocked(block);
 
                     lock (block_cache)
                     {
                         block_cache.Remove(hash);
                     }
+
+                    OnPersistUnlocked(block);
                 }
             }
         }

--- a/neo/Implementations/Blockchains/LevelDB/LevelDBBlockchain.cs
+++ b/neo/Implementations/Blockchains/LevelDB/LevelDBBlockchain.cs
@@ -685,6 +685,7 @@ namespace Neo.Implementations.Blockchains.LevelDB
                         // Reset cancellation token.
                         VerificationCancellationToken = new CancellationTokenSource();
                     }
+                    OnPersistUnlocked(block);
 
                     lock (block_cache)
                     {

--- a/neo/Network/LocalNode.cs
+++ b/neo/Network/LocalNode.cs
@@ -33,6 +33,7 @@ namespace Neo.Network
         private const int UnconnectedMax = 1000;
         public const int MemoryPoolSize = 50000;
         internal static readonly TimeSpan HashesExpiration = TimeSpan.FromSeconds(30);
+        private DateTime LastBlockReceived = DateTime.UtcNow;
 
         private static readonly Dictionary<UInt256, Transaction> mem_pool = new Dictionary<UInt256, Transaction>();
         private readonly HashSet<Transaction> temp_pool = new HashSet<Transaction>();

--- a/neo/Network/LocalNode.cs
+++ b/neo/Network/LocalNode.cs
@@ -222,7 +222,6 @@ namespace Neo.Network
                         verified.Add(tx);
                 });
                 
-                // Note, when running 
                 foreach (Transaction tx in verified)
                     mem_pool.Add(tx.Hash, tx);
             }


### PR DESCRIPTION
These changes keep mem_pool consistent across persisting blocks once the chain is synced. This ensures things already in the mem_pool at the time of persisting a block are prioritized over things in the temp_pool. The change will not slow down syncing the chain, since it only activates this code if the time since the last block was greater than 10 seconds. With our current block times this should be a safe change. Also, if there is a delay while syncing the chain, this could trigger the verification after persisting a block, but it won't slow things down much, since it will should have the next blocks right away if it is fairly well connected to the network.

This is to address issues discussed here:
https://github.com/neo-project/neo-cli/issues/168
https://github.com/neo-project/neo/pull/260

I've tested this now with the private net. With these changes. PR #260 seems to not be required. Consensus working as expected. Taking PR #260 with these changes is also ok.