### PR TITLE
Simplify consensus

### DIFF
--- a/neo/Consensus/ChangeView.cs
+++ b/neo/Consensus/ChangeView.cs
@@ -12,6 +12,14 @@ namespace Neo.Consensus
         {
         }
 
+        public static ChangeView Make(byte MyExpectedView)
+        {
+            return new ChangeView
+            {
+                NewViewNumber = MyExpectedView//ExpectedView[MyIndex]
+            };
+        }
+
         public override void Deserialize(BinaryReader reader)
         {
             base.Deserialize(reader);

--- a/neo/Consensus/ConsensusContext.cs
+++ b/neo/Consensus/ConsensusContext.cs
@@ -77,12 +77,27 @@ namespace Neo.Consensus
             };
         }
 
-        private static ulong GetNonce()
+        public ulong GetNonce()
         {
             byte[] nonce = new byte[sizeof(ulong)];
             Random rand = new Random();
             rand.NextBytes(nonce);
             return nonce.ToUInt64(0);
+        }
+
+        public uint GetLimitedTimestamp()
+        {
+            return Math.Max(DateTime.UtcNow.ToTimestamp(), Snapshot.GetHeader(_header.PrevHash).Timestamp + 1);
+        }
+
+        public uint GetTimestamp()
+        {
+            return Snapshot.GetHeader(_header.PrevHash).Timestamp;
+        }
+
+        public uint GetMaxTimestamp()
+        {
+            return DateTime.UtcNow.AddMinutes(10).ToTimestamp();
         }
 
         public void Fill(Wallet wallet)

--- a/neo/Consensus/ConsensusContext.cs
+++ b/neo/Consensus/ConsensusContext.cs
@@ -70,7 +70,7 @@ namespace Neo.Consensus
             return _header;
         }
 
-        private ConsensusPayload MakePayload(ConsensusMessage message)
+        public ConsensusPayload MakePayload(ConsensusMessage message)
         {
             message.ViewNumber = ViewNumber;
             return new ConsensusPayload
@@ -82,18 +82,6 @@ namespace Neo.Consensus
                 Timestamp = _header.Timestamp,
                 Data = message.ToArray()
             };
-        }
-
-        public ConsensusPayload MakePrepareRequest()
-        {
-            return MakePayload(new PrepareRequest
-            {
-                Nonce = _header.ConsensusData,
-                NextConsensus = _header.NextConsensus,
-                TransactionHashes = TransactionHashes,
-                MinerTransaction = (MinerTransaction)Transactions[TransactionHashes[0]],
-                Signature = Signatures[MyIndex]
-            });
         }
 
         public ConsensusPayload MakePrepareResponse(byte[] signature)

--- a/neo/Consensus/ConsensusContext.cs
+++ b/neo/Consensus/ConsensusContext.cs
@@ -43,7 +43,6 @@ namespace Neo.Consensus
             }
             if (MyIndex >= 0)
                 ExpectedView[MyIndex] = view_number;
-            _header = null; // ???
         }
 
         public uint GetPrimaryIndex(byte view_number)

--- a/neo/Consensus/ConsensusContext.cs
+++ b/neo/Consensus/ConsensusContext.cs
@@ -5,6 +5,7 @@ using Neo.Ledger;
 using Neo.Network.P2P.Payloads;
 using Neo.Persistence;
 using Neo.Wallets;
+using Neo.Plugins;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -74,6 +75,50 @@ namespace Neo.Consensus
                 Timestamp = _header.Timestamp,
                 Data = message.ToArray()
             };
