### PR TITLE
Consensus Testing Refactor: encapsulating timing functions

### DIFF
--- a/neo/Consensus/ConsensusContext.cs
+++ b/neo/Consensus/ConsensusContext.cs
@@ -1,5 +1,3 @@
-﻿using Akka.Actor;
-using Akka.Configuration;
 ﻿using Neo.Cryptography;
 using Neo.Cryptography.ECC;
 using Neo.IO;

--- a/neo/Consensus/ConsensusContext.cs
+++ b/neo/Consensus/ConsensusContext.cs
@@ -198,7 +198,7 @@ namespace Neo.Consensus
             _header = null;
         }
 
-        public void Fill()
+        public void Fill(uint CurrentTimestamp)
         {
             IEnumerable<Transaction> mem_pool = Blockchain.Singleton.GetMemoryPool();
             foreach (IPolicyPlugin plugin in Plugin.Policies)
@@ -232,6 +232,7 @@ namespace Neo.Consensus
             TransactionHashes = transactions.Select(p => p.Hash).ToArray();
             Transactions = transactions.ToDictionary(p => p.Hash);
             NextConsensus = Blockchain.GetConsensusAddress(Snapshot.GetValidators(transactions).ToArray());
+            Timestamp = CurrentTimestamp;
         }
 
         private static ulong GetNonce()

--- a/neo/Consensus/ConsensusContext.cs
+++ b/neo/Consensus/ConsensusContext.cs
@@ -1,3 +1,5 @@
+﻿using Akka.Actor;
+using Akka.Configuration;
 ﻿using Neo.Cryptography;
 using Neo.Cryptography.ECC;
 using Neo.IO;
@@ -33,7 +35,7 @@ namespace Neo.Consensus
         public byte[] ExpectedView;
         private KeyPair KeyPair;
         private readonly Wallet wallet;
-        private DateTime block_received_time;
+        public DateTime block_received_time;
 
         public int M => Validators.Length - (Validators.Length - 1) / 3;
 
@@ -273,6 +275,15 @@ namespace Neo.Consensus
         public DateTime GetUtcNow()
         {
             return DateTime.UtcNow;
+        }
+
+        public void ChangeTimer(TimeSpan delay, ITellScheduler scheduler, ICanTell receiver, IActorRef sender)
+        {
+            scheduler.ScheduleTellOnce(delay, receiver, new ConsensusTimer
+            {
+                Height = BlockIndex,
+                ViewNumber = ViewNumber
+            }, sender);
         }
     }
 }

--- a/neo/Consensus/ConsensusContext.cs
+++ b/neo/Consensus/ConsensusContext.cs
@@ -33,6 +33,7 @@ namespace Neo.Consensus
         public byte[] ExpectedView;
         private KeyPair KeyPair;
         private readonly Wallet wallet;
+        private DateTime block_received_time;
 
         public int M => Validators.Length - (Validators.Length - 1) / 3;
 
@@ -231,7 +232,7 @@ namespace Neo.Consensus
             TransactionHashes = transactions.Select(p => p.Hash).ToArray();
             Transactions = transactions.ToDictionary(p => p.Hash);
             NextConsensus = Blockchain.GetConsensusAddress(Snapshot.GetValidators(transactions).ToArray());
-            Timestamp = Math.Max(DateTime.UtcNow.ToTimestamp(), Snapshot.GetHeader(PrevHash).Timestamp + 1);
+            Timestamp = GetCurrentTimestamp();
         }
 
         private static ulong GetNonce()
@@ -252,6 +253,26 @@ namespace Neo.Consensus
             Fixed8 amount_netfee = Block.CalculateNetFee(Transactions.Values);
             if (tx_gen?.Outputs.Sum(p => p.Value) != amount_netfee) return false;
             return true;
