### PR TITLE
Add a Plugin type for observing transactions added or removed from the MemoryPool.

### DIFF
--- a/neo/Ledger/MemoryPool.cs
+++ b/neo/Ledger/MemoryPool.cs
@@ -287,7 +287,7 @@ namespace Neo.Ledger
 
             if (_unsortedTransactions.ContainsKey(hash)) return false;
 
-            List<Transaction> removedTransactions;
+            List<Transaction> removedTransactions = null;
             _txRwLock.EnterWriteLock();
             try
             {

--- a/neo/Ledger/MemoryPool.cs
+++ b/neo/Ledger/MemoryPool.cs
@@ -295,7 +295,9 @@ namespace Neo.Ledger
 
                 SortedSet<PoolItem> pool = tx.IsLowPriority ? _sortedLowPrioTransactions : _sortedHighPrioTransactions;
                 pool.Add(poolItem);
-                removedTransactions = RemoveOverCapacity();
+                if (Count > Capacity) {
+                    removedTransactions = RemoveOverCapacity();
+                }
             }
             finally
             {
@@ -314,17 +316,15 @@ namespace Neo.Ledger
 
         private List<Transaction> RemoveOverCapacity()
         {
-            List<Transaction> removedTransactions = null;
-            while (Count > Capacity)
+            List<Transaction> removedTransactions = new List<Transaction>();
+            do
             {
                 PoolItem minItem = GetLowestFeeTransaction(out var unsortedPool, out var sortedPool);
 
                 unsortedPool.Remove(minItem.Tx.Hash);
                 sortedPool.Remove(minItem);
-                if (removedTransactions == null)
-                    removedTransactions = new List<Transaction>();
                 removedTransactions.Add(minItem.Tx);
-            }
+            } while (Count > Capacity);
 
             return removedTransactions;
         }

--- a/neo/Ledger/MemoryPool.cs
+++ b/neo/Ledger/MemoryPool.cs
@@ -321,6 +321,8 @@ namespace Neo.Ledger
 
                 unsortedPool.Remove(minItem.Tx.Hash);
                 sortedPool.Remove(minItem);
+                if (removedTransactions == null)
+                    removedTransactions = new List<Transaction>();
                 removedTransactions.Add(minItem.Tx);
             }
 

--- a/neo/Ledger/MemoryPool.cs
+++ b/neo/Ledger/MemoryPool.cs
@@ -295,9 +295,8 @@ namespace Neo.Ledger
 
                 SortedSet<PoolItem> pool = tx.IsLowPriority ? _sortedLowPrioTransactions : _sortedHighPrioTransactions;
                 pool.Add(poolItem);
-                if (Count > Capacity) {
+                if (Count > Capacity)
                     removedTransactions = RemoveOverCapacity();
-                }
             }
             finally
             {

--- a/neo/Ledger/MemoryPool.cs
+++ b/neo/Ledger/MemoryPool.cs
@@ -314,14 +314,15 @@ namespace Neo.Ledger
 
         private void RemoveOverCapacity(ref List<Transaction> removedTransactions)
         {
+            if (removedTransactions == null)
+                removedTransactions = new List<Transaction>();
+
             while (Count > Capacity)
             {
                 PoolItem minItem = GetLowestFeeTransaction(out var unsortedPool, out var sortedPool);
 
                 unsortedPool.Remove(minItem.Tx.Hash);
                 sortedPool.Remove(minItem);
-                if (removedTransactions == null)
-                    removedTransactions = new List<Transaction>();
                 removedTransactions.Add(minItem.Tx);
             }
         }

--- a/neo/Ledger/MemoryPool.cs
+++ b/neo/Ledger/MemoryPool.cs
@@ -302,9 +302,10 @@ namespace Neo.Ledger
                 _txRwLock.ExitWriteLock();
             }
 
-            if (removedTransactions != null)
+            foreach (IMemoryPoolTxObserverPlugin plugin in Plugin.TxObserverPlugins)
             {
-                foreach (IMemoryPoolTxObserverPlugin plugin in Plugin.TxObserverPlugins)
+                plugin.AddedTransaction(poolItem.Tx);
+                if (removedTransactions != null)
                     plugin.RemovedTransactions(MemoryPoolTxRemovalReason.CapacityExceeded, removedTransactions);
             }
 

