### PR TITLE
AssemblyResolve handler for plugin third-party dependencies

### DIFF
--- a/neo/Plugins/Plugin.cs
+++ b/neo/Plugins/Plugin.cs
@@ -99,7 +99,7 @@ namespace Neo.Plugins
                     }
                     catch (Exception ex)
                     {
-                        Console.WriteLine("Failed to initialize plugin: " + ex); 
+                        Plugin.Log(nameof(Plugin), LogLevel.Error, $"Failed to initialize plugin: {ex.Message}");
                     }
                 }
             }
@@ -143,6 +143,7 @@ namespace Neo.Plugins
             }
             catch (Exception ex)
             {
+                Plugin.Log(nameof(Plugin), LogLevel.Error, $"Failed to initialize plugin dependency: {ex.Message}");
                 return null;
             }
         }

--- a/neo/Plugins/Plugin.cs
+++ b/neo/Plugins/Plugin.cs
@@ -135,7 +135,8 @@ namespace Neo.Plugins
             if (assembly != null)
                 return assembly;
 
-            string filename = args.Name.Split(',')[0] + ".dll";
+            AssemblyName an = new AssemblyName(args.Name);
+            string filename = an.Name + ".dll";
 
             try
             {

--- a/neo/Plugins/Plugin.cs
+++ b/neo/Plugins/Plugin.cs
@@ -99,7 +99,7 @@ namespace Neo.Plugins
                     }
                     catch (Exception ex)
                     {
-                        Plugin.Log(nameof(Plugin), LogLevel.Error, $"Failed to initialize plugin: {ex.Message}");
+                        Log(nameof(Plugin), LogLevel.Error, $"Failed to initialize plugin: {ex.Message}");
                     }
                 }
             }
@@ -144,7 +144,7 @@ namespace Neo.Plugins
             }
             catch (Exception ex)
             {
-                Plugin.Log(nameof(Plugin), LogLevel.Error, $"Failed to initialize plugin dependency: {ex.Message}");
+                Log(nameof(Plugin), LogLevel.Error, $"Failed to resolve assembly or its dependency: {ex.Message}");
                 return null;
             }
         }


### PR DESCRIPTION
I'm writing a [plugin for neo-cli to publish smart contract events to a Redis PubSub queue](https://github.com/hal0x2328/NeoPubSub). I quickly ran into a problem - since neo-cli plugins themselves are loaded at runtime, the existing .NET mechanism for resolving third-party dependencies in assemblies does not work (at least not for .Net Core), and the plugin fails to load with the following error: 
```
System.IO.FileNotFoundException: Could not load file or assembly 'ServiceStack.Redis, Version=5.0.0.0, Culture=neutral,
 PublicKeyToken=null'. The system cannot find the file specified.
```
This patch attempts to address this by adding an [AssemblyResolve](https://docs.microsoft.com/en-us/dotnet/api/system.appdomain.assemblyresolve?view=netframework-4.7.2) handler that is called when an assembly fails to load, and proceeds to attempt to resolve and load the dependencies of the plugin. (Note that the way the `CurrentDomain_AssemblyResolve` function is written here, the third-party DLLs the plugin is dependent on are expected to be in the main working directory of neo-cli, it may be the case that we want to place them in a subfolder of the plugin's tree).

After this patch is applied I no longer experience the above error and my plugin functions as expected.

In my research on this topic, I've also discovered that the approach I've taken may not be the ideal way to go about solving the problem - some other issues with runtime Assembly loading are noted [on this page](https://natemcmaster.com/blog/2018/07/25/netcore-plugins/) such as versioning issues/race conditions that might occur if multiple plugins attempt to use different versions of the same third-party library. This may not be a huge concern at present, so instead of incorporating this entire third-party class I implemented the more straightforward single-function solution.