### PR TITLE
Avoid error when Plugins folder does not exist

### DIFF
--- a/neo/Plugins/Plugin.cs
+++ b/neo/Plugins/Plugin.cs
@@ -25,14 +25,17 @@ namespace Neo.Plugins
 
         static Plugin()
         {
-            configWatcher = new FileSystemWatcher(pluginsPath, "*.json")
+            if (Directory.Exists(pluginsPath))
             {
-                EnableRaisingEvents = true,
-                IncludeSubdirectories = true,
-                NotifyFilter = NotifyFilters.CreationTime | NotifyFilters.LastWrite | NotifyFilters.Size,
-            };
-            configWatcher.Changed += ConfigWatcher_Changed;
-            configWatcher.Created += ConfigWatcher_Changed;
+                configWatcher = new FileSystemWatcher(pluginsPath, "*.json")
+                {
+                    EnableRaisingEvents = true,
+                    IncludeSubdirectories = true,
+                    NotifyFilter = NotifyFilters.CreationTime | NotifyFilters.LastWrite | NotifyFilters.Size,
+                };
+                configWatcher.Changed += ConfigWatcher_Changed;
+                configWatcher.Created += ConfigWatcher_Changed;
+            }
         }
 
         protected Plugin()


### PR DESCRIPTION
Application is currently breaking when folder Plugins does not exist on disk.