### PR TITLE
Neo.Transaction.GetWitnesses

### DIFF
--- a/neo/Network/P2P/Payloads/Witness.cs
+++ b/neo/Network/P2P/Payloads/Witness.cs
@@ -1,11 +1,12 @@
 ﻿using Neo.IO;
+using Neo.VM;
 using Neo.IO.Json;
 using Neo.SmartContract;
 using System.IO;
 
 namespace Neo.Network.P2P.Payloads
 {
-    public class Witness : ISerializable
+    public class Witness : ISerializable, IInteropInterface
     {
         public byte[] InvocationScript;
         public byte[] VerificationScript;

--- a/neo/SmartContract/ApplicationEngine.cs
+++ b/neo/SmartContract/ApplicationEngine.cs
@@ -542,6 +542,11 @@ namespace Neo.SmartContract
                     return 200;
                 case "Neo.Transaction.GetUnspentCoins":
                     return 200;
+                case "Neo.Transaction.GetWitnesses":
+                    return 200;
+                case "Neo.Witness.GetInvocationScript":
+                case "Neo.Witness.GetVerificationScript":
+                    return 100;
                 case "Neo.Account.IsStandard":
                     return 100;
                 case "Neo.Asset.Create":

--- a/neo/SmartContract/NeoService.cs
+++ b/neo/SmartContract/NeoService.cs
@@ -53,7 +53,10 @@ namespace Neo.SmartContract
             Register("Neo.Transaction.GetOutputs", Transaction_GetOutputs);
             Register("Neo.Transaction.GetReferences", Transaction_GetReferences);
             Register("Neo.Transaction.GetUnspentCoins", Transaction_GetUnspentCoins);
+            Register("Neo.Transaction.GetWitnesses", Transaction_GetWitnesses);
             Register("Neo.InvocationTransaction.GetScript", InvocationTransaction_GetScript);
+            Register("Neo.Witness.GetInvocationScript", Witness_GetInvocationScript);
+            Register("Neo.Witness.GetVerificationScript", Witness_GetVerificationScript);
             Register("Neo.Attribute.GetUsage", Attribute_GetUsage);
             Register("Neo.Attribute.GetData", Attribute_GetData);
             Register("Neo.Input.GetHash", Input_GetHash);
@@ -317,6 +320,20 @@ namespace Neo.SmartContract
             return false;
         }
 
+        private bool Transaction_GetWitnesses(ExecutionEngine engine)
+        {
+            if (engine.CurrentContext.EvaluationStack.Pop() is InteropInterface _interface)
+            {
+                Transaction tx = _interface.GetInterface<Transaction>();
+                if (tx == null) return false;
+                if (tx.Witnesses.Length > ApplicationEngine.MaxArraySize)
+                    return false;
+                engine.CurrentContext.EvaluationStack.Push(tx.Witnesses.Select(p => StackItem.FromInterface(p)).ToArray());
+                return true;
+            }
+            return false;
+        }
+
         private bool InvocationTransaction_GetScript(ExecutionEngine engine)
         {
             if (engine.CurrentContext.EvaluationStack.Pop() is InteropInterface _interface)
@@ -328,6 +345,31 @@ namespace Neo.SmartContract
             }
             return false;
         }
+
+        private bool Witness_GetInvocationScript(ExecutionEngine engine)
+        {
+            if (engine.CurrentContext.EvaluationStack.Pop() is InteropInterface _interface)
+            {
+                Witness witness = _interface.GetInterface<Witness>();
+                if (witness == null) return false;
+                engine.CurrentContext.EvaluationStack.Push(witness.InvocationScript);
+                return true;
+            }
+            return false;
+        }
+
+        private bool Witness_GetVerificationScript(ExecutionEngine engine)
+        {
+            if (engine.CurrentContext.EvaluationStack.Pop() is InteropInterface _interface)
+            {
+                Witness witness = _interface.GetInterface<Witness>();
+                if (witness == null) return false;
+                engine.CurrentContext.EvaluationStack.Push(witness.VerificationScript);
+                return true;
+            }
+            return false;
+        }
+
 
         private bool Attribute_GetUsage(ExecutionEngine engine)
         {


### PR DESCRIPTION
Add `Neo.Transaction.GetWitnesses`, `Neo.Witness.GetInvocationScript` and `Neo.Witness.GetVerificationScript`.

Closes #400 

This is necessary for a Smart Contract to be able to introspect the signers of a transaction.