### PR TITLE
Keeping IsStandard for compatibility with neo-cli

### DIFF
--- a/neo/SmartContract/Contract.cs
+++ b/neo/SmartContract/Contract.cs
@@ -10,6 +10,14 @@ namespace Neo.SmartContract
     {
         public byte[] Script;
         public ContractParameterType[] ParameterList;
+        
+        public bool IsStandard
+        {
+            get
+            {
+                return this.Script.IsStandardContract();
+            }
+        }
 
         private string _address;
         public string Address


### PR DESCRIPTION
I guess this field is missing on earlier versions of neo-cli. It could be fixed there, but perhaps is good to keep it here too.