### PR TITLE
More MemoryPool Unit Tests. Improve Re-broadcast back-off to an increasing linear formula.

### DIFF
--- a/neo.UnitTests/UT_MemoryPool.cs
+++ b/neo.UnitTests/UT_MemoryPool.cs
@@ -1,12 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Neo.Ledger;
 using FluentAssertions;
-using Neo.Cryptography;
 using Neo.Cryptography.ECC;
 using Neo.IO.Wrappers;
 using Neo.Network.P2P.Payloads;

--- a/neo.UnitTests/UT_MemoryPool.cs
+++ b/neo.UnitTests/UT_MemoryPool.cs
@@ -97,8 +97,6 @@ namespace Neo.UnitTests
             var tx = mockTx.Object;
             var randomBytes = new byte[16];
             _random.NextBytes(randomBytes);
-            // Can't override
-            // mockTx.SetupGet(p => p.Hash).Returns(new UInt256(Crypto.Default.Hash256(randomBytes)));
             tx.Script = randomBytes;
             tx.Attributes = new TransactionAttribute[0];
             tx.Inputs = new CoinReference[0];

--- a/neo.UnitTests/UT_MemoryPool.cs
+++ b/neo.UnitTests/UT_MemoryPool.cs
@@ -274,7 +274,7 @@ namespace Neo.UnitTests
         [TestMethod]
         public void CapacityTestWithUnverifiedHighProirtyTransactions()
         {
-            // Verify that unverified high priority transactions will not pushed out of the queue by incoming
+            // Verify that unverified high priority transactions will not be pushed out of the queue by incoming
             // low priority transactions
 
             // Fill pool with high priority transactions

--- a/neo/Ledger/MemoryPool.cs
+++ b/neo/Ledger/MemoryPool.cs
@@ -48,6 +48,7 @@ namespace Neo.Ledger
         // Allow reverified transactions to be rebroadcast if it has been this many block times since last broadcast.
         private const int BlocksTillRebroadcastLowPriorityPoolTx = 30;
         private const int BlocksTillRebroadcastHighPriorityPoolTx = 10;
+        private int RebroadcastMultiplierThreshold => Capacity / 10;
 
         private static readonly double MaxSecondsToReverifyHighPrioTx = (double) Blockchain.SecondsPerBlock / 3;
         private static readonly double MaxSecondsToReverifyLowPrioTx = (double) Blockchain.SecondsPerBlock / 5;
@@ -447,6 +448,9 @@ namespace Neo.Ledger
             {
                 int blocksTillRebroadcast = unverifiedSortedTxPool == _sortedHighPrioTransactions
                     ? BlocksTillRebroadcastHighPriorityPoolTx : BlocksTillRebroadcastLowPriorityPoolTx;
+
+                if (Count > RebroadcastMultiplierThreshold)
+                    blocksTillRebroadcast = blocksTillRebroadcast * Count / RebroadcastMultiplierThreshold;
 
                 var rebroadcastCutOffTime = DateTime.UtcNow.AddSeconds(
                     -Blockchain.SecondsPerBlock * blocksTillRebroadcast);


### PR DESCRIPTION
I added more unit tests to MemoryPool. I have not found any problems with the code.

Also, this adds the one additional improvement I wanted to make so that the time for rebroadcasting re-verified transactions increases linearly as the pool size increases up until the pool size hits the capacity.