### PR TITLE
Do not ask for the first hash if GlobalTasks

### DIFF
--- a/neo/Network/P2P/TaskManager.cs
+++ b/neo/Network/P2P/TaskManager.cs
@@ -234,7 +234,7 @@ namespace Neo.Network.P2P
                         break;
                     }
                 }
-                if (!globalTasks.Contains(hash))
+                if (!globalTasks.ContainsKey(hash))
                     session.RemoteNode.Tell(Message.Create("getblocks", GetBlocksPayload.Create(hash)));
             }
         }

--- a/neo/Network/P2P/TaskManager.cs
+++ b/neo/Network/P2P/TaskManager.cs
@@ -234,7 +234,8 @@ namespace Neo.Network.P2P
                         break;
                     }
                 }
-                session.RemoteNode.Tell(Message.Create("getblocks", GetBlocksPayload.Create(hash)));
+                if (!globalTasks.Contains(hash))
+                    session.RemoteNode.Tell(Message.Create("getblocks", GetBlocksPayload.Create(hash)));
             }
         }
     }


### PR DESCRIPTION
@erikzhang,
There was no verification for the first hash.

I included this else:
```cs
                if (!globalTasks.Contains(hash))
                    session.RemoteNode.Tell(Message.Create("getblocks", GetBlocksPayload.Create(hash)));
                else
                    Console.WriteLine("Wrong behavior. Asking for a hash contained in global task");
```

And the message appeared.