### PR TITLE
Minnor simplification on OnPrepareResponseReceived

### DIFF
--- a/neo/Consensus/ConsensusService.cs
+++ b/neo/Consensus/ConsensusService.cs
@@ -290,16 +290,10 @@ namespace Neo.Consensus
         {
             Log($"{nameof(OnPrepareResponseReceived)}: height={payload.BlockIndex} view={message.ViewNumber} index={payload.ValidatorIndex}");
             if (context.Signatures[payload.ValidatorIndex] != null) return;
+            context.Signatures[payload.ValidatorIndex] = message.Signature;
             byte[] hashData = context.MakeHeader()?.GetHashData();
-            if (hashData == null)
-            {
-                context.Signatures[payload.ValidatorIndex] = message.Signature;
-            }
-            else if (Crypto.Default.VerifySignature(hashData, message.Signature, context.Validators[payload.ValidatorIndex].EncodePoint(false)))
-            {
-                context.Signatures[payload.ValidatorIndex] = message.Signature;
+            if (hashData != null && Crypto.Default.VerifySignature(hashData, message.Signature, context.Validators[payload.ValidatorIndex].EncodePoint(false)))
                 CheckSignatures();
-            }
         }
 
         protected override void OnReceive(object message)


### PR DESCRIPTION
@erikzhang, @shargon, @igormcoelho.

This PR cleans a little bit the logic.
If this is right as it is, then, #434  is not applicable as `null`

In C++ the `if` exits the verification when the first check is false, thus, the same may happen here I think and `Crypto.Default.VerifySignature` would not have problems.