### PR TITLE
Allow persistence plugins to commit as a final step.

### DIFF
--- a/neo/Ledger/Blockchain.cs
+++ b/neo/Ledger/Blockchain.cs
@@ -609,9 +609,9 @@ namespace Neo.Ledger
                 }
                 foreach (IPersistencePlugin plugin in Plugin.PersistencePlugins)
                     plugin.OnPersist(snapshot, all_application_executed);
-                snapshot.Commit();
                 foreach (IPersistencePlugin plugin in Plugin.PersistencePlugins)
                     plugin.OnCommit(snapshot);
+                snapshot.Commit();
             }
             UpdateCurrentSnapshot();
             OnPersistCompleted(block);

--- a/neo/Ledger/Blockchain.cs
+++ b/neo/Ledger/Blockchain.cs
@@ -610,6 +610,8 @@ namespace Neo.Ledger
                 foreach (IPersistencePlugin plugin in Plugin.PersistencePlugins)
                     plugin.OnPersist(snapshot, all_application_executed);
                 snapshot.Commit();
+                foreach (IPersistencePlugin plugin in Plugin.PersistencePlugins)
+                    plugin.OnCommit(snapshot);
             }
             UpdateCurrentSnapshot();
             OnPersistCompleted(block);

--- a/neo/Plugins/IPersistencePlugin.cs
+++ b/neo/Plugins/IPersistencePlugin.cs
@@ -8,5 +8,6 @@ namespace Neo.Plugins
     {
         void OnPersist(Snapshot snapshot, IReadOnlyList<ApplicationExecuted> applicationExecutedList);
         void OnCommit(Snapshot snapshot);
+        bool ShouldThrowExceptionFromCommit(Exception ex);
     }
 }

--- a/neo/Plugins/IPersistencePlugin.cs
+++ b/neo/Plugins/IPersistencePlugin.cs
@@ -1,4 +1,5 @@
-﻿using Neo.Persistence;
+﻿using System;
+using Neo.Persistence;
 using System.Collections.Generic;
 using static Neo.Ledger.Blockchain;
 

--- a/neo/Plugins/IPersistencePlugin.cs
+++ b/neo/Plugins/IPersistencePlugin.cs
@@ -7,5 +7,6 @@ namespace Neo.Plugins
     public interface IPersistencePlugin
     {
         void OnPersist(Snapshot snapshot, IReadOnlyList<ApplicationExecuted> applicationExecutedList);
+        void OnCommit(Snapshot snapshot);
     }
 }


### PR DESCRIPTION
If there are multiple persistence plugins loaded and one of them throws an exception, then none of them should actually commit anything to a persistent store. To facilitate this behavior, I added an `OnCommit`  method to be called after all plugins have had a chance to process results from `OnPersist` and throw if something was wrong.

A persistence plugin implementing `IPersistencePlugin` should do any processing needed to stage data to persist in its `OnPersist` method, and then perform actual persistence in its `OnCommit` method. In this way database integrity is maximized. 