### PR TITLE
Fix the problem of getbalance RPC request

### DIFF
--- a/neo/Wallets/Wallet.cs
+++ b/neo/Wallets/Wallet.cs
@@ -331,9 +331,9 @@ namespace Neo.Wallets
                                     Key = account.ToArray()
                                 };
                                 StorageItem item = snapshot.Storages.TryGet(key);
-                                BigInteger value = new BigInteger(item.Value);
                                 if (item != null)
                                 {
+                                    BigInteger value = new BigInteger(item.Value);
                                     sum += value;
                                     values.Add(value);
                                 }

--- a/neo/Wallets/Wallet.cs
+++ b/neo/Wallets/Wallet.cs
@@ -317,7 +317,6 @@ namespace Neo.Wallets
                 {
                     foreach (var output in cOutputs)
                     {
-                        BigInteger sum = BigInteger.Zero;
                         List<BigInteger> values = new List<BigInteger>();
 
                         using (Snapshot snapshot = Blockchain.Singleton.GetSnapshot())
@@ -331,16 +330,7 @@ namespace Neo.Wallets
                                     Key = account.ToArray()
                                 };
                                 StorageItem item = snapshot.Storages.TryGet(key);
-                                if (item != null)
-                                {
-                                    BigInteger value = new BigInteger(item.Value);
-                                    sum += value;
-                                    values.Add(value);
-                                }
-                                else
-                                {
-                                    values.Add(BigInteger.Zero);
-                                }
+                                values.Add(item == null ? BigInteger.Zero : new BigInteger(item.Value));
                             }
                         }
                         var balances = values.Zip(accounts, (i, a) => new
@@ -348,6 +338,8 @@ namespace Neo.Wallets
                             Account = a,
                             Value = i
                         }).ToArray();
+                        BigInteger sum = balances.Aggregate(BigInteger.Zero, (x, y) => x + y.Value);
+
                         if (sum < output.Value) return null;
                         if (sum != output.Value)
                         {


### PR DESCRIPTION
In this PR:
1. Directly read the blockchain storage instead of calling the `balanceOf` method in NEP5 contract to get the balance, to avoid the gas limit and VM limit, and to query fast(<1000ms with 100k addresses).
2. Include some change from #451 by @erikzhang.