### PR TITLE
Updating Unknown to Policy Fail

### DIFF
--- a/neo/Ledger/Blockchain.cs
+++ b/neo/Ledger/Blockchain.cs
@@ -388,7 +388,7 @@ namespace Neo.Ledger
             if (!transaction.Verify(currentSnapshot, GetMemoryPool()))
                 return RelayResultReason.Invalid;
             if (!Plugin.CheckPolicy(transaction))
-                return RelayResultReason.Unknown;
+                return RelayResultReason.PolicyFail;
 
             if (!mem_pool.TryAdd(transaction.Hash, transaction))
                 return RelayResultReason.OutOfMemory;

--- a/neo/Ledger/RelayResultReason.cs
+++ b/neo/Ledger/RelayResultReason.cs
@@ -7,6 +7,7 @@
         OutOfMemory,
         UnableToVerify,
         Invalid,
+        PolicyFail,
         Unknown
     }
 }


### PR DESCRIPTION
My transaction was returning Unknown and I took plenty of time to understand/remember (@igormcoelho realized that) that the problem was the Policy Fail.

In this sense, `PolicyFail` sounds like a better reason to be returned in this case.