### PR TITLE
Order by fees when re-adding remaining transactions after persisting block

### DIFF
--- a/neo/Ledger/Blockchain.cs
+++ b/neo/Ledger/Blockchain.cs
@@ -380,7 +380,11 @@ namespace Neo.Ledger
             block_cache.Remove(block.Hash);
             foreach (Transaction tx in block.Transactions)
                 mem_pool.TryRemove(tx.Hash, out _);
-            foreach (Transaction tx in mem_pool.Values)
+            
+            foreach (Transaction tx in mem_pool.Values
+                .OrderByDescending(p => p.NetworkFee / p.Size)
+                .ThenByDescending(p => p.NetworkFee)
+                .ThenByDescending(p => new BigInteger(p.Hash.ToArray())))
                 Self.Tell(tx, ActorRefs.NoSender);
             mem_pool.Clear();
             PersistCompleted completed = new PersistCompleted { Block = block };


### PR DESCRIPTION
After the block is persisted we are re-inserting the transactions back into the message queue; however, since they may not all be processed by the time of the next consensus, they should be added in the order they are meant to be ordered when transactions are added. This makes that happen.