### PR TITLE
Minnor fix on consensus OnPrepareResponseReceived

### DIFF
--- a/neo/Consensus/ConsensusService.cs
+++ b/neo/Consensus/ConsensusService.cs
@@ -291,11 +291,7 @@ namespace Neo.Consensus
             Log($"{nameof(OnPrepareResponseReceived)}: height={payload.BlockIndex} view={message.ViewNumber} index={payload.ValidatorIndex}");
             if (context.Signatures[payload.ValidatorIndex] != null) return;
             byte[] hashData = context.MakeHeader()?.GetHashData();
-            if (hashData == null)
-            {
-                context.Signatures[payload.ValidatorIndex] = null;
-            }
-            else if (Crypto.Default.VerifySignature(hashData, message.Signature, context.Validators[payload.ValidatorIndex].EncodePoint(false)))
+            if (hashData != null && Crypto.Default.VerifySignature(hashData, message.Signature, context.Validators[payload.ValidatorIndex].EncodePoint(false)))
             {
                 context.Signatures[payload.ValidatorIndex] = message.Signature;
                 CheckSignatures();

--- a/neo/Consensus/ConsensusService.cs
+++ b/neo/Consensus/ConsensusService.cs
@@ -293,7 +293,7 @@ namespace Neo.Consensus
             byte[] hashData = context.MakeHeader()?.GetHashData();
             if (hashData == null)
             {
-                context.Signatures[payload.ValidatorIndex] = message.Signature;
+                context.Signatures[payload.ValidatorIndex] = null;
             }
             else if (Crypto.Default.VerifySignature(hashData, message.Signature, context.Validators[payload.ValidatorIndex].EncodePoint(false)))
             {


### PR DESCRIPTION
Hi, @erikzhang, @shargon, @igormcoelho.

Sorry for insisting on that, but I think that we had skip this in the last PR.

Lines 296 and 300 are the same (if they are the same, the `if` at line 294 would be just about `CheckSignatures()`.
But I believe line 296 should be null because of the Header being `null`, otherwise, an arbitrarily payload can get its signature inside `context.Signatures`.