### PR TITLE
Use R/W Locking for mempool, cache, and block headers for greater concurrency.

### DIFF
--- a/neo/IO/Caching/Cache.cs
+++ b/neo/IO/Caching/Cache.cs
@@ -174,6 +174,7 @@ namespace Neo.IO.Caching
         public void Dispose()
         {
             Clear();
+            RwSyncRootLock.Dispose();
         }
 
         public IEnumerator<TValue> GetEnumerator()

--- a/neo/IO/Caching/Cache.cs
+++ b/neo/IO/Caching/Cache.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 
 namespace Neo.IO.Caching
 {
@@ -21,7 +22,7 @@ namespace Neo.IO.Caching
             }
         }
 
-        public readonly object SyncRoot = new object();
+        protected readonly ReaderWriterLock RwSyncRootLock = new ReaderWriterLock();
         protected readonly Dictionary<TKey, CacheItem> InnerDictionary = new Dictionary<TKey, CacheItem>();
         private readonly int max_capacity;
 
@@ -29,11 +30,16 @@ namespace Neo.IO.Caching
         {
             get
             {
-                lock (SyncRoot)
+                RwSyncRootLock.AcquireReaderLock(-1);
+                try
                 {
                     if (!InnerDictionary.TryGetValue(key, out CacheItem item)) throw new KeyNotFoundException();
                     OnAccess(item);
                     return item.Value;
+                }
+                finally
+                {
+                    RwSyncRootLock.ReleaseReaderLock();
                 }
             }
         }
@@ -42,9 +48,14 @@ namespace Neo.IO.Caching
         {
             get
             {
-                lock (SyncRoot)
+                RwSyncRootLock.AcquireReaderLock(-1);
+                try
                 {
                     return InnerDictionary.Count;
+                }
+                finally
+                {
+                    RwSyncRootLock.ReleaseReaderLock();
                 }
             }
         }
@@ -65,9 +76,14 @@ namespace Neo.IO.Caching
         public void Add(TValue item)
         {
             TKey key = GetKeyForItem(item);
-            lock (SyncRoot)
+            RwSyncRootLock.AcquireWriterLock(-1);
+            try
             {
                 AddInternal(key, item);
+            }
+            finally
+            {
+                RwSyncRootLock.ReleaseWriterLock();
             }
         }
 
@@ -93,7 +109,8 @@ namespace Neo.IO.Caching
 
         public void AddRange(IEnumerable<TValue> items)
         {
-            lock (SyncRoot)
+            RwSyncRootLock.AcquireWriterLock(-1);
+            try
             {
                 foreach (TValue item in items)
                 {
@@ -101,26 +118,40 @@ namespace Neo.IO.Caching
                     AddInternal(key, item);
                 }
             }
+            finally
+            {
+                RwSyncRootLock.ReleaseWriterLock();
+            }
         }
 
         public void Clear()
         {
-            lock (SyncRoot)
+            RwSyncRootLock.AcquireWriterLock(-1);
+            try
             {
                 foreach (CacheItem item_del in InnerDictionary.Values.ToArray())
                 {
                     RemoveInternal(item_del);
                 }
             }
+            finally
+            {
+                RwSyncRootLock.ReleaseWriterLock();
+            }
         }
 
         public bool Contains(TKey key)
         {
-            lock (SyncRoot)
+            RwSyncRootLock.AcquireReaderLock(-1);
+            try
             {
                 if (!InnerDictionary.TryGetValue(key, out CacheItem cacheItem)) return false;
                 OnAccess(cacheItem);
                 return true;
+            }
+            finally
+            {
+                RwSyncRootLock.ReleaseReaderLock();
             }
         }
 
@@ -147,12 +178,17 @@ namespace Neo.IO.Caching
 
         public IEnumerator<TValue> GetEnumerator()
         {
-            lock (SyncRoot)
+            RwSyncRootLock.AcquireReaderLock(-1);
+            try
             {
                 foreach (TValue item in InnerDictionary.Values.Select(p => p.Value))
                 {
                     yield return item;
                 }
+            }
+            finally
+            {
+                RwSyncRootLock.ReleaseReaderLock();
             }
         }
 
