### PR TITLE
Update Helper.cs

### DIFF
--- a/neo/IO/Helper.cs
+++ b/neo/IO/Helper.cs
@@ -31,7 +31,7 @@ namespace Neo.IO
             return serializable;
         }
 
-        public static T[] AsSerializableArray<T>(this byte[] value, int max = 0x10000000) where T : ISerializable, new()
+        public static T[] AsSerializableArray<T>(this byte[] value, int max = 0x1000000) where T : ISerializable, new()
         {
             using (MemoryStream ms = new MemoryStream(value, false))
             using (BinaryReader reader = new BinaryReader(ms, Encoding.UTF8))
@@ -118,7 +118,7 @@ namespace Neo.IO
             return obj;
         }
 
-        public static T[] ReadSerializableArray<T>(this BinaryReader reader, int max = 0x10000000) where T : ISerializable, new()
+        public static T[] ReadSerializableArray<T>(this BinaryReader reader, int max = 0x1000000) where T : ISerializable, new()
         {
             T[] array = new T[reader.ReadVarInt((ulong)max)];
             for (int i = 0; i < array.Length; i++)
@@ -129,12 +129,12 @@ namespace Neo.IO
             return array;
         }
 
-        public static byte[] ReadVarBytes(this BinaryReader reader, int max = 0X7fffffc7)
+        public static byte[] ReadVarBytes(this BinaryReader reader, int max = 0x1000000)
         {
             return reader.ReadBytes((int)reader.ReadVarInt((ulong)max));
         }
 
-        public static ulong ReadVarInt(this BinaryReader reader, ulong max = ulong.MaxValue)
+        public static ulong ReadVarInt(this BinaryReader reader, ulong max = 0x1000000)
         {
             byte fb = reader.ReadByte();
             ulong value;
@@ -150,7 +150,7 @@ namespace Neo.IO
             return value;
         }
 
-        public static string ReadVarString(this BinaryReader reader, int max = 0X7fffffc7)
+        public static string ReadVarString(this BinaryReader reader, int max = 0x1000000)
         {
             return Encoding.UTF8.GetString(reader.ReadVarBytes(max));
         }


### PR DESCRIPTION
We think that with 16mb by default is enought to prevent some DOS, and enought for any case of use.

There are some methods like this, that could be used for deny service with crafted payloads (in this case, a crafted wallet):

https://github.com/neo-project/neo/blob/8e7c9f50a0f8c98f40186443b15965d110cff19f/neo/Wallets/SQLite/VerificationContract.cs#L17-L18