### PR TITLE
add constant storage

### DIFF
--- a/neo.UnitTests/UT_StorageItem.cs
+++ b/neo.UnitTests/UT_StorageItem.cs
@@ -38,14 +38,14 @@ namespace Neo.UnitTests
         public void Size_Get()
         {
             uut.Value = TestUtils.GetByteArray(10, 0x42);
-            uut.Size.Should().Be(12); // 2 + 10
+            uut.Size.Should().Be(13); // 2 + 10 + 1
         }
 
         [TestMethod]
         public void Size_Get_Larger()
         {
             uut.Value = TestUtils.GetByteArray(88, 0x42);
-            uut.Size.Should().Be(90); // 2 + 88
+            uut.Size.Should().Be(91); // 2 + 88 + 1
         }
 
         [TestMethod]
@@ -65,7 +65,7 @@ namespace Neo.UnitTests
         [TestMethod]
         public void Deserialize()
         {
-            byte[] data = new byte[] { 0, 10, 66, 32, 32, 32, 32, 32, 32, 32, 32, 32 };
+            byte[] data = new byte[] { 0, 10, 66, 32, 32, 32, 32, 32, 32, 32, 32, 32, 0 };
             int index = 0;
             using (MemoryStream ms = new MemoryStream(data, index, data.Length - index, false))
             {
@@ -97,9 +97,9 @@ namespace Neo.UnitTests
                 }
             }
 
-            byte[] requiredData = new byte[] { 0, 10, 66, 32, 32, 32, 32, 32, 32, 32, 32, 32 };
+            byte[] requiredData = new byte[] { 0, 10, 66, 32, 32, 32, 32, 32, 32, 32, 32, 32, 0 };
 
-            data.Length.Should().Be(12);
+            data.Length.Should().Be(13);
             for (int i = 0; i < 12; i++)
             {
                 data[i].Should().Be(requiredData[i]);

--- a/neo/Ledger/StorageFlags.cs
+++ b/neo/Ledger/StorageFlags.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace Neo.Ledger
+{
+    [Flags]
+    public enum StorageFlags : byte
+    {
+        None = 0,
+        Constant = 0x01
+    }
+}

--- a/neo/Ledger/StorageItem.cs
+++ b/neo/Ledger/StorageItem.cs
@@ -6,14 +6,16 @@ namespace Neo.Ledger
     public class StorageItem : StateBase, ICloneable<StorageItem>
     {
         public byte[] Value;
+        public bool IsConstant;
 
-        public override int Size => base.Size + Value.GetVarSize();
+        public override int Size => base.Size + Value.GetVarSize() + sizeof(bool);
 
         StorageItem ICloneable<StorageItem>.Clone()
         {
             return new StorageItem
             {
-                Value = Value
+                Value = Value,
+                IsConstant = IsConstant
             };
         }
 
@@ -21,17 +23,20 @@ namespace Neo.Ledger
         {
             base.Deserialize(reader);
             Value = reader.ReadVarBytes();
+            IsConstant = reader.ReadBoolean();
         }
 
         void ICloneable<StorageItem>.FromReplica(StorageItem replica)
         {
             Value = replica.Value;
+            IsConstant = replica.IsConstant;
         }
 
         public override void Serialize(BinaryWriter writer)
         {
             base.Serialize(writer);
             writer.WriteVarBytes(Value);
+            writer.Write(IsConstant);
         }
     }
 }

--- a/neo/SmartContract/ApplicationEngine.cs
+++ b/neo/SmartContract/ApplicationEngine.cs
@@ -578,6 +578,7 @@ namespace Neo.SmartContract
                 case "AntShares.Storage.Get":
                     return 100;
                 case "System.Storage.Put":
+                case "System.Storage.PutEx":
                 case "Neo.Storage.Put":
                 case "AntShares.Storage.Put":
                     return ((CurrentContext.EvaluationStack.Peek(1).GetByteArray().Length + CurrentContext.EvaluationStack.Peek(2).GetByteArray().Length - 1) / 1024 + 1) * 1000;

--- a/neo/SmartContract/NeoService.cs
+++ b/neo/SmartContract/NeoService.cs
@@ -757,7 +757,8 @@ namespace Neo.SmartContract
                             Key = pair.Key.Key
                         }, new StorageItem
                         {
-                            Value = pair.Value.Value
+                            Value = pair.Value.Value,
+                            IsConstant = false
                         });
                     }
                 }


### PR DESCRIPTION
The constant storage can be written once by the contract and can no longer be modified.

This is useful for storing data that should not be modified, such as total amount of tokens, digital identity information, and so on.

I am not sure if I should limit the maximum size of constant storage for each contract. Because regardless of whether it is constant data, the cost of writing data is the same for attackers.

Closes #341 