### PR TITLE
Bump version to 2.9.5

### DIFF
--- a/neo/neo.csproj
+++ b/neo/neo.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Copyright>2015-2018 The Neo Project</Copyright>
     <AssemblyTitle>Neo</AssemblyTitle>
-    <Version>2.9.4</Version>
+    <Version>2.9.5</Version>
     <Authors>The Neo Project</Authors>
     <TargetFrameworks>netstandard2.0;net47</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>


### PR DESCRIPTION
It seems like now is a good time to release 2.9.5 with the MemoryPool improvements.