### PR TITLE
Allowing ABI to be stored in the blockchain

### DIFF
--- a/neo/Core/ContractState.cs
+++ b/neo/Core/ContractState.cs
@@ -106,7 +106,18 @@ namespace Neo.Core
             json["code_version"] = CodeVersion;
             json["author"] = Author;
             json["email"] = Email;
-            json["description"] = Description;
+            JObject DescriptionWithABI;
+            try
+            {
+                DescriptionWithABI = JObject.Parse(Description);
+                json["description"] = DescriptionWithABI["description"];
+                json["ABI"] = DescriptionWithABI["ABI"];
+            }
+            catch (FormatException)
+            {
+                json["description"] = Description;
+                json["ABI"] = "{}";
+            }
             json["properties"] = new JObject();
             json["properties"]["storage"] = HasStorage;
             json["properties"]["dynamic_invoke"] = HasDynamicInvoke;

--- a/neo/Core/ContractState.cs
+++ b/neo/Core/ContractState.cs
@@ -1,6 +1,7 @@
 ﻿using Neo.IO;
 using Neo.IO.Json;
 using Neo.SmartContract;
+using System;
 using System.IO;
 using System.Linq;
 


### PR DESCRIPTION
This change intends to strength the usage of NEP-3, by storing the ABI in the blockchain and allowing easy retrieval with RPC call "getcontractstate". This change is really simple and do not break compatibility with anything else, it just explores the description field, in order to store the ABI together with a raw description of the contract. For older deployed contracts, the ABI will be empty "{}", and newer contracts could use this field in the following way:
```
{
    "description": "Usual contract description",
    "ABI" : {
           // contract ABI
     }
}
```