+        }
+
+        private static ulong GetNonce()
+        {
+            byte[] nonce = new byte[sizeof(ulong)];
+            Random rand = new Random();
+            rand.NextBytes(nonce);
+            return nonce.ToUInt64(0);
+        }
+
+        public void Fill(Wallet wallet)
+        {
+            IEnumerable<Transaction> mem_pool = Blockchain.Singleton.GetMemoryPool();
+            foreach (IPolicyPlugin plugin in Plugin.Policies)
+                mem_pool = plugin.FilterForBlock(mem_pool);
+            List<Transaction> transactions = mem_pool.ToList();
+            Fixed8 amount_netfee = Block.CalculateNetFee(transactions);
+            TransactionOutput[] outputs = amount_netfee == Fixed8.Zero ? new TransactionOutput[0] : new[] { new TransactionOutput
+            {
+                AssetId = Blockchain.UtilityToken.Hash,
+                Value = amount_netfee,
+                ScriptHash = wallet.GetChangeAddress()
+            } };
+            while (true)
+            {
+                ulong nonce = GetNonce();
+                MinerTransaction tx = new MinerTransaction
+                {
+                    Nonce = (uint)(nonce % (uint.MaxValue + 1ul)),
+                    Attributes = new TransactionAttribute[0],
+                    Inputs = new CoinReference[0],
+                    Outputs = outputs,
+                    Witnesses = new Witness[0]
+                };
+                if (!Snapshot.ContainsTransaction(tx.Hash))
+                {
+                    _header.ConsensusData = nonce;
+                    transactions.Insert(0, tx);
+                    break;
+                }
+            }
+            TransactionHashes = transactions.Select(p => p.Hash).ToArray();
+            Transactions = transactions.ToDictionary(p => p.Hash);
+            _header.NextConsensus = Blockchain.GetConsensusAddress(Snapshot.GetValidators(transactions).ToArray());
         }
 
 

--- a/neo/Consensus/ConsensusContext.cs
+++ b/neo/Consensus/ConsensusContext.cs
@@ -84,13 +84,6 @@ namespace Neo.Consensus
             };
         }
 
-        public ConsensusPayload MakePrepareResponse(byte[] signature)
-        {
-            return MakePayload(new PrepareResponse
-            {
-                Signature = signature
-            });
-        }
 
         public void Reset(Wallet wallet)
         {

--- a/neo/Consensus/ConsensusContext.cs
+++ b/neo/Consensus/ConsensusContext.cs
@@ -51,14 +51,6 @@ namespace Neo.Consensus
             return p >= 0 ? (uint)p : (uint)(p + Validators.Length);
         }
 
-        public ConsensusPayload MakeChangeView()
-        {
-            return MakePayload(new ChangeView
-            {
-                NewViewNumber = ExpectedView[MyIndex]
-            });
-        }
-
         public Block _header = null;
         public Block MakeHeader()
         {

--- a/neo/Consensus/ConsensusContext.cs
+++ b/neo/Consensus/ConsensusContext.cs
@@ -21,7 +21,6 @@ namespace Neo.Consensus
         public Snapshot Snapshot;
         public ECPoint[] Validators;
         public int MyIndex;
-        public uint PrimaryIndex;
         public uint Timestamp;
         public ulong Nonce;
         public UInt160 NextConsensus;
@@ -37,7 +36,6 @@ namespace Neo.Consensus
         {
             State &= ConsensusState.SignatureSent;
             ViewNumber = view_number;
-            PrimaryIndex = GetPrimaryIndex(view_number);
             if (State == ConsensusState.Initial)
             {
                 TransactionHashes = null;
@@ -129,13 +127,12 @@ namespace Neo.Consensus
             State = ConsensusState.Initial;
             PrevHash = Snapshot.CurrentBlockHash;
             BlockIndex = Snapshot.Height + 1;
-            ViewNumber = 0;
             Validators = Snapshot.GetValidators();
-            MyIndex = -1;
-            PrimaryIndex = BlockIndex % (uint)Validators.Length;
+            ViewNumber = 0;
             TransactionHashes = null;
             Signatures = new byte[Validators.Length][];
             ExpectedView = new byte[Validators.Length];
+            MyIndex = -1;
             KeyPair = null;
             for (int i = 0; i < Validators.Length; i++)
             {

--- a/neo/Consensus/ConsensusContext.cs
+++ b/neo/Consensus/ConsensusContext.cs
@@ -46,6 +46,11 @@ namespace Neo.Consensus
                 ExpectedView[MyIndex] = view_number;
         }
 
+        public void Dispose()
+        {
+            Snapshot?.Dispose();
+        }
+
         public uint GetPrimaryIndex(byte view_number)
         {
             int p = ((int)BlockIndex - view_number) % Validators.Length;
@@ -165,11 +170,6 @@ namespace Neo.Consensus
                     break;
                 }
             }
-        }
-
-        public void Dispose()
-        {
-            Snapshot?.Dispose();
         }
     }
 }

