### PR TITLE
getrawtransactionheight

### DIFF
--- a/neo/Network/RPC/RpcServer.cs
+++ b/neo/Network/RPC/RpcServer.cs
@@ -320,6 +320,19 @@ namespace Neo.Network.RPC
                         }
                         return tx.ToArray().ToHexString();
                     }
+                case "getrawtransactionheight":
+                    {
+                        UInt256 hash = UInt256.Parse(_params[0].AsString());
+                        Transaction tx = Blockchain.Singleton.GetTransaction(hash);
+                        if (tx == null)
+                            throw new RpcException(-100, "Unknown transaction");
+
+                        uint? height = Blockchain.Singleton.Store.GetTransactions().TryGet(hash)?.BlockIndex;
+                        if (height != null)
+                            return header.Index;
+
+                       throw new RpcException(-32603, "Invalid height");
+                    }                    
                 case "getstorage":
                     {
                         UInt160 script_hash = UInt160.Parse(_params[0].AsString());


### PR DESCRIPTION
Nowadays two calls are need to get a transaction height, `getrawtransaction` with `verbose` and then use the `blockhash`.
Other option is to use `confirmations`, but it can be misleading.