### PR TITLE
Consensus data analyses by Nodes with special Plugin

### DIFF
--- a/neo/Consensus/ConsensusService.cs
+++ b/neo/Consensus/ConsensusService.cs
@@ -195,6 +195,8 @@ namespace Neo.Consensus
             if (context.State.HasFlag(ConsensusState.RequestReceived)) return;
             if (payload.ValidatorIndex != context.PrimaryIndex) return;
             Log($"{nameof(OnPrepareRequestReceived)}: height={payload.BlockIndex} view={message.ViewNumber} index={payload.ValidatorIndex} tx={message.TransactionHashes.Length}");
+            foreach (IConsensusMetricsPlugin plugin in Plugin.ConsensusPlugins)
+                plugin.AnalyzePrepareRequestReceived(payload);
             if (!context.State.HasFlag(ConsensusState.Backup)) return;
             if (payload.Timestamp <= context.PrevHeader.Timestamp || payload.Timestamp > TimeProvider.Current.UtcNow.AddMinutes(10).ToTimestamp())
             {

--- a/neo/Consensus/ConsensusService.cs
+++ b/neo/Consensus/ConsensusService.cs
@@ -256,6 +256,8 @@ namespace Neo.Consensus
         {
             if (context.Signatures[payload.ValidatorIndex] != null) return;
             Log($"{nameof(OnPrepareResponseReceived)}: height={payload.BlockIndex} view={message.ViewNumber} index={payload.ValidatorIndex}");
+            foreach (IConsensusMetricsPlugin plugin in Plugin.ConsensusPlugins)
+                plugin.AnalyzePrepareResponse(payload);
             byte[] hashData = context.MakeHeader()?.GetHashData();
             if (hashData == null)
             {

--- a/neo/Consensus/ConsensusService.cs
+++ b/neo/Consensus/ConsensusService.cs
@@ -196,7 +196,7 @@ namespace Neo.Consensus
             if (payload.ValidatorIndex != context.PrimaryIndex) return;
             Log($"{nameof(OnPrepareRequestReceived)}: height={payload.BlockIndex} view={message.ViewNumber} index={payload.ValidatorIndex} tx={message.TransactionHashes.Length}");
             foreach (IConsensusMetricsPlugin plugin in Plugin.ConsensusPlugins)
-                plugin.AnalyzePrepareRequestReceived(payload);
+                plugin.AnalyzePrepareRequest(payload);
             if (!context.State.HasFlag(ConsensusState.Backup)) return;
             if (payload.Timestamp <= context.PrevHeader.Timestamp || payload.Timestamp > TimeProvider.Current.UtcNow.AddMinutes(10).ToTimestamp())
             {

--- a/neo/Plugins/IConsensusMetricsPlugin.cs
+++ b/neo/Plugins/IConsensusMetricsPlugin.cs
@@ -4,6 +4,6 @@ namespace Neo.Plugins
 {
     public interface IConsensusMetricsPlugin
     {
-        void AnalyzePrepareRequestReceived(ConsensusPayload payload);
+        void AnalyzePrepareRequest(ConsensusPayload payload);
     }
 }

--- a/neo/Plugins/IConsensusMetricsPlugin.cs
+++ b/neo/Plugins/IConsensusMetricsPlugin.cs
@@ -5,5 +5,6 @@ namespace Neo.Plugins
     public interface IConsensusMetricsPlugin
     {
         void AnalyzePrepareRequest(ConsensusPayload payload);
+        void AnalyzePrepareResponse(ConsensusPayload payload);
     }
 }

--- a/neo/Plugins/IConsensusMetricsPlugin.cs
+++ b/neo/Plugins/IConsensusMetricsPlugin.cs
@@ -1,0 +1,9 @@
+﻿using Neo.Network.P2P.Payloads;
+
+namespace Neo.Plugins
+{
+    public interface IConsensusMetricsPlugin
+    {
+        void AnalyzePrepareRequestReceived(ConsensusPayload payload);
+    }
+}

--- a/neo/Plugins/Plugin.cs
+++ b/neo/Plugins/Plugin.cs
@@ -16,6 +16,8 @@ namespace Neo.Plugins
         internal static readonly List<IPolicyPlugin> Policies = new List<IPolicyPlugin>();
         internal static readonly List<IRpcPlugin> RpcPlugins = new List<IRpcPlugin>();
         internal static readonly List<IPersistencePlugin> PersistencePlugins = new List<IPersistencePlugin>();
+        internal static readonly List<IConsensusMetricsPlugin> ConsensusPlugins = new List<IConsensusMetricsPlugin>();
+
 
         private static readonly string pluginsPath = Path.Combine(Path.GetDirectoryName(Assembly.GetEntryAssembly().Location), "Plugins");
         private static readonly FileSystemWatcher configWatcher;


### PR DESCRIPTION
@erikzhang, I think that this is a good design, because it does not increase any load on Consensus themselves.

In this sense, we can have Agents (specialized nodes) on the network specialized (with this plugin) for checking status and statistics about CN.

@igormcoelho, what do you think?

An example of the first analyzes thought to be implemented is that any node could get the PrepareRequest Payload and check:
- The proposed TXs against its local mempool, verifying:
   - The number of transactions match an efficient criteria;
   - The transactions selected by the primary are really the ones that should be selected, considering your mempool order;
   - Among others.