@@ -165,11 +201,16 @@ namespace Neo.IO.Caching
 
         public bool Remove(TKey key)
         {
-            lock (SyncRoot)
+            RwSyncRootLock.AcquireWriterLock(-1);
+            try
             {
                 if (!InnerDictionary.TryGetValue(key, out CacheItem cacheItem)) return false;
                 RemoveInternal(cacheItem);
                 return true;
+            }
+            finally
+            {
+                RwSyncRootLock.ReleaseWriterLock();
             }
         }
 
@@ -183,8 +224,7 @@ namespace Neo.IO.Caching
         private void RemoveInternal(CacheItem item)
         {
             InnerDictionary.Remove(item.Key);
-            IDisposable disposable = item.Value as IDisposable;
-            if (disposable != null)
+            if (item.Value is IDisposable disposable)
             {
                 disposable.Dispose();
             }
@@ -192,7 +232,8 @@ namespace Neo.IO.Caching
 
         public bool TryGet(TKey key, out TValue item)
         {
-            lock (SyncRoot)
+            RwSyncRootLock.AcquireReaderLock(-1);
+            try
             {
                 if (InnerDictionary.TryGetValue(key, out CacheItem cacheItem))
                 {
@@ -200,6 +241,10 @@ namespace Neo.IO.Caching
                     item = cacheItem.Value;
                     return true;
                 }
+            }
+            finally
+            {
+                RwSyncRootLock.ReleaseReaderLock();
             }
             item = default(TValue);
             return false;

--- a/neo/IO/Caching/Cache.cs
+++ b/neo/IO/Caching/Cache.cs
@@ -22,7 +22,7 @@ namespace Neo.IO.Caching
             }
         }
 
-        protected readonly ReaderWriterLock RwSyncRootLock = new ReaderWriterLock();
+        protected readonly ReaderWriterLockSlim RwSyncRootLock = new ReaderWriterLockSlim();
         protected readonly Dictionary<TKey, CacheItem> InnerDictionary = new Dictionary<TKey, CacheItem>();
         private readonly int max_capacity;
 
@@ -30,7 +30,7 @@ namespace Neo.IO.Caching
         {
             get
             {
-                RwSyncRootLock.AcquireReaderLock(-1);
+                RwSyncRootLock.EnterReadLock();
                 try
                 {
                     if (!InnerDictionary.TryGetValue(key, out CacheItem item)) throw new KeyNotFoundException();
@@ -39,7 +39,7 @@ namespace Neo.IO.Caching
                 }
                 finally
                 {
-                    RwSyncRootLock.ReleaseReaderLock();
+                    RwSyncRootLock.ExitReadLock();
                 }
             }
         }
@@ -48,14 +48,14 @@ namespace Neo.IO.Caching
         {
             get
             {
-                RwSyncRootLock.AcquireReaderLock(-1);
+                RwSyncRootLock.EnterReadLock();
                 try
                 {
                     return InnerDictionary.Count;
                 }
                 finally
                 {
-                    RwSyncRootLock.ReleaseReaderLock();
+                    RwSyncRootLock.ExitReadLock();
                 }
             }
         }
@@ -76,14 +76,14 @@ namespace Neo.IO.Caching
         public void Add(TValue item)
         {
             TKey key = GetKeyForItem(item);
-            RwSyncRootLock.AcquireWriterLock(-1);
+            RwSyncRootLock.EnterWriteLock();
             try
             {
                 AddInternal(key, item);
             }
             finally
             {
-                RwSyncRootLock.ReleaseWriterLock();
+                RwSyncRootLock.ExitWriteLock();
             }
         }
 
