### PR TITLE
Allow setting Additional GAS to be used in RpcInvoke for RpcServer. Expose overloaded ApplicationEngine.Run allowing a passed Snapshot.

### DIFF
--- a/neo/NeoSystem.cs
+++ b/neo/NeoSystem.cs
@@ -57,7 +57,7 @@ namespace Neo
         }
 
         public void StartRpc(IPAddress bindAddress, int port, Wallet wallet = null, string sslCert = null, string password = null, 
-            string[] trustedAuthorities = null, long maxGasInvoke = 99000000000L)
+            string[] trustedAuthorities = null, long maxGasInvoke = 0L)
         {
             rpcServer = new RpcServer(this, wallet, maxGasInvoke);
             rpcServer.Start(bindAddress, port, sslCert, password, trustedAuthorities);

--- a/neo/NeoSystem.cs
+++ b/neo/NeoSystem.cs
@@ -57,7 +57,7 @@ namespace Neo
         }
 
         public void StartRpc(IPAddress bindAddress, int port, Wallet wallet = null, string sslCert = null, string password = null, 
-            string[] trustedAuthorities = null, long maxGasInvoke = 0L)
+            string[] trustedAuthorities = null, Fixed8 maxGasInvoke = default(Fixed8))
         {
             rpcServer = new RpcServer(this, wallet, maxGasInvoke);
             rpcServer.Start(bindAddress, port, sslCert, password, trustedAuthorities);

--- a/neo/NeoSystem.cs
+++ b/neo/NeoSystem.cs
@@ -56,9 +56,10 @@ namespace Neo
             });
         }
 
-        public void StartRpc(IPAddress bindAddress, int port, Wallet wallet = null, string sslCert = null, string password = null, string[] trustedAuthorities = null)
+        public void StartRpc(IPAddress bindAddress, int port, Wallet wallet = null, string sslCert = null, string password = null, 
+            string[] trustedAuthorities = null, long maxGasInvoke = 99000000000L)
         {
-            rpcServer = new RpcServer(this, wallet);
+            rpcServer = new RpcServer(this, wallet, maxGasInvoke);
             rpcServer.Start(bindAddress, port, sslCert, password, trustedAuthorities);
         }
     }

--- a/neo/Network/RPC/RpcServer.cs
+++ b/neo/Network/RPC/RpcServer.cs
@@ -34,11 +34,13 @@ namespace Neo.Network.RPC
         private readonly NeoSystem system;
         private readonly Wallet wallet;
         private IWebHost host;
+        private Fixed8 maxGasInvoke;
 
-        public RpcServer(NeoSystem system, Wallet wallet = null)
+        public RpcServer(NeoSystem system, Wallet wallet = null, long maxGasInvoke = 99000000000L)
         {
             this.system = system;
             this.wallet = wallet;
+            this.maxGasInvoke = new Fixed8(maxGasInvoke);
         }
 
         private static JObject CreateErrorResponse(JObject id, int code, string message, JObject data = null)