--- a/neo/Consensus/ConsensusService.cs
+++ b/neo/Consensus/ConsensusService.cs
@@ -387,7 +387,7 @@ namespace Neo.Consensus
             context.ExpectedView[context.MyIndex]++;
             Log($"request change view: height={context.BlockIndex} view={context.ViewNumber} nv={context.ExpectedView[context.MyIndex]} state={context.State}");
             ChangeTimer(TimeSpan.FromSeconds(Blockchain.SecondsPerBlock << (context.ExpectedView[context.MyIndex] + 1)));
-            SignAndRelay(context.MakeChangeView());
+            SignAndRelay(context.MakePayload(ChangeView.Make(context.ExpectedView[context.MyIndex])));
             CheckExpectedView(context.ExpectedView[context.MyIndex]);
         }
 

--- a/neo/Consensus/ConsensusService.cs
+++ b/neo/Consensus/ConsensusService.cs
@@ -345,7 +345,7 @@ namespace Neo.Consensus
                     context._header.Timestamp = Math.Max(DateTime.UtcNow.ToTimestamp(), context.Snapshot.GetHeader(context._header.PrevHash).Timestamp + 1);
                     context.Signatures[context.MyIndex] = context.MakeHeader().Sign(context.KeyPair);
                 }
-                SignAndRelay(context.MakePrepareRequest());
+                SignAndRelay(context.MakePayload(PrepareRequest.Make(context._header, context.TransactionHashes, (MinerTransaction)context.Transactions[context.TransactionHashes[0]], context.Signatures[context.MyIndex])));
                 if (context.TransactionHashes.Length > 1)
                 {
                     foreach (InvPayload payload in InvPayload.CreateGroup(InventoryType.TX, context.TransactionHashes.Skip(1).ToArray()))

--- a/neo/Consensus/ConsensusService.cs
+++ b/neo/Consensus/ConsensusService.cs
@@ -50,7 +50,7 @@ namespace Neo.Consensus
                     Log($"send prepare response");
                     context.State |= ConsensusState.SignatureSent;
                     context.Signatures[context.MyIndex] = context.MakeHeader().Sign(context.KeyPair);
-                    SignAndRelay(context.MakePrepareResponse(context.Signatures[context.MyIndex]));
+                    SignAndRelay(context.MakePayload(PrepareResponse.Make(context.Signatures[context.MyIndex])));
                     CheckSignatures();
                 }
                 else