+        }
+
+        public uint GetSnapshotTimestamp()
+        {
+            return Snapshot.GetHeader(PrevHash).Timestamp;
+        }
+
+        public uint GetLimitTimestamp()
+        {
+            return DateTime.UtcNow.AddMinutes(10).ToTimestamp();
+        }
+
+        public uint GetCurrentTimestamp()
+        {
+            return Math.Max(DateTime.UtcNow.ToTimestamp(), Snapshot.GetHeader(PrevHash).Timestamp + 1);
+        }
+
+        public DateTime GetUtcNow()
+        {
+            return DateTime.UtcNow;
         }
     }
 }

--- a/neo/Consensus/ConsensusContext.cs
+++ b/neo/Consensus/ConsensusContext.cs
@@ -198,7 +198,7 @@ namespace Neo.Consensus
             _header = null;
         }
 
-        public void Fill(uint CurrentTimestamp)
+        public void Fill(uint currentTimestamp)
         {
             IEnumerable<Transaction> mem_pool = Blockchain.Singleton.GetMemoryPool();
             foreach (IPolicyPlugin plugin in Plugin.Policies)
@@ -232,7 +232,7 @@ namespace Neo.Consensus
             TransactionHashes = transactions.Select(p => p.Hash).ToArray();
             Transactions = transactions.ToDictionary(p => p.Hash);
             NextConsensus = Blockchain.GetConsensusAddress(Snapshot.GetValidators(transactions).ToArray());
-            Timestamp = CurrentTimestamp;
+            Timestamp = currentTimestamp;
         }
 
         private static ulong GetNonce()

--- a/neo/Consensus/ConsensusContext.cs
+++ b/neo/Consensus/ConsensusContext.cs
@@ -264,12 +264,12 @@ namespace Neo.Consensus
 
         public uint GetLimitTimestamp()
         {
-            return DateTime.UtcNow.AddMinutes(10).ToTimestamp();
+            return GetUtcNow().AddMinutes(10).ToTimestamp();
         }
 
         public uint GetCurrentTimestamp()
         {
-            return Math.Max(DateTime.UtcNow.ToTimestamp(), Snapshot.GetHeader(PrevHash).Timestamp + 1);
+            return Math.Max(GetUtcNow().ToTimestamp(), GetSnapshotTimestamp() + 1);
         }
 
         public DateTime GetUtcNow()

--- a/neo/Consensus/ConsensusContext.cs
+++ b/neo/Consensus/ConsensusContext.cs
@@ -234,7 +234,6 @@ namespace Neo.Consensus
             TransactionHashes = transactions.Select(p => p.Hash).ToArray();
             Transactions = transactions.ToDictionary(p => p.Hash);
             NextConsensus = Blockchain.GetConsensusAddress(Snapshot.GetValidators(transactions).ToArray());
-            Timestamp = GetCurrentTimestamp();
         }
 
         private static ulong GetNonce()
@@ -255,35 +254,6 @@ namespace Neo.Consensus
             Fixed8 amount_netfee = Block.CalculateNetFee(Transactions.Values);
             if (tx_gen?.Outputs.Sum(p => p.Value) != amount_netfee) return false;
             return true;
-        }
-
-        public uint GetSnapshotTimestamp()
-        {
-            return Snapshot.GetHeader(PrevHash).Timestamp;
-        }
-
-        public uint GetLimitTimestamp()
-        {
-            return GetUtcNow().AddMinutes(10).ToTimestamp();
-        }
-
-        public uint GetCurrentTimestamp()
-        {
-            return Math.Max(GetUtcNow().ToTimestamp(), GetSnapshotTimestamp() + 1);
-        }
-
-        public DateTime GetUtcNow()
-        {
-            return DateTime.UtcNow;
-        }
-
-        public void ChangeTimer(TimeSpan delay, ITellScheduler scheduler, ICanTell receiver, IActorRef sender)
-        {
-            scheduler.ScheduleTellOnce(delay, receiver, new ConsensusTimer
-            {
-                Height = BlockIndex,
-                ViewNumber = ViewNumber
-            }, sender);
         }
     }
 }