--- a/neo/Plugins/IMemoryPoolTxObserverPlugin.cs
+++ b/neo/Plugins/IMemoryPoolTxObserverPlugin.cs
@@ -5,7 +5,7 @@ namespace Neo.Plugins
 {
     public interface IMemoryPoolTxObserverPlugin
     {
-        void AddedTransaction(Transaction tx);
-        void RemovedTransactions(MemoryPoolTxRemovalReason reason, IEnumerable<Transaction> transactions);
+        void TransactionAdded(Transaction tx);
+        void TransactionsRemoved(MemoryPoolTxRemovalReason reason, IEnumerable<Transaction> transactions);
     }
 }

--- a/neo/Plugins/IMemoryPoolTxObserverPlugin.cs
+++ b/neo/Plugins/IMemoryPoolTxObserverPlugin.cs
@@ -5,7 +5,7 @@ namespace Neo.Plugins
 {
     public interface IMemoryPoolTxObserverPlugin
     {
-        bool AddedTransaction(Transaction tx);
-        bool RemovedTransactions(MemoryPoolTxRemovalReason reason, IEnumerable<Transaction> transactions);
+        void AddedTransaction(Transaction tx);
+        void RemovedTransactions(MemoryPoolTxRemovalReason reason, IEnumerable<Transaction> transactions);
     }
 }

--- a/neo/Plugins/IMemoryPoolTxObserverPlugin.cs
+++ b/neo/Plugins/IMemoryPoolTxObserverPlugin.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+using Neo.Network.P2P.Payloads;
+
+namespace Neo.Plugins
+{
+    public interface IMemoryPoolTxObserverPlugin
+    {
+        bool AddedTransaction(Transaction tx);
+        bool RemovedTransactions(MemoryPoolTxRemovalReason reason, IEnumerable<Transaction> transactions);
+    }
+}

--- a/neo/Plugins/MemoryPoolTxRemovalReason.cs
+++ b/neo/Plugins/MemoryPoolTxRemovalReason.cs
@@ -1,0 +1,14 @@
+﻿namespace Neo.Plugins
+{
+    public enum MemoryPoolTxRemovalReason : byte
+    {
+        /// <summary>
+        /// The transaction was ejected since it was the lowest priority transaction and the MemoryPool capacity was exceeded.
+        /// </summary>
+        CapacityExceeded,
+        /// <summary>
+        /// The transaction was ejected due to failing re-validation after a block was persisted.
+        /// </summary>
+        NoLongerValid,
+    }
+}

--- a/neo/Plugins/Plugin.cs
+++ b/neo/Plugins/Plugin.cs
@@ -16,6 +16,7 @@ namespace Neo.Plugins
         internal static readonly List<IPolicyPlugin> Policies = new List<IPolicyPlugin>();
         internal static readonly List<IRpcPlugin> RpcPlugins = new List<IRpcPlugin>();
         internal static readonly List<IPersistencePlugin> PersistencePlugins = new List<IPersistencePlugin>();
+        internal static readonly List<IMemoryPoolTxObserverPlugin> TxObserverPlugins = new List<IMemoryPoolTxObserverPlugin>();
 
         private static readonly string pluginsPath = Path.Combine(Path.GetDirectoryName(Assembly.GetEntryAssembly().Location), "Plugins");
         private static readonly FileSystemWatcher configWatcher;
@@ -51,6 +52,7 @@ namespace Neo.Plugins
             if (this is IPolicyPlugin policy) Policies.Add(policy);
             if (this is IRpcPlugin rpc) RpcPlugins.Add(rpc);
             if (this is IPersistencePlugin persistence) PersistencePlugins.Add(persistence);
+            if (this is IMemoryPoolTxObserverPlugin txObserver) TxObserverPlugins.Add(txObserver);
 
             Configure();
         }


### PR DESCRIPTION
This implements a plugin type for observing transactions added to the `MemoryPool` or removed due to a reason other than being accepted in a block. 

This implements the suggestion from #566.
Closes #566 