### PR TITLE
`ApplicationEngine` wrong calculation of `_stackItemCount` with `CALL_IXX`

### DIFF
--- a/neo/SmartContract/ApplicationEngine.cs
+++ b/neo/SmartContract/ApplicationEngine.cs
@@ -463,11 +463,9 @@ namespace Neo.SmartContract
 
         protected virtual long GetPrice(OpCode nextInstruction)
         {
-            if (nextInstruction <= OpCode.PUSH16) return 0;
+            if (nextInstruction <= OpCode.NOP) return 0;
             switch (nextInstruction)
             {
-                case OpCode.NOP:
-                    return 0;
                 case OpCode.APPCALL:
                 case OpCode.TAILCALL:
                     return 10;

--- a/neo/SmartContract/ApplicationEngine.cs
+++ b/neo/SmartContract/ApplicationEngine.cs
@@ -275,9 +275,6 @@ namespace Neo.SmartContract
             else
                 switch (nextInstruction)
                 {
-                    case OpCode.RET:
-                        is_stackitem_count_strict = false;
-                        break;
                     case OpCode.JMPIF:
                     case OpCode.JMPIFNOT:
                     case OpCode.DROP:
@@ -320,6 +317,7 @@ namespace Neo.SmartContract
                     case OpCode.CALL_EDT:
                         stackitem_count -= 1;
                         break;
+                    case OpCode.RET:
                     case OpCode.APPCALL:
                     case OpCode.TAILCALL:
                     case OpCode.NOT:

--- a/neo/SmartContract/ApplicationEngine.cs
+++ b/neo/SmartContract/ApplicationEngine.cs
@@ -275,6 +275,9 @@ namespace Neo.SmartContract
             else
                 switch (nextInstruction)
                 {
+                    case OpCode.RET:
+                        is_stackitem_count_strict = false;
+                        break;
                     case OpCode.JMPIF:
                     case OpCode.JMPIFNOT:
                     case OpCode.DROP:


### PR DESCRIPTION
Currently we have a counter `_stackItemCount` for ensure that the stack count is not higher than 2048.

The problem is that we think that every time we will copy the full `EvaluationStack` from the CurrentContext to the previous one, but `rvcount` define the number of items to `return` to the previous context.

So the problem is when you leave StackItems behind in the context created by `CALL_I` opcode. For example like this:

```
CALL_I 0x00, 0x00, [OFFSET_TO_JMP]  // -> rvcount=0 , pcount=0
RET // We haven`t got nothing in the stack but _stackItemCount=1

> OFFSET_TO_JMP:
PUSH1   // _stackItemCount++;
RET
```

`_stackItemCount` should be recalculated when a CALL_IXX operation ends