### PR TITLE
update ConsensusService.CheckExpectedView

### DIFF
--- a/neo/Consensus/ConsensusService.cs
+++ b/neo/Consensus/ConsensusService.cs
@@ -75,7 +75,9 @@ namespace Neo.Consensus
         private void CheckExpectedView(byte view_number)
         {
             if (context.ViewNumber == view_number) return;
-            if (context.ExpectedView.Count(p => p == view_number) >= context.M)
+            view_number = context.ViewNumber;
+            view_number++;
+            if (context.ExpectedView.Count(p => p >= view_number) >= context.M)
             {
                 InitializeConsensus(view_number);
             }


### PR DESCRIPTION
**Background**
Sometimes consensus nodes cann't reach a consensus on `view_number` in a short time when they have different `context.ExpectedView[node.MyIndex]` value.  

Eg, 4 nodes have the sample `context.ExpectedView`
```
context.ViewNumber= 0
context.ExpectedView[node1] = 1
context.ExpectedView[node2] = 2
context.ExpectedView[node3] = 3
context.ExpectedView[node4] = 4
```
all waiting for a consensus on `view_number`,  and timeout for `RequestChangeView`. But in the next round, the `context.ExpectedView` still cannot make a consensus.

```
context.ViewNumber= 0
context.ExpectedView[node1] = 2
context.ExpectedView[node2] = 3
context.ExpectedView[node3] = 4
context.ExpectedView[node4] = 5
```

```
private void CheckExpectedView(byte view_number)
{
       if (context.ViewNumber == view_number) return;
       if (context.ExpectedView.Count(p => p == view_number) >= context.M)
        {
            InitializeConsensus(view_number);
        }
}
```

**Solution**
If more than 2f+1 nodes have send `ChangeView` message,  we just enter the next round `view_number = context.ViewNumber + 1 ` immediately. (As we don't need to care about every node's `new_view_number` , but the `ChangeView` message itself)

```
 private void CheckExpectedView(byte view_number)
 {
           if (context.ViewNumber == view_number) return;
           view_number = context.ViewNumber;
           view_number++;
           if (context.ExpectedView.Count(p => p >= view_number) >= context.M)
           {
                InitializeConsensus(view_number);
           }
}
```