### PR TITLE
Resolve rounding to prioritise fee tx over free tx

### DIFF
--- a/neo/Network/LocalNode.cs
+++ b/neo/Network/LocalNode.cs
@@ -277,6 +277,7 @@ namespace Neo.Network
 
             UInt256[] hashes = mem_pool.Values.AsParallel()
                 .OrderBy(p => p.NetworkFee / p.Size)
+                .ThenBy(p => p.NetworkFee)
                 .ThenBy(p => new BigInteger(p.Hash.ToArray()))
                 .Take(mem_pool.Count - MemoryPoolSize)
                 .Select(p => p.Hash)


### PR DESCRIPTION
Similar to https://github.com/neo-project/neo-plugins/commit/095e89fb175e2b9a6c55bd0c88f7c039d2145d1c
The method CheckMemPool() is used to trim the Mempool to avoid it going above the Maximum (currently 50,000).
The prioritisation is done by ordering the TX by NetworkFee/Size. However, as pointed out by the previous commit to neo-plugin by @belane and @jseagrave21, this integer division can be 0 even if NetworkFee > 0.

To resolve this, we then add another sort by NetworkFee.

This means any paid transaction will be ranked ahead of a free one, as this is the desired behaviour. @erikzhang @PeterLinX 