### PR TITLE
Add NotificationPlugin interface

### DIFF
--- a/neo/Plugins/NotificationPlugin.cs
+++ b/neo/Plugins/NotificationPlugin.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+
+namespace Neo.Plugins
+{
+    public abstract class NotificationPlugin : Plugin
+    {
+        private static readonly List<NotificationPlugin> instances = new List<NotificationPlugin>();
+
+        public new static IEnumerable<NotificationPlugin> Instances => instances;
+
+        public string UserAgent { get; set; }
+
+        protected NotificationPlugin()
+        {
+            instances.Add(this);
+        }
+
+        public abstract bool StartPersistingNotifications();
+        public abstract bool StartRESTApi();
+
+    }
+}


### PR DESCRIPTION
This PR adds a `NotificationPlugin` interface for plugins that wish to persist events emitted from smart contracts, and provide a REST interface for applications that wish to query those events.

- `StartPersistingNotifications` would be called on any `NotificationPlugin` that is installed in the `plugins` directory.  This method creates a database and begins saving events to the database.

- `UserAgent` is an interface to instruct the NotificationPlugin what version of neo core is running when persisting events

- `StartRESTApi` would optionally be called on any `NotificationPlugin` interface in the event that the operator wishes to expose a REST interface for public consumption of notification events.


All feedback welcome! 