### PR TITLE
minor optimization for priority message queue

### DIFF
--- a/neo/IO/Actors/PriorityMessageQueue.cs
+++ b/neo/IO/Actors/PriorityMessageQueue.cs
@@ -34,9 +34,9 @@ namespace Neo.IO.Actors
         {
             Interlocked.Increment(ref idle);
             if (envelope.Message is Idle) return;
-            if (dropper(envelope.Message, high.Concat(low).Select(p => p.Message)))
-                return;
             ConcurrentQueue<Envelope> queue = priority_generator(envelope.Message) ? high : low;
+            if (dropper(envelope.Message, queue.Select(p => p.Message)))
+                return;
             queue.Enqueue(envelope);
         }
 


### PR DESCRIPTION
Since each message is a one-to-one relationship to the queue, there is no need to pull the messages out of both queues for comparison