### PR TITLE
Make StorageIterator public

### DIFF
--- a/neo/SmartContract/Iterators/StorageIterator.cs
+++ b/neo/SmartContract/Iterators/StorageIterator.cs
@@ -4,13 +4,18 @@ using System.Collections.Generic;
 
 namespace Neo.SmartContract.Iterators
 {
-    internal class StorageIterator : IIterator
+    public class StorageIterator : IIterator
     {
         private readonly IEnumerator<KeyValuePair<StorageKey, StorageItem>> enumerator;
 
         public StorageIterator(IEnumerator<KeyValuePair<StorageKey, StorageItem>> enumerator)
         {
             this.enumerator = enumerator;
+        }
+
+        public IEnumerator<KeyValuePair<StorageKey, StorageItem>> GetEnumerator()
+        {
+            return enumerator;
         }
 
         public void Dispose()


### PR DESCRIPTION
I'm writing a plugin to extend the RPC service on my nodes with a `findstorage` method to allow direct RPC queries in order to enumerate a smart contract's storage by key prefix, with pagination to better deal with queries that may contain hundreds or thousands of results, instead of passing them through the extra overhead of the VM and unnecessarily complicating the smart contract code. 

In order to do this in a plugin, first I need access to the `StorageIterator` class and the ability to use it as an enumerator in a `foreach` loop. This pull request addresses that need.