### PR TITLE
Remove ClaimTransaction  for IsLowPriority

### DIFF
--- a/neo/Network/P2P/Payloads/Transaction.cs
+++ b/neo/Network/P2P/Payloads/Transaction.cs
@@ -49,7 +49,7 @@ namespace Neo.Network.P2P.Payloads
 
         InventoryType IInventory.InventoryType => InventoryType.TX;
 
-        public bool IsLowPriority => Type == TransactionType.ClaimTransaction || NetworkFee < Settings.Default.LowPriorityThreshold;
+        public bool IsLowPriority => NetworkFee < Settings.Default.LowPriorityThreshold;
 
         private Fixed8 _network_fee = -Fixed8.Satoshi;
         public virtual Fixed8 NetworkFee


### PR DESCRIPTION
Is not necessary because according to https://github.com/neo-project/neo-plugins/issues/33#issuecomment-445194586 we can check that for `ClaimTransaction` is not possible to assign fee.