### PR TITLE
Downgrade Sqlite to 2.1.4

### DIFF
--- a/neo/neo.csproj
+++ b/neo/neo.csproj
@@ -37,7 +37,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Https" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.WebSockets" Version="2.2.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.2.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.1.4" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
     <PackageReference Include="Neo.VM" Version="2.3.3.1" />
     <PackageReference Include="System.Text.Encodings.Web" Version="4.5.0" />


### PR DESCRIPTION
```
/opt/neoLib/neo/neo.csproj : error NU1605: Detected package downgrade: System.IO.FileSystem.Primitives from 4.3.0 to 4.0.1. Reference the package directly from the project to select a different version.  [/opt/neoCli/neo-cli/neo-cli.csproj]
/opt/neoLib/neo/neo.csproj : error NU1605:  Neo -> Microsoft.EntityFrameworkCore.Sqlite 2.2.0 -> Microsoft.EntityFrameworkCore.Sqlite.Core 2.2.0 -> Microsoft.Extensions.DependencyModel 2.1.0 -> Microsoft.DotNet.PlatformAbstractions 2.1.0 -> System.IO.FileSystem 4.0.1 -> runtime.unix.System.IO.FileSystem 4.3.0 -> System.IO.FileSystem.Primitives (>= 4.3.0)  [/opt/neoCli/neo-cli/neo-cli.csproj]
/opt/neoLib/neo/neo.csproj : error NU1605:  Neo -> Microsoft.EntityFrameworkCore.Sqlite 2.2.0 -> Microsoft.EntityFrameworkCore.Sqlite.Core 2.2.0 -> Microsoft.Extensions.DependencyModel 2.1.0 -> Microsoft.DotNet.PlatformAbstractions 2.1.0 -> System.IO.FileSystem 4.0.1 -> System.IO.FileSystem.Primitives (>= 4.0.1) [/opt/neoCli/neo-cli/neo-cli.csproj]
```