@@ -109,7 +109,7 @@ namespace Neo.IO.Caching
 
         public void AddRange(IEnumerable<TValue> items)
         {
-            RwSyncRootLock.AcquireWriterLock(-1);
+            RwSyncRootLock.EnterWriteLock();
             try
             {
                 foreach (TValue item in items)
@@ -120,13 +120,13 @@ namespace Neo.IO.Caching
             }
             finally
             {
-                RwSyncRootLock.ReleaseWriterLock();
+                RwSyncRootLock.ExitWriteLock();
             }
         }
 
         public void Clear()
         {
-            RwSyncRootLock.AcquireWriterLock(-1);
+            RwSyncRootLock.EnterWriteLock();
             try
             {
                 foreach (CacheItem item_del in InnerDictionary.Values.ToArray())
@@ -136,13 +136,13 @@ namespace Neo.IO.Caching
             }
             finally
             {
-                RwSyncRootLock.ReleaseWriterLock();
+                RwSyncRootLock.ExitWriteLock();
             }
         }
 
         public bool Contains(TKey key)
         {
-            RwSyncRootLock.AcquireReaderLock(-1);
+            RwSyncRootLock.EnterReadLock();
             try
             {
                 if (!InnerDictionary.TryGetValue(key, out CacheItem cacheItem)) return false;
@@ -151,7 +151,7 @@ namespace Neo.IO.Caching
             }
             finally
             {
-                RwSyncRootLock.ReleaseReaderLock();
+                RwSyncRootLock.ExitReadLock();
             }
         }
 
@@ -178,7 +178,7 @@ namespace Neo.IO.Caching
 
         public IEnumerator<TValue> GetEnumerator()
         {
-            RwSyncRootLock.AcquireReaderLock(-1);
+            RwSyncRootLock.EnterReadLock();
             try
             {
                 foreach (TValue item in InnerDictionary.Values.Select(p => p.Value))
@@ -188,7 +188,7 @@ namespace Neo.IO.Caching
             }
             finally
             {
-                RwSyncRootLock.ReleaseReaderLock();
+                RwSyncRootLock.ExitReadLock();
             }
         }
 
@@ -201,7 +201,7 @@ namespace Neo.IO.Caching
 
         public bool Remove(TKey key)
         {
-            RwSyncRootLock.AcquireWriterLock(-1);
+            RwSyncRootLock.EnterWriteLock();
             try
             {
                 if (!InnerDictionary.TryGetValue(key, out CacheItem cacheItem)) return false;
@@ -210,7 +210,7 @@ namespace Neo.IO.Caching
             }
             finally
             {
-                RwSyncRootLock.ReleaseWriterLock();
+                RwSyncRootLock.ExitWriteLock();
             }
         }
 
@@ -232,7 +232,7 @@ namespace Neo.IO.Caching
 
         public bool TryGet(TKey key, out TValue item)
         {
-            RwSyncRootLock.AcquireReaderLock(-1);
+            RwSyncRootLock.EnterReadLock();
             try
             {
                 if (InnerDictionary.TryGetValue(key, out CacheItem cacheItem))
@@ -244,7 +244,7 @@ namespace Neo.IO.Caching
             }
             finally
             {
-                RwSyncRootLock.ReleaseReaderLock();
+                RwSyncRootLock.ExitReadLock();
             }
             item = default(TValue);
             return false;

--- a/neo/IO/Caching/Cache.cs
+++ b/neo/IO/Caching/Cache.cs
@@ -22,7 +22,7 @@ namespace Neo.IO.Caching
             }
         }
 
-        protected readonly ReaderWriterLockSlim RwSyncRootLock = new ReaderWriterLockSlim();
+        protected readonly ReaderWriterLockSlim RwSyncRootLock = new ReaderWriterLockSlim(LockRecursionPolicy.SupportsRecursion);
         protected readonly Dictionary<TKey, CacheItem> InnerDictionary = new Dictionary<TKey, CacheItem>();
         private readonly int max_capacity;
 

--- a/neo/Implementations/Blockchains/LevelDB/LevelDBBlockchain.cs
+++ b/neo/Implementations/Blockchains/LevelDB/LevelDBBlockchain.cs
@@ -21,7 +21,9 @@ namespace Neo.Implementations.Blockchains.LevelDB
 
         private DB db;
         private Thread thread_persistence;
+        private ReaderWriterLock headerIndexRwLock = new ReaderWriterLock();
         private List<UInt256> header_index = new List<UInt256>();
+        private ReaderWriterLock headerCacheRwLock = new ReaderWriterLock();
         private Dictionary<UInt256, Header> header_cache = new Dictionary<UInt256, Header>();
         private Dictionary<UInt256, Block> block_cache = new Dictionary<UInt256, Block>();
         private uint current_block_height = 0;
