### PR TITLE
Fix exception due to concurrent access of MethodHashes.

### DIFF
--- a/neo/SmartContract/Helper.cs
+++ b/neo/SmartContract/Helper.cs
@@ -3,6 +3,7 @@ using Neo.Network.P2P.Payloads;
 using Neo.Persistence;
 using Neo.VM;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Text;
 
@@ -10,7 +11,8 @@ namespace Neo.SmartContract
 {
     public static class Helper
     {
-        private static readonly Dictionary<string, uint> method_hashes = new Dictionary<string, uint>();
+        private static readonly ConcurrentDictionary<string, uint> MethodHashes
+            = new ConcurrentDictionary<string, uint>();
 
         public static bool IsMultiSigContract(this byte[] script)
         {
@@ -75,10 +77,10 @@ namespace Neo.SmartContract
 
         public static uint ToInteropMethodHash(this string method)
         {
-            if (method_hashes.TryGetValue(method, out uint hash))
+            if (MethodHashes.TryGetValue(method, out uint hash))
                 return hash;
             hash = BitConverter.ToUInt32(Encoding.ASCII.GetBytes(method).Sha256(), 0);
-            method_hashes[method] = hash;
+            MethodHashes[method] = hash;
             return hash;
         }
 

--- a/neo/SmartContract/Helper.cs
+++ b/neo/SmartContract/Helper.cs
@@ -4,7 +4,6 @@ using Neo.Persistence;
 using Neo.VM;
 using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Text;
 
 namespace Neo.SmartContract
@@ -77,11 +76,7 @@ namespace Neo.SmartContract
 
         public static uint ToInteropMethodHash(this string method)
         {
-            if (MethodHashes.TryGetValue(method, out uint hash))
-                return hash;
-            hash = BitConverter.ToUInt32(Encoding.ASCII.GetBytes(method).Sha256(), 0);
-            MethodHashes[method] = hash;
-            return hash;
+            return MethodHashes.GetOrAdd(method, p => BitConverter.ToUInt32(Encoding.ASCII.GetBytes(p).Sha256(), 0));
         }
 
         public static UInt160 ToScriptHash(this byte[] script)


### PR DESCRIPTION
Fixed this exception:
```
[ERROR][12/19/18 7:06:42 AM][Thread 0006][akka://NeoSystem/user/$a] Operations that change non-concurrent collections must have exclusive access. A concurrent update was performed on this collection and corrupted its state. The collection's state is no longer correct.
Cause: System.InvalidOperationException: Operations that change non-concurrent collections must have exclusive access. A concurrent update was performed on this collection and corrupted its state. The collection's state is no longer correct.
   at System.Collections.Generic.Dictionary`2.FindEntry(TKey key)
   at System.Collections.Generic.Dictionary`2.TryGetValue(TKey key, TValue& value)
   at Neo.SmartContract.Helper.ToInteropMethodHash(String method) in .../neo/SmartContract/Helper.cs:line 78
   at Neo.SmartContract.StandardService.Register(String method, Func`2 handler) in .../neo/SmartContract/StandardService.cs:line 112
   at Neo.SmartContract.NeoService..ctor(TriggerType trigger, Snapshot snapshot) in .../neo/SmartContract/NeoService.cs:line 89
   at Neo.SmartContract.ApplicationEngine..ctor(TriggerType trigger, IScriptContainer container, Snapshot snapshot, Fixed8 gas, Boolean testMode) in .../neo/SmartContract/ApplicationEngine.cs:line 62
   at Neo.SmartContract.Helper.VerifyWitnesses(IVerifiable verifiable, Snapshot snapshot) in .../neo/SmartContract/Helper.cs:line 117
   at Neo.Network.P2P.Payloads.Transaction.Verify(Snapshot snapshot, IEnumerable`1 mempool) in .../neo/Network/P2P/Payloads/Transaction.cs:line 319
   at Neo.Network.P2P.Payloads.InvocationTransaction.Verify(Snapshot snapshot, IEnumerable`1 mempool) in .../neo/Network/P2P/Payloads/InvocationTransaction.cs:line 65
...
```