--- a/neo/Consensus/ConsensusService.cs
+++ b/neo/Consensus/ConsensusService.cs
@@ -288,8 +288,7 @@ namespace Neo.Consensus
                 context.State |= ConsensusState.RequestSent;
                 if (!context.State.HasFlag(ConsensusState.SignatureSent))
                 {
-                    context.Fill();
-                    context.Timestamp = GetCurrentTimestamp();
+                    context.Fill(GetCurrentTimestamp());
                     context.SignHeader();
                 }
                 system.LocalNode.Tell(new LocalNode.SendDirectly { Inventory = context.MakePrepareRequest() });

--- a/neo/Consensus/ConsensusService.cs
+++ b/neo/Consensus/ConsensusService.cs
@@ -60,7 +60,7 @@ namespace Neo.Consensus
             return true;
         }
 
-        public void ChangeTimer(TimeSpan delay)
+        private void ChangeTimer(TimeSpan delay)
         {
             Context.System.Scheduler.ScheduleTellOnce(delay, Self, new Timer
             {

--- a/neo/Consensus/ConsensusService.cs
+++ b/neo/Consensus/ConsensusService.cs
@@ -60,6 +60,15 @@ namespace Neo.Consensus
             return true;
         }
 
+        public void ChangeTimer(TimeSpan delay)
+        {
+            Context.System.Scheduler.ScheduleTellOnce(delay, Self, new Timer
+            {
+                Height = context.BlockIndex,
+                ViewNumber = context.ViewNumber
+            }, ActorRefs.NoSender);
+        }
+
         private void CheckExpectedView(byte view_number)
         {
             if (context.ViewNumber == view_number) return;
@@ -327,15 +336,6 @@ namespace Neo.Consensus
             ChangeTimer(TimeSpan.FromSeconds(Blockchain.SecondsPerBlock << (context.ExpectedView[context.MyIndex] + 1)));
             system.LocalNode.Tell(new LocalNode.SendDirectly { Inventory = context.MakeChangeView() });
             CheckExpectedView(context.ExpectedView[context.MyIndex]);
-        }
-
-        public void ChangeTimer(TimeSpan delay)
-        {
-            Context.System.Scheduler.ScheduleTellOnce(delay, Self, new Timer
-            {
-                Height = context.BlockIndex,
-                ViewNumber = context.ViewNumber
-            }, ActorRefs.NoSender);
         }
 
         public uint GetSnapshotTimestamp()

--- a/neo/Consensus/ConsensusTimer.cs
+++ b/neo/Consensus/ConsensusTimer.cs
@@ -1,18 +1,3 @@
-using Akka.Actor;
-using Akka.Configuration;
-using Neo.Cryptography;
-using Neo.IO;
-using Neo.IO.Actors;
-using Neo.Ledger;
-using Neo.Network.P2P;
-using Neo.Network.P2P.Payloads;
-using Neo.Persistence;
-using Neo.Plugins;
-using Neo.Wallets;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-
 namespace Neo.Consensus
 {
     internal class ConsensusTimer

--- a/neo/Consensus/ConsensusTimer.cs
+++ b/neo/Consensus/ConsensusTimer.cs
@@ -1,0 +1,23 @@
+using Akka.Actor;
+using Akka.Configuration;
+using Neo.Cryptography;
+using Neo.IO;
+using Neo.IO.Actors;
+using Neo.Ledger;
+using Neo.Network.P2P;
+using Neo.Network.P2P.Payloads;
+using Neo.Persistence;
+using Neo.Plugins;
+using Neo.Wallets;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Neo.Consensus
+{
+    internal class ConsensusTimer
+    {
+        public uint Height;
+        public byte ViewNumber;
+    }
+}

--- a/neo/Consensus/ConsensusTimer.cs
+++ b/neo/Consensus/ConsensusTimer.cs
@@ -1,8 +1,0 @@
-namespace Neo.Consensus
-{
-    internal class ConsensusTimer
-    {
-        public uint Height;
-        public byte ViewNumber;
-    }
-}


### PR DESCRIPTION
To allow a viable and strong unit testing on ConsensusService (#436), we need to delegate some of its current tasks. I believe timestamp decisions would fit better on ConsensusContext class.
[EDIT] a better approach was not to move it to ConsensusContext, but just encapsulate timing functions on ConsensusService itself.