@@ -125,7 +127,8 @@ namespace Neo.Implementations.Blockchains.LevelDB
                     block_cache.Add(block.Hash, block);
                 }
             }
-            lock (header_index)
+            headerIndexRwLock.AcquireWriterLock(-1);
+            try
             {
                 if (block.Index - 1 >= header_index.Count) return false;
                 if (block.Index == header_index.Count)
@@ -137,6 +140,10 @@ namespace Neo.Implementations.Blockchains.LevelDB
                 }
                 if (block.Index < header_index.Count)
                     new_block_event.Set();
+            }
+            finally
+            {
+                headerIndexRwLock.ReleaseWriterLock();
             }
             return true;
         }
@@ -161,9 +168,11 @@ namespace Neo.Implementations.Blockchains.LevelDB
 
         protected internal override void AddHeaders(IEnumerable<Header> headers)
         {
-            lock (header_index)
+            headerIndexRwLock.AcquireWriterLock(-1);
+            try
             {
-                lock (header_cache)
+                headerCacheRwLock.AcquireWriterLock(-1);
+                try
                 {
                     WriteBatch batch = new WriteBatch();
                     foreach (Header header in headers)
@@ -177,6 +186,15 @@ namespace Neo.Implementations.Blockchains.LevelDB
                     db.Write(WriteOptions.Default, batch);
                     header_cache.Clear();
                 }
+                finally
+                {
+                    headerCacheRwLock.ReleaseWriterLock();                    
+                }
+                
+            }
+            finally
+            {
+                headerIndexRwLock.ReleaseWriterLock();
             }
         }
 
@@ -231,10 +249,15 @@ namespace Neo.Implementations.Blockchains.LevelDB
         public override UInt256 GetBlockHash(uint height)
         {
             if (current_block_height < height) return null;
-            lock (header_index)
+            headerIndexRwLock.AcquireReaderLock(-1);
+            try
             {
                 if (header_index.Count <= height) return null;
-                return header_index[(int)height];
+                return header_index[(int) height];
+            }
+            finally
+            {
+                headerIndexRwLock.ReleaseReaderLock();
             }
         }
 