--- a/neo/Consensus/ConsensusService.cs
+++ b/neo/Consensus/ConsensusService.cs
@@ -179,7 +179,6 @@ namespace Neo.Consensus
 
         private void OnChangeViewReceived(ConsensusPayload payload, ChangeView message)
         {
-            Log($"{nameof(OnChangeViewReceived)}: height={payload.BlockIndex} view={message.ViewNumber} index={payload.ValidatorIndex} nv={message.NewViewNumber}");
             if (message.NewViewNumber <= context.ExpectedView[payload.ValidatorIndex])
                 return;
             Log($"{nameof(OnChangeViewReceived)}: height={payload.BlockIndex} view={message.ViewNumber} index={payload.ValidatorIndex} nv={message.NewViewNumber}");
@@ -292,7 +291,6 @@ namespace Neo.Consensus
         {
             if (context.Signatures[payload.ValidatorIndex] != null) return;
             Log($"{nameof(OnPrepareResponseReceived)}: height={payload.BlockIndex} view={message.ViewNumber} index={payload.ValidatorIndex}");
-            if (context.Signatures[payload.ValidatorIndex] != null) return;
             byte[] hashData = context.MakeHeader()?.GetHashData();
             if (hashData == null)
             {

--- a/neo/Consensus/ConsensusService.cs
+++ b/neo/Consensus/ConsensusService.cs
@@ -101,50 +101,6 @@ namespace Neo.Consensus
             }
         }
 
-        private void FillContext()
-        {
-            IEnumerable<Transaction> mem_pool = Blockchain.Singleton.GetMemoryPool();
-            foreach (IPolicyPlugin plugin in Plugin.Policies)
-                mem_pool = plugin.FilterForBlock(mem_pool);
-            List<Transaction> transactions = mem_pool.ToList();
-            Fixed8 amount_netfee = Block.CalculateNetFee(transactions);
-            TransactionOutput[] outputs = amount_netfee == Fixed8.Zero ? new TransactionOutput[0] : new[] { new TransactionOutput
-            {
-                AssetId = Blockchain.UtilityToken.Hash,
-                Value = amount_netfee,
-                ScriptHash = wallet.GetChangeAddress()
-            } };
-            while (true)
-            {
-                ulong nonce = GetNonce();
-                MinerTransaction tx = new MinerTransaction
-                {
-                    Nonce = (uint)(nonce % (uint.MaxValue + 1ul)),
-                    Attributes = new TransactionAttribute[0],
-                    Inputs = new CoinReference[0],
-                    Outputs = outputs,
-                    Witnesses = new Witness[0]
-                };
-                if (!context.Snapshot.ContainsTransaction(tx.Hash))
-                {
-                    context._header.ConsensusData = nonce;
-                    transactions.Insert(0, tx);
-                    break;
-                }
-            }
-            context.TransactionHashes = transactions.Select(p => p.Hash).ToArray();
-            context.Transactions = transactions.ToDictionary(p => p.Hash);
-            context._header.NextConsensus = Blockchain.GetConsensusAddress(context.Snapshot.GetValidators(transactions).ToArray());
-        }
-
-        private static ulong GetNonce()
-        {
-            byte[] nonce = new byte[sizeof(ulong)];
-            Random rand = new Random();
-            rand.NextBytes(nonce);
-            return nonce.ToUInt64(0);
-        }
-
         private void InitializeConsensus(byte view_number)
         {
             if (view_number == 0)
@@ -341,7 +297,7 @@ namespace Neo.Consensus
                 context.State |= ConsensusState.RequestSent;
                 if (!context.State.HasFlag(ConsensusState.SignatureSent))
                 {
-                    FillContext();
+                    context.Fill(wallet);
                     context._header.Timestamp = Math.Max(DateTime.UtcNow.ToTimestamp(), context.Snapshot.GetHeader(context._header.PrevHash).Timestamp + 1);
                     context.Signatures[context.MyIndex] = context.MakeHeader().Sign(context.KeyPair);
                 }

--- a/neo/Consensus/ConsensusService.cs
+++ b/neo/Consensus/ConsensusService.cs
@@ -239,7 +239,7 @@ namespace Neo.Consensus
             if (payload.ValidatorIndex != context.GetPrimaryIndex(context.ViewNumber)) return;
             Log($"{nameof(OnPrepareRequestReceived)}: height={payload.BlockIndex} view={message.ViewNumber} index={payload.ValidatorIndex} tx={message.TransactionHashes.Length}");
             if (!context.State.HasFlag(ConsensusState.Backup)) return;
-            if (payload.Timestamp <= context.Snapshot.GetHeader(context._header.PrevHash).Timestamp || payload.Timestamp > DateTime.UtcNow.AddMinutes(10).ToTimestamp())
+            if (payload.Timestamp <= context.GetTimestamp() || payload.Timestamp > context.GetMaxTimestamp())
             {
                 Log($"Timestamp incorrect: {payload.Timestamp}", LogLevel.Warning);
                 return;
@@ -346,7 +346,7 @@ namespace Neo.Consensus
                 if (!context.State.HasFlag(ConsensusState.SignatureSent))
                 {
                     context.Fill(wallet);
-                    context._header.Timestamp = Math.Max(DateTime.UtcNow.ToTimestamp(), context.Snapshot.GetHeader(context._header.PrevHash).Timestamp + 1);
+                    context._header.Timestamp = context.GetLimitedTimestamp();
                     context.Signatures[context.MyIndex] = context.MakeHeader().Sign(context.KeyPair);
                 }
                 SignAndRelay(context.MakePayload(PrepareRequest.Make(context._header, context.TransactionHashes, (MinerTransaction)context.Transactions[context.TransactionHashes[0]], context.Signatures[context.MyIndex])));

--- a/neo/Consensus/ConsensusService.cs
+++ b/neo/Consensus/ConsensusService.cs
@@ -154,8 +154,8 @@ namespace Neo.Consensus
             if (context.MyIndex < 0) return;
             if (view_number > 0)
                 Log($"changeview: view={view_number} primary={context.Validators[context.GetPrimaryIndex((byte)(view_number - 1u))]}", LogLevel.Warning);
-            Log($"initialize: height={context.BlockIndex} view={view_number} index={context.MyIndex} role={(context.MyIndex == context.PrimaryIndex ? ConsensusState.Primary : ConsensusState.Backup)}");
-            if (context.MyIndex == context.PrimaryIndex)
+            Log($"initialize: height={context.BlockIndex} view={view_number} index={context.MyIndex} role={(context.MyIndex == context.GetPrimaryIndex(view_number) ? ConsensusState.Primary : ConsensusState.Backup)}");
+            if (context.MyIndex == context.GetPrimaryIndex(view_number))
             {
                 context.State |= ConsensusState.Primary;
                 TimeSpan span = DateTime.UtcNow - block_received_time;
@@ -237,7 +237,7 @@ namespace Neo.Consensus
             Log($"{nameof(OnPrepareRequestReceived)}: height={payload.BlockIndex} view={message.ViewNumber} index={payload.ValidatorIndex} tx={message.TransactionHashes.Length}");
             if (!context.State.HasFlag(ConsensusState.Backup) || context.State.HasFlag(ConsensusState.RequestReceived))
                 return;
-            if (payload.ValidatorIndex != context.PrimaryIndex) return;
+            if (payload.ValidatorIndex != context.GetPrimaryIndex(context.ViewNumber)) return;
             if (payload.Timestamp <= context.Snapshot.GetHeader(context.PrevHash).Timestamp || payload.Timestamp > DateTime.UtcNow.AddMinutes(10).ToTimestamp())
             {
                 Log($"Timestamp incorrect: {payload.Timestamp}", LogLevel.Warning);

--- a/neo/Consensus/PrepareRequest.cs
+++ b/neo/Consensus/PrepareRequest.cs
@@ -19,6 +19,18 @@ namespace Neo.Consensus
         {
         }
 
+        public static PrepareRequest Make(Block _header, UInt256[] TransactionHashes, MinerTransaction MinerTx, byte[] MySignature)
+        {
+            return new PrepareRequest
+            {
+                Nonce = _header.ConsensusData,
+                NextConsensus = _header.NextConsensus,
+                TransactionHashes = TransactionHashes,
+                MinerTransaction = MinerTx,//(MinerTransaction)Transactions[TransactionHashes[0]],
+                Signature = MySignature//Signatures[MyIndex]
+            };
+        }
+
         public override void Deserialize(BinaryReader reader)
         {
             base.Deserialize(reader);

--- a/neo/Consensus/PrepareResponse.cs
+++ b/neo/Consensus/PrepareResponse.cs
@@ -11,6 +11,14 @@ namespace Neo.Consensus
         {
         }
 
+        public static PrepareResponse Make(byte[] signature)
+        {
+            return new PrepareResponse
+            {
+                Signature = signature
+            };
+        }
+
         public override void Deserialize(BinaryReader reader)
         {
             base.Deserialize(reader);


### PR DESCRIPTION
HI guys, in order to generate unit tests, I noticed that classes ConsensusService and ConsensusContext are very big, and needed to give away some obligations.
The changes are simple:
- FillContext() goes to ConsensusContext (instead of ConsensusService)
- MakePrepareRequest() goes to PrepareRequest (instead of ConsensusContext)
- MakePrepareResponse() goes to PrepareResponse (instead of ConsensusContext)
- MakeChangeView() goes to ChangeView (instead of ConsensusContext)
- many local variables on ConsensusContext were appended to Block _header variable, since this class is specialized on it
- removed variable PrimaryIndex and replaced by function call GetPrimaryIndex