### PR TITLE
Treat Claim transactions as the highest low priority transactions + Unit test

### DIFF
--- a/neo.UnitTests/UT_PoolItem.cs
+++ b/neo.UnitTests/UT_PoolItem.cs
@@ -34,6 +34,19 @@ namespace Neo.UnitTests
         }
 
         [TestMethod]
+        public void PoolItem_CompareTo_ClaimTx()
+        {
+            var tx1 = GenerateClaimTx();
+            // Non-free low-priority transaction
+            var tx2 = MockGenerateInvocationTx(new Fixed8(99999), 50).Object;
+
+            var poolItem1 = new PoolItem(tx1);
+            var poolItem2 = new PoolItem(tx2);
+            poolItem1.CompareTo(poolItem2).Should().Be(1);
+            poolItem2.CompareTo(poolItem1).Should().Be(-1);
+        }
+
+        [TestMethod]
         public void PoolItem_CompareTo_Fee()
         {
             int size1 = 50;
@@ -122,6 +135,19 @@ namespace Neo.UnitTests
             return mockTx;
         }
 
+        public static Transaction GenerateClaimTx()
+        {
+            var mockTx = new Mock<ClaimTransaction>();
+            mockTx.CallBase = true;
+            mockTx.SetupGet(mr => mr.NetworkFee).Returns(Fixed8.Zero);
+            mockTx.SetupGet(mr => mr.Size).Returns(50);
+            var tx = mockTx.Object;
+            tx.Attributes = new TransactionAttribute[0];
+            tx.Inputs = new CoinReference[0];
+            tx.Outputs = new TransactionOutput[0];
+            tx.Witnesses = new Witness[0];
+            return mockTx.Object;
+        }
 
         // Generate Mock InvocationTransaction with different sizes and prices
         public static Mock<InvocationTransaction> MockGenerateInvocationTx(Fixed8 networkFee, int size, byte[] overrideScriptBytes=null)


### PR DESCRIPTION
In order to ensure claims transactions get processed with a large backlog of low priority transactions, we should sort the claim transactions first among the low priority transactions.