@@ -263,20 +286,30 @@ namespace Neo.Implementations.Blockchains.LevelDB
         public override Header GetHeader(uint height)
         {
             UInt256 hash;
-            lock (header_index)
+            headerIndexRwLock.AcquireReaderLock(-1);
+            try
             {
                 if (header_index.Count <= height) return null;
-                hash = header_index[(int)height];
+                hash = header_index[(int) height];
+            }
+            finally
+            {
+                headerIndexRwLock.ReleaseReaderLock();
             }
             return GetHeader(hash);
         }
 
         public override Header GetHeader(UInt256 hash)
         {
-            lock (header_cache)
+            headerCacheRwLock.AcquireReaderLock(-1);
+            try
             {
                 if (header_cache.TryGetValue(hash, out Header header))
                     return header;
+            }
+            finally
+            {
+                headerCacheRwLock.ReleaseReaderLock();
             }
             Slice value;
             if (!db.TryGet(ReadOptions.Default, SliceBuilder.Begin(DataEntryPrefix.DATA_Block).Add(hash), out value))
@@ -293,11 +326,16 @@ namespace Neo.Implementations.Blockchains.LevelDB
         {
             Header header = GetHeader(hash);
             if (header == null) return null;
-            lock (header_index)
+            headerIndexRwLock.AcquireReaderLock(-1);
+            try
             {
                 if (header.Index + 1 >= header_index.Count)
                     return null;
-                return header_index[(int)header.Index + 1];
+                return header_index[(int) header.Index + 1];
+            }
+            finally
+            {
+                headerIndexRwLock.ReleaseReaderLock();
             }
         }
 
@@ -634,10 +672,15 @@ namespace Neo.Implementations.Blockchains.LevelDB
                 while (!disposed)
                 {
                     UInt256 hash;
-                    lock (header_index)
+                    headerIndexRwLock.AcquireReaderLock(-1);
+                    try
                     {
                         if (header_index.Count <= current_block_height + 1) break;
-                        hash = header_index[(int)current_block_height + 1];
+                        hash = header_index[(int) current_block_height + 1];
+                    }
+                    finally
+                    {
+                        headerIndexRwLock.ReleaseReaderLock();
                     }
                     Block block;
                     lock (block_cache)

--- a/neo/Implementations/Blockchains/LevelDB/LevelDBBlockchain.cs
+++ b/neo/Implementations/Blockchains/LevelDB/LevelDBBlockchain.cs
@@ -21,9 +21,9 @@ namespace Neo.Implementations.Blockchains.LevelDB
 
         private DB db;
         private Thread thread_persistence;
-        private ReaderWriterLockSlim headerIndexRwLock = new ReaderWriterLockSlim();
+        private ReaderWriterLockSlim headerIndexRwLock = new ReaderWriterLockSlim(LockRecursionPolicy.SupportsRecursion);
         private List<UInt256> header_index = new List<UInt256>();
-        private ReaderWriterLockSlim headerCacheRwLock = new ReaderWriterLockSlim();
+        private ReaderWriterLockSlim headerCacheRwLock = new ReaderWriterLockSlim(LockRecursionPolicy.SupportsRecursion);
         private Dictionary<UInt256, Header> header_cache = new Dictionary<UInt256, Header>();
         private Dictionary<UInt256, Block> block_cache = new Dictionary<UInt256, Block>();
         private uint current_block_height = 0;

--- a/neo/Implementations/Blockchains/LevelDB/LevelDBBlockchain.cs
+++ b/neo/Implementations/Blockchains/LevelDB/LevelDBBlockchain.cs
@@ -229,6 +229,8 @@ namespace Neo.Implementations.Blockchains.LevelDB
                 db.Dispose();
                 db = null;
             }
+            headerCacheRwLock.Dispose();
+            headerIndexRwLock.Dispose();
         }
 
         public override AccountState GetAccountState(UInt160 script_hash)

--- a/neo/Network/LocalNode.cs
+++ b/neo/Network/LocalNode.cs
@@ -120,7 +120,7 @@ namespace Neo.Network
             if (Blockchain.Default == null) return false;
             lock (Blockchain.Default.PersistLock)
             {
-                MemPoolReadWriteLock.EnterReadLock();
+                MemPoolReadWriteLock.EnterWriteLock();
                 try
                 {
                     if (mem_pool.ContainsKey(tx.Hash)) return false;
@@ -131,7 +131,7 @@ namespace Neo.Network
                 }
                 finally
                 {
-                    MemPoolReadWriteLock.ExitReadLock();
+                    MemPoolReadWriteLock.ExitWriteLock();
                 }
             }
             return true;

--- a/neo/Network/LocalNode.cs
+++ b/neo/Network/LocalNode.cs
@@ -35,7 +35,7 @@ namespace Neo.Network
         internal static readonly TimeSpan HashesExpiration = TimeSpan.FromSeconds(30);
         private DateTime LastBlockReceived = DateTime.UtcNow;
 
-        private static readonly ReaderWriterLockSlim MemPoolReadWriteLock = new ReaderWriterLockSlim();
+        private static readonly ReaderWriterLockSlim MemPoolReadWriteLock = new ReaderWriterLockSlim(LockRecursionPolicy.SupportsRecursion);
         private static readonly Dictionary<UInt256, Transaction> mem_pool = new Dictionary<UInt256, Transaction>();
         private readonly HashSet<Transaction> temp_pool = new HashSet<Transaction>();
         internal static readonly Dictionary<UInt256, DateTime> KnownHashes = new Dictionary<UInt256, DateTime>();

--- a/neo/Network/LocalNode.cs
+++ b/neo/Network/LocalNode.cs
@@ -534,6 +534,7 @@ namespace Neo.Network
 
                     new_tx_event.Dispose();
                 }
+                MemPoolReadWriteLock.Dispose();
             }
         }
 


### PR DESCRIPTION
Readers should not block other readers for locking data structures like the mempool and block headers. This addresses the issue by using Read/Write locks.