### PR TITLE
Caching FeePerByte on Transaction

### DIFF
--- a/neo/Network/P2P/Payloads/Transaction.cs
+++ b/neo/Network/P2P/Payloads/Transaction.cs
@@ -93,6 +93,18 @@ namespace Neo.Network.P2P.Payloads
             }
         }
 
+        private Fixed8 _feePerByte = -Fixed8.Satoshi;
+
+        public Fixed8 FeePerByte
+        {
+            get
+            {
+                if(_feePerByte == -Fixed8.Satoshi)
+                    _feePerByte = NetworkFee / Size;
+                return _feePerByte;
+            }
+        }
+
         public virtual int Size => sizeof(TransactionType) + sizeof(byte) + Attributes.GetVarSize() + Inputs.GetVarSize() + Outputs.GetVarSize() + Witnesses.GetVarSize();
 
         public virtual Fixed8 SystemFee => Settings.Default.SystemFee.TryGetValue(Type, out Fixed8 fee) ? fee : Fixed8.Zero;

--- a/neo/Network/P2P/Payloads/Transaction.cs
+++ b/neo/Network/P2P/Payloads/Transaction.cs
@@ -34,6 +34,21 @@ namespace Neo.Network.P2P.Payloads
         public TransactionOutput[] Outputs;
         public Witness[] Witnesses { get; set; }
 
+        private Fixed8 _feePerByte = -Fixed8.Satoshi;
+        /// <summary>
+        /// The <c>NetworkFee</c> for the transaction divided by its <c>Size</c>.
+        /// <para>Note that this property must be used with care. Getting the value of this property multiple times will return the same result. The value of this property can only be obtained after the transaction has been completely built (no longer modified).</para>
+        /// </summary>
+        public Fixed8 FeePerByte
+        {
+            get
+            {
+                if (_feePerByte == -Fixed8.Satoshi)
+                    _feePerByte = NetworkFee / Size;
+                return _feePerByte;
+            }
+        }
+
         private UInt256 _hash = null;
         public UInt256 Hash
         {
@@ -90,18 +105,6 @@ namespace Neo.Network.P2P.Payloads
                     _references = dictionary;
                 }
                 return _references;
-            }
-        }
-
-        private Fixed8 _feePerByte = -Fixed8.Satoshi;
-
-        public Fixed8 FeePerByte
-        {
-            get
-            {
-                if(_feePerByte == -Fixed8.Satoshi)
-                    _feePerByte = NetworkFee / Size;
-                return _feePerByte;
             }
         }
 


### PR DESCRIPTION
As discussed in https://github.com/neo-project/neo/pull/500, it would be useful to have FeePerByte cached on Transaction. This can be useful for neo-plugins too.