### PR TITLE
Remove Unverified Blocks after using them

### DIFF
--- a/neo/Ledger/Blockchain.cs
+++ b/neo/Ledger/Blockchain.cs
@@ -371,6 +371,11 @@ namespace Neo.Ledger
                     });
                     snapshot.HeaderHashIndex.GetAndChange().Hash = header.Hash;
                     snapshot.HeaderHashIndex.GetAndChange().Index = header.Index;
+                    if (block_cache_unverified.TryGetValue(header.Index, out LinkedList<Block> unverifiedBlocks))
+                    {
+                        foreach (var unverifiedBlock in unverifiedBlocks)
+                            Self.Tell(unverifiedBlock, ActorRefs.NoSender);
+                    }
                 }
                 SaveHeaderHashList(snapshot);
                 snapshot.Commit();

--- a/neo/Ledger/Blockchain.cs
+++ b/neo/Ledger/Blockchain.cs
@@ -289,8 +289,7 @@ namespace Neo.Ledger
             if (block.Index == Height + 1)
             {
                 Block block_persist = block;
-                List<Block> blocksToPersistList = new List<Block>();
-                                
+                List<Block> blocksToPersistList = new List<Block>();                                
                 while (true)
                 {
                     blocksToPersistList.Add(block_persist);

--- a/neo/Ledger/Blockchain.cs
+++ b/neo/Ledger/Blockchain.cs
@@ -290,19 +290,7 @@ namespace Neo.Ledger
             {
                 Block block_persist = block;
                 List<Block> blocksToPersistList = new List<Block>();
-                
-                foreach (LinkedList<Block> blocksUnverifiedLL in block_cache_unverified.Values)
-                {
-                    foreach (var unverifiedBlock in blocksUnverifiedLL)
-                        if(unverifiedBlock.Index <= block_persist.Index)  
-                        {
-                            Console.WriteLine("\n\n\n\n\n\n\n\n This is strange blockUnverified.Index:{blockUnverified.Index} \n\n\n\n\n\n");
-                            //Just clean the block_cache, but we should find why it is not been cleaned as expected.
-                            block_cache_unverified.Remove(unverifiedBlock.Index);
-                            break;
-                        }
-                }
-                
+                                
                 while (true)
                 {
                     blocksToPersistList.Add(block_persist);
@@ -328,7 +316,8 @@ namespace Neo.Ledger
                 if (block_cache_unverified.TryGetValue(Height + 1, out LinkedList<Block> unverifiedBlocks))
                 {
                     foreach (var unverifiedBlock in unverifiedBlocks)
-                        Self.Tell(unverifiedBlock, ActorRefs.NoSender);                
+                        Self.Tell(unverifiedBlock, ActorRefs.NoSender);   
+                    block_cache_unverified.Remove(Height + 1);
                 }
             }
             else

--- a/neo/Ledger/Blockchain.cs
+++ b/neo/Ledger/Blockchain.cs
@@ -296,13 +296,8 @@ namespace Neo.Ledger
                        if (blockUnverified.Index <= block_persist.Index)
                        {
                                 Console.WriteLine("\n\n\n\n\n\n\n\n This is strange blockUnverified.Index:{blockUnverified.Index} \n\n\n\n\n\n");
-                                
-                                //This part can be removed, there is not sense to Persist I again...aeguageuhea
-                                if (blockUnverified.Verify(currentSnapshot))
-                                    blocksToPersistList.Add(blockUnverified);
-
                                 //Just clean the block_cache, but we should find why it is not been cleaned as expected.
-                                 block_cache_unverified.Remove(blockUnverified.Index);
+                                block_cache_unverified.Remove(blockUnverified.Index);
                         }
                 }
                 

--- a/neo/Ledger/Blockchain.cs
+++ b/neo/Ledger/Blockchain.cs
@@ -291,13 +291,15 @@ namespace Neo.Ledger
                 Block block_persist = block;
                 List<Block> blocksToPersistList = new List<Block>();
                 
-                foreach (Block blockUnverified in block_cache_unverified.Values)
+                foreach (LinkedList<Block> blocksUnverifiedLL in block_cache_unverified.Values)
                 {
-                       if (blockUnverified.Index <= block_persist.Index)
-                       {
-                                Console.WriteLine("\n\n\n\n\n\n\n\n This is strange blockUnverified.Index:{blockUnverified.Index} \n\n\n\n\n\n");
-                                //Just clean the block_cache, but we should find why it is not been cleaned as expected.
-                                block_cache_unverified.Remove(blockUnverified.Index);
+                    foreach (var unverifiedBlock in blocksUnverifiedLL)
+                        if(unverifiedBlock.Index <= block_persist.Index)  
+                        {
+                            Console.WriteLine("\n\n\n\n\n\n\n\n This is strange blockUnverified.Index:{blockUnverified.Index} \n\n\n\n\n\n");
+                            //Just clean the block_cache, but we should find why it is not been cleaned as expected.
+                            block_cache_unverified.Remove(unverifiedBlock.Index);
+                            break;
                         }
                 }
                 

--- a/neo/Ledger/Blockchain.cs
+++ b/neo/Ledger/Blockchain.cs
@@ -290,7 +290,22 @@ namespace Neo.Ledger
             {
                 Block block_persist = block;
                 List<Block> blocksToPersistList = new List<Block>();
+                
+                foreach (Block blockUnverified in block_cache_unverified.Values)
+                {
+                       if (blockUnverified.Index <= block_persist.Index)
+                       {
+                                Console.WriteLine("\n\n\n\n\n\n\n\n This is strange blockUnverified.Index:{blockUnverified.Index} \n\n\n\n\n\n");
+                                
+                                //This part can be removed, there is not sense to Persist I again...aeguageuhea
+                                if (blockUnverified.Verify(currentSnapshot))
+                                    blocksToPersistList.Add(blockUnverified);
 
+                                //Just clean the block_cache, but we should find why it is not been cleaned as expected.
+                                 block_cache_unverified.Remove(blockUnverified.Index);
+                        }
+                }
+                
                 while (true)
                 {
                     blocksToPersistList.Add(block_persist);
@@ -371,11 +386,6 @@ namespace Neo.Ledger
                     });
                     snapshot.HeaderHashIndex.GetAndChange().Hash = header.Hash;
                     snapshot.HeaderHashIndex.GetAndChange().Index = header.Index;
-                    if (block_cache_unverified.TryGetValue(header.Index, out LinkedList<Block> unverifiedBlocks))
-                    {
-                        foreach (var unverifiedBlock in unverifiedBlocks)
-                            Self.Tell(unverifiedBlock, ActorRefs.NoSender);
-                    }
                 }
                 SaveHeaderHashList(snapshot);
                 snapshot.Commit();


### PR DESCRIPTION
@erikzhang @jsolman,

Maybe we are missing blocks in the `block_cache_unverified`.

Sometimes we can have blocks there and then we receive the headers.
In this sense, we should resend them in order that they enter in the `block_cache` or are directed Persisted.

What do you think?