### PR TITLE
Add RpcServer 'getblockheader' method call plus minor clean-up.

### DIFF
--- a/neo/Network/RPC/RpcServer.cs
+++ b/neo/Network/RPC/RpcServer.cs
@@ -467,10 +467,5 @@ namespace Neo.Network.RPC
 
             host.Start();
         }
-
-        public void Stop()
-        {
-            host.StopAsync();
-        }
     }
 }

--- a/neo/Network/RPC/RpcServer.cs
+++ b/neo/Network/RPC/RpcServer.cs
@@ -112,36 +112,59 @@ namespace Neo.Network.RPC
                                 json["nextblockhash"] = hash.ToString();
                             return json;
                         }
-                        else
-                        {
-                            return block.ToArray().ToHexString();
-                        }
+
+                        return block.ToArray().ToHexString();
                     }
                 case "getblockcount":
                     return Blockchain.Default.Height + 1;
-                case "getblockhash":
+                case "getblockheader":
                     {
-                        uint height = (uint)_params[0].AsNumber();
-                        if (height >= 0 && height <= Blockchain.Default.Height)
+                        Header header;
+                        if (_params[0] is JNumber)
                         {
-                            return Blockchain.Default.GetBlockHash(height).ToString();
+                            uint height = (uint)_params[0].AsNumber();
+                            header = Blockchain.Default.GetHeader(height);
                         }
                         else
                         {
-                            throw new RpcException(-100, "Invalid Height");
+                            UInt256 hash = UInt256.Parse(_params[0].AsString());
+                            header = Blockchain.Default.GetHeader(hash);
                         }
+                        if (header == null)
+                            throw new RpcException(-100, "Unknown block");
+
+                        bool verbose = _params.Count >= 2 && _params[1].AsBooleanOrDefault(false);
+                        if (verbose)
+                        {
+                            JObject json = header.ToJson();
+                            json["confirmations"] = Blockchain.Default.Height - header.Index + 1;
+                            UInt256 hash = Blockchain.Default.GetNextBlockHash(header.Hash);
+                            if (hash != null)
+                                json["nextblockhash"] = hash.ToString();
+                            return json;                            
+                        }
+
+                        return header.ToArray().ToHexString();
+                    }
+                case "getblockhash":
+                    {
+                        uint height = (uint)_params[0].AsNumber();
+                        if (height <= Blockchain.Default.Height)
+                        {
+                            return Blockchain.Default.GetBlockHash(height).ToString();
+                        }
+
+                        throw new RpcException(-100, "Invalid Height");
                     }
                 case "getblocksysfee":
                     {
                         uint height = (uint)_params[0].AsNumber();
-                        if (height >= 0 && height <= Blockchain.Default.Height)
+                        if (height <= Blockchain.Default.Height)
                         {
                             return Blockchain.Default.GetSysFeeAmount(height).ToString();
                         }
-                        else
-                        {
-                            throw new RpcException(-100, "Invalid Height");
-                        }
+
+                        throw new RpcException(-100, "Invalid Height");
                     }
                 case "getconnectioncount":
                     return LocalNode.RemoteNodeCount;
@@ -175,10 +198,8 @@ namespace Neo.Network.RPC
                             }
                             return json;
                         }
-                        else
-                        {
-                            return tx.ToArray().ToHexString();
-                        }
+
+                        return tx.ToArray().ToHexString();
                     }
                 case "getstorage":
                     {
@@ -445,6 +466,11 @@ namespace Neo.Network.RPC
             .Build();
 
             host.Start();
+        }
+
+        public void Stop()
+        {
+            host.StopAsync();
         }
     }
 }


### PR DESCRIPTION
Some clients only need the block header but are making calls to getblock. One could argue this can be in a plugin, but really the base RPC methods should support getting the block header by index or hash.
I've added it and also done some minor clean-up.