### PR TITLE
Consensus Testing Refactor: make Snapshot private on ConsensusContext

### DIFF
--- a/neo/Consensus/ConsensusContext.cs
+++ b/neo/Consensus/ConsensusContext.cs
@@ -19,7 +19,8 @@ namespace Neo.Consensus
         public UInt256 PrevHash;
         public uint BlockIndex;
         public byte ViewNumber;
-        public Snapshot Snapshot;
+        private Snapshot Snapshot;
+        public uint SnapshotHeight => Snapshot.Height;
         public ECPoint[] Validators;
         public int MyIndex;
         public uint PrimaryIndex;
@@ -47,6 +48,13 @@ namespace Neo.Consensus
             if (MyIndex >= 0)
                 ExpectedView[MyIndex] = view_number;
             _header = null;
+        }
+
+        public bool MustReject(Transaction tx, bool verify)
+        {
+          return Snapshot.ContainsTransaction(tx.Hash) ||
+              (verify && !tx.Verify(Snapshot, Transactions.Values)) ||
+              !Plugin.CheckPolicy(tx);
         }
 
         public void Dispose()

--- a/neo/Consensus/ConsensusService.cs
+++ b/neo/Consensus/ConsensusService.cs
@@ -35,9 +35,7 @@ namespace Neo.Consensus
 
         private bool AddTransaction(Transaction tx, bool verify)
         {
-            if (context.Snapshot.ContainsTransaction(tx.Hash) ||
-                (verify && !tx.Verify(context.Snapshot, context.Transactions.Values)) ||
-                !Plugin.CheckPolicy(tx))
+            if (context.MustReject(tx, verify))
             {
                 Log($"reject tx: {tx.Hash}{Environment.NewLine}{tx.ToArray().ToHexString()}", LogLevel.Warning);
                 RequestChangeView();
@@ -150,9 +148,9 @@ namespace Neo.Consensus
                 return;
             if (payload.PrevHash != context.PrevHash || payload.BlockIndex != context.BlockIndex)
             {
-                if (context.Snapshot.Height + 1 < payload.BlockIndex)
+                if (context.SnapshotHeight + 1 < payload.BlockIndex)
                 {
-                    Log($"chain sync: expected={payload.BlockIndex} current: {context.Snapshot.Height} nodes={LocalNode.Singleton.ConnectedCount}", LogLevel.Warning);
+                    Log($"chain sync: expected={payload.BlockIndex} current: {context.SnapshotHeight} nodes={LocalNode.Singleton.ConnectedCount}", LogLevel.Warning);
                 }
                 return;
             }


### PR DESCRIPTION
To allow a viable and strong unit testing on ConsensusService (#436), we need to delegate some of its current tasks. I believe Snapshot should be private on ConsensusContext class, because only Snapshot.Height and tx verification is currently needed (timestamp was already moved to ConsensusContext too).