@@ -71,7 +73,7 @@ namespace Neo.Network.RPC
 
         private JObject GetInvokeResult(byte[] script)
         {
-            ApplicationEngine engine = ApplicationEngine.Run(script, null, null, false, new Fixed8(99000000000L));
+            ApplicationEngine engine = ApplicationEngine.Run(script, null, null, false, maxGasInvoke);
             JObject json = new JObject();
             json["script"] = script.ToHexString();
             json["state"] = engine.State;

--- a/neo/Network/RPC/RpcServer.cs
+++ b/neo/Network/RPC/RpcServer.cs
@@ -40,7 +40,7 @@ namespace Neo.Network.RPC
         {
             this.system = system;
             this.wallet = wallet;
-            this.maxGasInvoke = new Fixed8(maxGasInvoke);
+            this.maxGasInvoke = maxGasInvoke;
         }
 
         private static JObject CreateErrorResponse(JObject id, int code, string message, JObject data = null)

--- a/neo/Network/RPC/RpcServer.cs
+++ b/neo/Network/RPC/RpcServer.cs
@@ -71,7 +71,7 @@ namespace Neo.Network.RPC
 
         private JObject GetInvokeResult(byte[] script)
         {
-            ApplicationEngine engine = ApplicationEngine.Run(script);
+            ApplicationEngine engine = ApplicationEngine.Run(script, null, null, false, new Fixed8(29000000000L));
             JObject json = new JObject();
             json["script"] = script.ToHexString();
             json["state"] = engine.State;

--- a/neo/Network/RPC/RpcServer.cs
+++ b/neo/Network/RPC/RpcServer.cs
@@ -36,7 +36,7 @@ namespace Neo.Network.RPC
         private IWebHost host;
         private Fixed8 maxGasInvoke;
 
-        public RpcServer(NeoSystem system, Wallet wallet = null, long maxGasInvoke = 0L)
+        public RpcServer(NeoSystem system, Wallet wallet = null, Fixed8 maxGasInvoke = default)
         {
             this.system = system;
             this.wallet = wallet;

--- a/neo/Network/RPC/RpcServer.cs
+++ b/neo/Network/RPC/RpcServer.cs
@@ -71,7 +71,7 @@ namespace Neo.Network.RPC
 
         private JObject GetInvokeResult(byte[] script)
         {
-            ApplicationEngine engine = ApplicationEngine.Run(script, null, null, false, new Fixed8(29000000000L));
+            ApplicationEngine engine = ApplicationEngine.Run(script, null, null, false, new Fixed8(99000000000L));
             JObject json = new JObject();
             json["script"] = script.ToHexString();
             json["state"] = engine.State;

--- a/neo/Network/RPC/RpcServer.cs
+++ b/neo/Network/RPC/RpcServer.cs
@@ -36,7 +36,7 @@ namespace Neo.Network.RPC
         private IWebHost host;
         private Fixed8 maxGasInvoke;
 
-        public RpcServer(NeoSystem system, Wallet wallet = null, Fixed8 maxGasInvoke = default)
+        public RpcServer(NeoSystem system, Wallet wallet = null, Fixed8 maxGasInvoke = default(Fixed8))
         {
             this.system = system;
             this.wallet = wallet;

--- a/neo/Network/RPC/RpcServer.cs
+++ b/neo/Network/RPC/RpcServer.cs
@@ -36,7 +36,7 @@ namespace Neo.Network.RPC
         private IWebHost host;
         private Fixed8 maxGasInvoke;
 
-        public RpcServer(NeoSystem system, Wallet wallet = null, long maxGasInvoke = 99000000000L)
+        public RpcServer(NeoSystem system, Wallet wallet = null, long maxGasInvoke = 0L)
         {
             this.system = system;
             this.wallet = wallet;

--- a/neo/SmartContract/ApplicationEngine.cs
+++ b/neo/SmartContract/ApplicationEngine.cs
@@ -604,30 +604,36 @@ namespace Neo.SmartContract
             return true;
         }
 
-        public static ApplicationEngine Run(byte[] script, IScriptContainer container = null, Block persisting_block = null, bool testMode = false)
+        public static ApplicationEngine Run(byte[] script, Snapshot snapshot,
+            IScriptContainer container = null, Block persistingBlock = null, bool testMode = false, Fixed8 extraGAS = default(Fixed8))
+        {
+            snapshot.PersistingBlock = persistingBlock ?? new Block
+            {
+                Version = 0,
+                PrevHash = snapshot.CurrentBlockHash,
+                MerkleRoot = new UInt256(),
+                Timestamp = snapshot.Blocks[snapshot.CurrentBlockHash].TrimmedBlock.Timestamp + Blockchain.SecondsPerBlock,
+                Index = snapshot.Height + 1,
+                ConsensusData = 0,
+                NextConsensus = snapshot.Blocks[snapshot.CurrentBlockHash].TrimmedBlock.NextConsensus,
+                Witness = new Witness
+                {
+                    InvocationScript = new byte[0],
+                    VerificationScript = new byte[0]
+                },
+                Transactions = new Transaction[0]
+            };
+            ApplicationEngine engine = new ApplicationEngine(TriggerType.Application, container, snapshot, extraGAS, testMode);
+            engine.LoadScript(script);
+            engine.Execute();
+            return engine;
+        }
+        
+        public static ApplicationEngine Run(byte[] script, IScriptContainer container = null, Block persistingBlock = null, bool testMode = false, Fixed8 extraGAS = default(Fixed8))
         {
             using (Snapshot snapshot = Blockchain.Singleton.GetSnapshot())
             {
-                snapshot.PersistingBlock = persisting_block ?? new Block
-                {
-                    Version = 0,
-                    PrevHash = snapshot.CurrentBlockHash,
-                    MerkleRoot = new UInt256(),
-                    Timestamp = snapshot.Blocks[snapshot.CurrentBlockHash].TrimmedBlock.Timestamp + Blockchain.SecondsPerBlock,
-                    Index = snapshot.Height + 1,
-                    ConsensusData = 0,
-                    NextConsensus = snapshot.Blocks[snapshot.CurrentBlockHash].TrimmedBlock.NextConsensus,
-                    Witness = new Witness
-                    {
-                        InvocationScript = new byte[0],
-                        VerificationScript = new byte[0]
-                    },
-                    Transactions = new Transaction[0]
-                };
-                ApplicationEngine engine = new ApplicationEngine(TriggerType.Application, container, snapshot, Fixed8.Zero, testMode);
-                engine.LoadScript(script);
-                engine.Execute();
-                return engine;
+                return Run(script, snapshot, container, persistingBlock, testMode, extraGAS);
             }
         }
     }

--- a/neo/SmartContract/ApplicationEngine.cs
+++ b/neo/SmartContract/ApplicationEngine.cs
@@ -607,7 +607,7 @@ namespace Neo.SmartContract
         public static ApplicationEngine Run(byte[] script, Snapshot snapshot,
             IScriptContainer container = null, Block persistingBlock = null, bool testMode = false, Fixed8 extraGAS = default(Fixed8))
         {
-            snapshot.PersistingBlock = persistingBlock ?? new Block
+            snapshot.PersistingBlock = persistingBlock ?? snapshot.PersistingBlock ?? new Block
             {
                 Version = 0,
                 PrevHash = snapshot.CurrentBlockHash,


### PR DESCRIPTION
It was reported (https://github.com/neo-project/neo/issues/396) that invoke calls prior to 2.9.0 supported more than 10 GAS limit. There should be some limit, but not 10 since it helps batch results coming back to clients. This raises the limit to 300 GAS. 

Note: It was reported Neon wallet currently makes invokes that use between 40 and 50 GAS.

Also, some users of neo core want to run against a snapshot that may not be the current block. I'm exposing a mechanism to do this with the overloaded ApplicationEngine.Run method.

Close #396 