### PR TITLE
Minor comments update on Mempool class

### DIFF
--- a/neo/Ledger/MemoryPool.cs
+++ b/neo/Ledger/MemoryPool.cs
@@ -433,10 +433,12 @@ namespace Neo.Ledger
             List<PoolItem> invalidItems = new List<PoolItem>();
             foreach (PoolItem item in unverifiedSortedTxPool.Reverse().Take(count))
             {
-                // Re-verify the top fee max high priority transactions that can be verified in a block
+                // Re-verify up to `count` transactions that can be verified in a block
+                // for High Priority fees it is limited to _maxTxPerBlock, while
+                // for Low Priority fees it is limited to _maxLowPriorityTxPerBlock
                 if (item.Transaction.Verify(snapshot, _unsortedTransactions.Select(p => p.Value.Transaction)))
                     reverifiedItems.Add(item);
-                else // Transaction no longer valid -- will be removed from unverifiedTxPool.
+                else // Transaction no longer valid -- it will be removed from unverifiedTxPool.
                     invalidItems.Add(item);
 
                 if (DateTime.UtcNow > reverifyCutOffTimeStamp) break;

--- a/neo/Ledger/MemoryPool.cs
+++ b/neo/Ledger/MemoryPool.cs
@@ -433,8 +433,7 @@ namespace Neo.Ledger
             foreach (PoolItem item in unverifiedSortedTxPool.Reverse().Take(count))
             {
                 // Re-verify up to `count` transactions that can be verified in a block
-                // for high priority txs cut-off is limited to _maxTxPerBlock, while
-                // for low priority txs cut-off is limited to _maxLowPriorityTxPerBlock
+                // since unverifiedSortedTxPool is ordered in an ascending manner, we take the end of it
                 if (item.Transaction.Verify(snapshot, _unsortedTransactions.Select(p => p.Value.Transaction)))
                     reverifiedItems.Add(item);
                 else // Transaction no longer valid -- it will be removed from unverifiedTxPool.

--- a/neo/Ledger/MemoryPool.cs
+++ b/neo/Ledger/MemoryPool.cs
@@ -432,8 +432,8 @@ namespace Neo.Ledger
             List<PoolItem> invalidItems = new List<PoolItem>();
             foreach (PoolItem item in unverifiedSortedTxPool.Reverse().Take(count))
             {
-                // Re-verify up to `count` transactions that can be verified in a block
-                // since unverifiedSortedTxPool is ordered in an ascending manner, we take the end of it
+                // Re-verify up to `count` transactions since unverifiedSortedTxPool is ordered
+                // in an ascending manner, we take the end of it
                 if (item.Transaction.Verify(snapshot, _unsortedTransactions.Select(p => p.Value.Transaction)))
                     reverifiedItems.Add(item);
                 else // Transaction no longer valid -- it will be removed from unverifiedTxPool.

--- a/neo/Ledger/MemoryPool.cs
+++ b/neo/Ledger/MemoryPool.cs
@@ -427,13 +427,12 @@ namespace Neo.Ledger
             SortedSet<PoolItem> unverifiedSortedTxPool, int count, double secondsTimeout, Snapshot snapshot)
         {
             DateTime reverifyCutOffTimeStamp = DateTime.UtcNow.AddSeconds(secondsTimeout);
-
             List<PoolItem> reverifiedItems = new List<PoolItem>(count);
             List<PoolItem> invalidItems = new List<PoolItem>();
+            
+            // Since unverifiedSortedTxPool is ordered in an ascending manner, we take from the end.
             foreach (PoolItem item in unverifiedSortedTxPool.Reverse().Take(count))
             {
-                // Re-verify up to `count` transactions since unverifiedSortedTxPool is ordered
-                // in an ascending manner, the end of it is taken.
                 if (item.Transaction.Verify(snapshot, _unsortedTransactions.Select(p => p.Value.Transaction)))
                     reverifiedItems.Add(item);
                 else // Transaction no longer valid -- it will be removed from unverifiedTxPool.

--- a/neo/Ledger/MemoryPool.cs
+++ b/neo/Ledger/MemoryPool.cs
@@ -433,7 +433,7 @@ namespace Neo.Ledger
             foreach (PoolItem item in unverifiedSortedTxPool.Reverse().Take(count))
             {
                 // Re-verify up to `count` transactions since unverifiedSortedTxPool is ordered
-                // in an ascending manner, we take the end of it
+                // in an ascending manner, the end of it is taken.
                 if (item.Transaction.Verify(snapshot, _unsortedTransactions.Select(p => p.Value.Transaction)))
                     reverifiedItems.Add(item);
                 else // Transaction no longer valid -- it will be removed from unverifiedTxPool.

--- a/neo/Ledger/MemoryPool.cs
+++ b/neo/Ledger/MemoryPool.cs
@@ -434,8 +434,8 @@ namespace Neo.Ledger
             foreach (PoolItem item in unverifiedSortedTxPool.Reverse().Take(count))
             {
                 // Re-verify up to `count` transactions that can be verified in a block
-                // for High Priority fees it is limited to _maxTxPerBlock, while
-                // for Low Priority fees it is limited to _maxLowPriorityTxPerBlock
+                // for high priority txs cut-off is limited to _maxTxPerBlock, while
+                // for low priority txs cut-off is limited to _maxLowPriorityTxPerBlock
                 if (item.Transaction.Verify(snapshot, _unsortedTransactions.Select(p => p.Value.Transaction)))
                     reverifiedItems.Add(item);
                 else // Transaction no longer valid -- it will be removed from unverifiedTxPool.

--- a/neo/Ledger/MemoryPool.cs
+++ b/neo/Ledger/MemoryPool.cs
@@ -45,7 +45,7 @@ namespace Neo.Ledger
             }
         }
 
-        // Allow reverified transactions to be rebroadcast if it has been this many block times since last broadcast.
+        // Allow a reverified transaction to be rebroadcasted if it has been this many block times since last broadcast.
         private const int BlocksTillRebroadcastLowPriorityPoolTx = 30;
         private const int BlocksTillRebroadcastHighPriorityPoolTx = 10;
         private int RebroadcastMultiplierThreshold => Capacity / 10;
@@ -82,7 +82,6 @@ namespace Neo.Ledger
         /// </summary>
         private readonly SortedSet<PoolItem> _sortedLowPrioTransactions = new SortedSet<PoolItem>();
 
-
         /// <summary>
         /// Store the unverified transactions currently in the pool.
         ///
@@ -94,12 +93,11 @@ namespace Neo.Ledger
         private readonly SortedSet<PoolItem> _unverifiedSortedHighPriorityTransactions = new SortedSet<PoolItem>();
         private readonly SortedSet<PoolItem> _unverifiedSortedLowPriorityTransactions = new SortedSet<PoolItem>();
 
-        // internal methods to aid in unit testing
+        // Internal methods to aid in unit testing
         internal int SortedHighPrioTxCount => _sortedHighPrioTransactions.Count;
         internal int SortedLowPrioTxCount => _sortedLowPrioTransactions.Count;
         internal int UnverifiedSortedHighPrioTxCount => _unverifiedSortedHighPriorityTransactions.Count;
         internal int UnverifiedSortedLowPrioTxCount => _unverifiedSortedLowPriorityTransactions.Count;
-
 
         private int _maxTxPerBlock;
         private int _maxLowPriorityTxPerBlock;


### PR DESCRIPTION
@jsolman, this is just a minor comment fix on mempool `ReverifyTransactions`.
Please, check if it was done accordingly.

Furthermore, I just wonder i `foreach (PoolItem item in unverifiedSortedTxPool.Reverse().Take(count))` is correct? I did get this Revert.
I think we could create another PR for Unit Test this order once #554 is merged.