### PR TITLE
Simplify `RecoveryMessage`

### DIFF
--- a/neo.UnitTests/UT_Consensus.cs
+++ b/neo.UnitTests/UT_Consensus.cs
@@ -275,7 +275,7 @@ namespace Neo.UnitTests
         {
             var msg = new RecoveryMessage
             {
-                ChangeViewMessages = new Dictionary<ushort, RecoveryMessage.ChangeViewPayloadCompact>()
+                ChangeViewMessages = new Dictionary<int, RecoveryMessage.ChangeViewPayloadCompact>()
                 {
                     {
                         0,
@@ -319,7 +319,7 @@ namespace Neo.UnitTests
                     }
                 },
                 PreparationHash = new UInt256(Crypto.Default.Hash256(new[] { (byte)'a' })),
-                PreparationMessages = new Dictionary<ushort, RecoveryMessage.PreparationPayloadCompact>()
+                PreparationMessages = new Dictionary<int, RecoveryMessage.PreparationPayloadCompact>()
                 {
                     {
                         0,
@@ -346,7 +346,7 @@ namespace Neo.UnitTests
                         }
                     }
                 },
-                CommitMessages = new Dictionary<ushort, RecoveryMessage.CommitPayloadCompact>()
+                CommitMessages = new Dictionary<int, RecoveryMessage.CommitPayloadCompact>()
             };
 
             // msg.TransactionHashes = null;
@@ -372,7 +372,7 @@ namespace Neo.UnitTests
                 txs[i] = TestUtils.CreateRandomHashInvocationMockTransaction().Object;
             var msg = new RecoveryMessage
             {
-                ChangeViewMessages = new Dictionary<ushort, RecoveryMessage.ChangeViewPayloadCompact>()
+                ChangeViewMessages = new Dictionary<int, RecoveryMessage.ChangeViewPayloadCompact>()
                 {
                     {
                         0,
@@ -423,7 +423,7 @@ namespace Neo.UnitTests
                     MinerTransaction = (MinerTransaction)txs[0]
                 },
                 PreparationHash = new UInt256(Crypto.Default.Hash256(new[] { (byte)'a' })),
-                PreparationMessages = new Dictionary<ushort, RecoveryMessage.PreparationPayloadCompact>()
+                PreparationMessages = new Dictionary<int, RecoveryMessage.PreparationPayloadCompact>()
                 {
                     {
                         0,
@@ -450,7 +450,7 @@ namespace Neo.UnitTests
                         }
                     }
                 },
-                CommitMessages = new Dictionary<ushort, RecoveryMessage.CommitPayloadCompact>()
+                CommitMessages = new Dictionary<int, RecoveryMessage.CommitPayloadCompact>()
             };
 
             var copiedMsg = TestUtils.CopyMsgBySerialization(msg, new RecoveryMessage());;
@@ -471,7 +471,7 @@ namespace Neo.UnitTests
                 txs[i] = TestUtils.CreateRandomHashInvocationMockTransaction().Object;
             var msg = new RecoveryMessage
             {
-                ChangeViewMessages = new Dictionary<ushort, RecoveryMessage.ChangeViewPayloadCompact>(),
+                ChangeViewMessages = new Dictionary<int, RecoveryMessage.ChangeViewPayloadCompact>(),
                 PrepareRequestMessage = new PrepareRequest
                 {
                     TransactionHashes = txs.Select(p => p.Hash).ToArray(),
@@ -479,7 +479,7 @@ namespace Neo.UnitTests
                     NextConsensus = UInt160.Parse("5555AAAA5555AAAA5555AAAA5555AAAA5555AAAA"),
                     MinerTransaction = (MinerTransaction)txs[0]
                 },
-                PreparationMessages = new Dictionary<ushort, RecoveryMessage.PreparationPayloadCompact>()
+                PreparationMessages = new Dictionary<int, RecoveryMessage.PreparationPayloadCompact>()
                 {
                     {
                         0,
@@ -514,7 +514,7 @@ namespace Neo.UnitTests
                         }
                     }
                 },
-                CommitMessages = new Dictionary<ushort, RecoveryMessage.CommitPayloadCompact>()
+                CommitMessages = new Dictionary<int, RecoveryMessage.CommitPayloadCompact>()
             };
 
             var copiedMsg = TestUtils.CopyMsgBySerialization(msg, new RecoveryMessage());;
@@ -535,7 +535,7 @@ namespace Neo.UnitTests
                 txs[i] = TestUtils.CreateRandomHashInvocationMockTransaction().Object;
             var msg = new RecoveryMessage
             {
-                ChangeViewMessages = new Dictionary<ushort, RecoveryMessage.ChangeViewPayloadCompact>(),
+                ChangeViewMessages = new Dictionary<int, RecoveryMessage.ChangeViewPayloadCompact>(),
                 PrepareRequestMessage = new PrepareRequest
                 {
                     TransactionHashes = txs.Select(p => p.Hash).ToArray(),
@@ -543,7 +543,7 @@ namespace Neo.UnitTests
                     NextConsensus = UInt160.Parse("5555AAAA5555AAAA5555AAAA5555AAAA5555AAAA"),
                     MinerTransaction = (MinerTransaction)txs[0]
                 },
-                PreparationMessages = new Dictionary<ushort, RecoveryMessage.PreparationPayloadCompact>()
+                PreparationMessages = new Dictionary<int, RecoveryMessage.PreparationPayloadCompact>()
                 {
                     {
                         0,
@@ -578,7 +578,7 @@ namespace Neo.UnitTests
                         }
                     }
                 },
-                CommitMessages = new Dictionary<ushort, RecoveryMessage.CommitPayloadCompact>
+                CommitMessages = new Dictionary<int, RecoveryMessage.CommitPayloadCompact>
                 {
                     {
                         1,

--- a/neo.UnitTests/UT_Consensus.cs
+++ b/neo.UnitTests/UT_Consensus.cs
@@ -4,18 +4,17 @@ using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Neo.Consensus;
+using Neo.Cryptography;
 using Neo.IO;
 using Neo.Ledger;
 using Neo.Network.P2P;
 using Neo.Network.P2P.Payloads;
+using Neo.Persistence;
 using System;
-using System.IO;
+using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
 using System.Security.Cryptography;
-using Neo.Cryptography;
-using Neo.Persistence;
-using Remotion.Linq.Clauses;
 using ECPoint = Neo.Cryptography.ECC.ECPoint;
 
 namespace Neo.UnitTests
@@ -274,197 +273,339 @@ namespace Neo.UnitTests
         [TestMethod]
         public void TestSerializeAndDeserializeRecoveryMessageWithChangeViewsAndNoPrepareRequest()
         {
-            var msg = new RecoveryMessage();
-            msg.ChangeViewWitnessInvocationScripts = new byte[7][];
-            msg.ChangeViewWitnessInvocationScripts[0] = new [] {(byte) 'A'};
-            msg.ChangeViewWitnessInvocationScripts[1] = new [] {(byte) 'B'};
-            msg.ChangeViewWitnessInvocationScripts[2] = null;
-            msg.ChangeViewWitnessInvocationScripts[3] = new [] {(byte) 'C'};
-            msg.ChangeViewWitnessInvocationScripts[4] = null;
-            msg.ChangeViewWitnessInvocationScripts[5] = null;
-            msg.ChangeViewWitnessInvocationScripts[6] = new [] {(byte) 'D'};
-            msg.ChangeViewTimestamps = new uint[7];
-            msg.ChangeViewTimestamps[0] = 6;
-            msg.ChangeViewTimestamps[1] = 5;
-            msg.ChangeViewTimestamps[2] = 4;
-            msg.ChangeViewTimestamps[3] = 3;
-            msg.ChangeViewTimestamps[4] = uint.MaxValue;
-            msg.ChangeViewTimestamps[5] = 2;
-            msg.ChangeViewTimestamps[6] = 1;
-            msg.OriginalChangeViewNumbers = new byte[7];
-            msg.OriginalChangeViewNumbers[0] = 9;
-            msg.OriginalChangeViewNumbers[1] = 7;
-            msg.OriginalChangeViewNumbers[2] = 6;
-            msg.OriginalChangeViewNumbers[3] = 5;
-            msg.OriginalChangeViewNumbers[4] = 4;
-            msg.OriginalChangeViewNumbers[5] = 3;
-            msg.OriginalChangeViewNumbers[6] = 2;
+            var msg = new RecoveryMessage
+            {
+                ChangeViewMessages = new Dictionary<ushort, RecoveryMessage.ChangeViewPayloadCompact>()
+                {
+                    {
+                        0,
+                        new RecoveryMessage.ChangeViewPayloadCompact
+                        {
+                            ValidatorIndex = 0,
+                            OriginalViewNumber = 9,
+                            Timestamp = 6,
+                            InvocationScript = new[] { (byte)'A' }
+                        }
+                    },
+                    {
+                        1,
+                        new RecoveryMessage.ChangeViewPayloadCompact
+                        {
+                            ValidatorIndex = 1,
+                            OriginalViewNumber = 7,
+                            Timestamp = 5,
+                            InvocationScript = new[] { (byte)'B' }
+                        }
+                    },
+                    {
+                        3,
+                        new RecoveryMessage.ChangeViewPayloadCompact
+                        {
+                            ValidatorIndex = 3,
+                            OriginalViewNumber = 5,
+                            Timestamp = 3,
+                            InvocationScript = new[] { (byte)'C' }
+                        }
+                    },
+                    {
+                        6,
+                        new RecoveryMessage.ChangeViewPayloadCompact
+                        {
+                            ValidatorIndex = 6,
+                            OriginalViewNumber = 2,
+                            Timestamp = 1,
+                            InvocationScript = new[] { (byte)'D' }
+                        }
+                    }
+                },
+                PreparationHash = new UInt256(Crypto.Default.Hash256(new[] { (byte)'a' })),
+                PreparationMessages = new Dictionary<ushort, RecoveryMessage.PreparationPayloadCompact>()
+                {
+                    {
+                        0,
+                        new RecoveryMessage.PreparationPayloadCompact
+                        {
+                            ValidatorIndex = 0,
+                            InvocationScript = new[] { (byte)'t', (byte)'e' }
+                        }
+                    },
+                    {
+                        3,
+                        new RecoveryMessage.PreparationPayloadCompact
+                        {
+                            ValidatorIndex = 3,
+                            InvocationScript = new[] { (byte)'1', (byte)'2' }
+                        }
+                    },
+                    {
+                        6,
+                        new RecoveryMessage.PreparationPayloadCompact
+                        {
+                            ValidatorIndex = 6,
+                            InvocationScript = new[] { (byte)'3', (byte)'!' }
+                        }
+                    }
+                },
+                CommitMessages = new Dictionary<ushort, RecoveryMessage.CommitPayloadCompact>()
+            };
 
             // msg.TransactionHashes = null;
             // msg.Nonce = 0;
             // msg.NextConsensus = null;
             // msg.MinerTransaction = (MinerTransaction) null;
             msg.PrepareRequestMessage.Should().Be(null);
-            msg.PreparationHash = new UInt256(Crypto.Default.Hash256(new [] {(byte) 'a'}));
-            msg.PrepareWitnessInvocationScripts = new byte[7][];
-            msg.PrepareWitnessInvocationScripts[0] = new [] {(byte)'t', (byte)'e'};
-            msg.PrepareWitnessInvocationScripts[1] = null;
-            msg.PrepareWitnessInvocationScripts[2] = null;
-            msg.PrepareWitnessInvocationScripts[3] = new [] {(byte)'1', (byte)'2'};
-            msg.PrepareWitnessInvocationScripts[4] = null;
-            msg.PrepareWitnessInvocationScripts[5] = null;
-            msg.PrepareWitnessInvocationScripts[6] = new [] {(byte)'3', (byte)'!'};
 
             var copiedMsg = TestUtils.CopyMsgBySerialization(msg, new RecoveryMessage());;
 
-            copiedMsg.ChangeViewWitnessInvocationScripts.ShouldAllBeEquivalentTo(msg.ChangeViewWitnessInvocationScripts);
-            copiedMsg.ChangeViewTimestamps.ShouldAllBeEquivalentTo(msg.ChangeViewTimestamps);
-            copiedMsg.OriginalChangeViewNumbers.ShouldAllBeEquivalentTo(msg.OriginalChangeViewNumbers);
+            copiedMsg.ChangeViewMessages.ShouldAllBeEquivalentTo(msg.ChangeViewMessages);
             copiedMsg.PreparationHash.Should().Be(msg.PreparationHash);
-            copiedMsg.PrepareWitnessInvocationScripts.ShouldAllBeEquivalentTo(msg.PrepareWitnessInvocationScripts);
-            (copiedMsg.CommitSignatures == null).Should().Be(true);
+            copiedMsg.PreparationMessages.ShouldAllBeEquivalentTo(msg.PreparationMessages);
+            copiedMsg.CommitMessages.Count.Should().Be(0);
         }
 
         [TestMethod]
         public void TestSerializeAndDeserializeRecoveryMessageWithChangeViewsAndPrepareRequest()
         {
-            var msg = new RecoveryMessage();
-            msg.ChangeViewWitnessInvocationScripts = new byte[7][];
-            msg.ChangeViewWitnessInvocationScripts[0] = new [] {(byte) 'A'};
-            msg.ChangeViewWitnessInvocationScripts[1] = new [] {(byte) 'B'};
-            msg.ChangeViewWitnessInvocationScripts[2] = null;
-            msg.ChangeViewWitnessInvocationScripts[3] = new [] {(byte) 'C'};
-            msg.ChangeViewWitnessInvocationScripts[4] = null;
-            msg.ChangeViewWitnessInvocationScripts[5] = null;
-            msg.ChangeViewWitnessInvocationScripts[6] = new [] {(byte) 'D'};
-            msg.ChangeViewTimestamps = new uint[7];
-            msg.ChangeViewTimestamps[0] = 6;
-            msg.ChangeViewTimestamps[1] = 5;
-            msg.ChangeViewTimestamps[2] = 4;
-            msg.ChangeViewTimestamps[3] = 3;
-            msg.ChangeViewTimestamps[4] = uint.MaxValue;
-            msg.ChangeViewTimestamps[5] = 2;
-            msg.ChangeViewTimestamps[6] = 1;
-            msg.OriginalChangeViewNumbers = new byte[7];
-            msg.OriginalChangeViewNumbers[0] = 9;
-            msg.OriginalChangeViewNumbers[1] = 7;
-            msg.OriginalChangeViewNumbers[2] = 6;
-            msg.OriginalChangeViewNumbers[3] = 5;
-            msg.OriginalChangeViewNumbers[4] = 4;
-            msg.OriginalChangeViewNumbers[5] = 3;
-            msg.OriginalChangeViewNumbers[6] = 2;
-            int txCountToInlcude = 5;
-            var prepareRequest = new PrepareRequest();
-            prepareRequest.TransactionHashes = new UInt256[txCountToInlcude];
-            Transaction[] txs = new Transaction[txCountToInlcude];
+            Transaction[] txs = new Transaction[5];
             txs[0] = TestUtils.CreateRandomMockMinerTransaction().Object;
-            prepareRequest.TransactionHashes[0] = txs[0].Hash;
-            for (int i = 1; i < txCountToInlcude; i++)
-            {
+            for (int i = 1; i < txs.Length; i++)
                 txs[i] = TestUtils.CreateRandomHashInvocationMockTransaction().Object;
-                prepareRequest.TransactionHashes[i] = txs[i].Hash;
-            }
-            prepareRequest.Nonce = UInt64.MaxValue;
-            prepareRequest.NextConsensus = UInt160.Parse("5555AAAA5555AAAA5555AAAA5555AAAA5555AAAA");
-            prepareRequest.MinerTransaction = (MinerTransaction) txs[0];
-            msg.PrepareRequestMessage = prepareRequest;
-            msg.PrepareWitnessInvocationScripts = new byte[7][];
-            msg.PrepareWitnessInvocationScripts[0] = new [] {(byte)'t', (byte)'e'};
-            msg.PrepareWitnessInvocationScripts[1] = new [] {(byte)'s', (byte)'t'};
-            msg.PrepareWitnessInvocationScripts[2] = null;
-            msg.PrepareWitnessInvocationScripts[3] = new [] {(byte)'1', (byte)'2'};
-            msg.PrepareWitnessInvocationScripts[4] = null;
-            msg.PrepareWitnessInvocationScripts[5] = null;
-            msg.PrepareWitnessInvocationScripts[6] = null;
+            var msg = new RecoveryMessage
+            {
+                ChangeViewMessages = new Dictionary<ushort, RecoveryMessage.ChangeViewPayloadCompact>()
+                {
+                    {
+                        0,
+                        new RecoveryMessage.ChangeViewPayloadCompact
+                        {
+                            ValidatorIndex = 0,
+                            OriginalViewNumber = 9,
+                            Timestamp = 6,
+                            InvocationScript = new[] { (byte)'A' }
+                        }
+                    },
+                    {
+                        1,
+                        new RecoveryMessage.ChangeViewPayloadCompact
+                        {
+                            ValidatorIndex = 1,
+                            OriginalViewNumber = 7,
+                            Timestamp = 5,
+                            InvocationScript = new[] { (byte)'B' }
+                        }
+                    },
+                    {
+                        3,
+                        new RecoveryMessage.ChangeViewPayloadCompact
+                        {
+                            ValidatorIndex = 3,
+                            OriginalViewNumber = 5,
+                            Timestamp = 3,
+                            InvocationScript = new[] { (byte)'C' }
+                        }
+                    },
+                    {
+                        6,
+                        new RecoveryMessage.ChangeViewPayloadCompact
+                        {
+                            ValidatorIndex = 6,
+                            OriginalViewNumber = 2,
+                            Timestamp = 1,
+                            InvocationScript = new[] { (byte)'D' }
+                        }
+                    }
+                },
+                PrepareRequestMessage = new PrepareRequest
+                {
+                    TransactionHashes = txs.Select(p => p.Hash).ToArray(),
+                    Nonce = ulong.MaxValue,
+                    NextConsensus = UInt160.Parse("5555AAAA5555AAAA5555AAAA5555AAAA5555AAAA"),
+                    MinerTransaction = (MinerTransaction)txs[0]
+                },
+                PreparationHash = new UInt256(Crypto.Default.Hash256(new[] { (byte)'a' })),
+                PreparationMessages = new Dictionary<ushort, RecoveryMessage.PreparationPayloadCompact>()
+                {
+                    {
+                        0,
+                        new RecoveryMessage.PreparationPayloadCompact
+                        {
+                            ValidatorIndex = 0,
+                            InvocationScript = new[] { (byte)'t', (byte)'e' }
+                        }
+                    },
+                    {
+                        1,
+                        new RecoveryMessage.PreparationPayloadCompact
+                        {
+                            ValidatorIndex = 1,
+                            InvocationScript = new[] { (byte)'s', (byte)'t' }
+                        }
+                    },
+                    {
+                        3,
+                        new RecoveryMessage.PreparationPayloadCompact
+                        {
+                            ValidatorIndex = 3,
+                            InvocationScript = new[] { (byte)'1', (byte)'2' }
+                        }
+                    }
+                },
+                CommitMessages = new Dictionary<ushort, RecoveryMessage.CommitPayloadCompact>()
+            };
 
             var copiedMsg = TestUtils.CopyMsgBySerialization(msg, new RecoveryMessage());;
 
-            copiedMsg.ChangeViewWitnessInvocationScripts.ShouldAllBeEquivalentTo(msg.ChangeViewWitnessInvocationScripts);
-            copiedMsg.ChangeViewTimestamps.ShouldAllBeEquivalentTo(msg.ChangeViewTimestamps);
+            copiedMsg.ChangeViewMessages.ShouldAllBeEquivalentTo(msg.ChangeViewMessages);
             copiedMsg.PrepareRequestMessage.ShouldBeEquivalentTo(msg.PrepareRequestMessage);
             copiedMsg.PreparationHash.Should().Be(null);
-            copiedMsg.PrepareWitnessInvocationScripts.ShouldAllBeEquivalentTo(msg.PrepareWitnessInvocationScripts);
-            (copiedMsg.CommitSignatures == null).Should().Be(true);
+            copiedMsg.PreparationMessages.ShouldAllBeEquivalentTo(msg.PreparationMessages);
+            copiedMsg.CommitMessages.Count.Should().Be(0);
         }
 
         [TestMethod]
         public void TestSerializeAndDeserializeRecoveryMessageWithoutChangeViewsWithoutCommits()
         {
-            var msg = new RecoveryMessage();
-            int txCountToInlcude = 5;
-            var prepareRequest = new PrepareRequest();
-            prepareRequest.TransactionHashes = new UInt256[txCountToInlcude];
-            Transaction[] txs = new Transaction[txCountToInlcude];
+            Transaction[] txs = new Transaction[5];
             txs[0] = TestUtils.CreateRandomMockMinerTransaction().Object;
-            prepareRequest.TransactionHashes[0] = txs[0].Hash;
-            for (int i = 1; i < txCountToInlcude; i++)
-            {
+            for (int i = 1; i < txs.Length; i++)
                 txs[i] = TestUtils.CreateRandomHashInvocationMockTransaction().Object;
-                prepareRequest.TransactionHashes[i] = txs[i].Hash;
-            }
-            prepareRequest.Nonce = UInt64.MaxValue;
-            prepareRequest.NextConsensus = UInt160.Parse("5555AAAA5555AAAA5555AAAA5555AAAA5555AAAA");
-            prepareRequest.MinerTransaction = (MinerTransaction) txs[0];
-            msg.PrepareRequestMessage = prepareRequest;
-            msg.PrepareWitnessInvocationScripts = new byte[7][];
-            msg.PrepareWitnessInvocationScripts[0] = new [] {(byte)'t', (byte)'e'};
-            msg.PrepareWitnessInvocationScripts[1] = new [] {(byte)'s', (byte)'t'};
-            msg.PrepareWitnessInvocationScripts[2] = null;
-            msg.PrepareWitnessInvocationScripts[3] = new [] {(byte)'1', (byte)'2'};
-            msg.PrepareWitnessInvocationScripts[4] = null;
-            msg.PrepareWitnessInvocationScripts[5] = null;
-            msg.PrepareWitnessInvocationScripts[6] = new [] {(byte)'3', (byte)'!'};
+            var msg = new RecoveryMessage
+            {
+                ChangeViewMessages = new Dictionary<ushort, RecoveryMessage.ChangeViewPayloadCompact>(),
+                PrepareRequestMessage = new PrepareRequest
+                {
+                    TransactionHashes = txs.Select(p => p.Hash).ToArray(),
+                    Nonce = ulong.MaxValue,
+                    NextConsensus = UInt160.Parse("5555AAAA5555AAAA5555AAAA5555AAAA5555AAAA"),
+                    MinerTransaction = (MinerTransaction)txs[0]
+                },
+                PreparationMessages = new Dictionary<ushort, RecoveryMessage.PreparationPayloadCompact>()
+                {
+                    {
+                        0,
+                        new RecoveryMessage.PreparationPayloadCompact
+                        {
+                            ValidatorIndex = 0,
+                            InvocationScript = new[] { (byte)'t', (byte)'e' }
+                        }
+                    },
+                    {
+                        1,
+                        new RecoveryMessage.PreparationPayloadCompact
+                        {
+                            ValidatorIndex = 1,
+                            InvocationScript = new[] { (byte)'s', (byte)'t' }
+                        }
+                    },
+                    {
+                        3,
+                        new RecoveryMessage.PreparationPayloadCompact
+                        {
+                            ValidatorIndex = 3,
+                            InvocationScript = new[] { (byte)'1', (byte)'2' }
+                        }
+                    },
+                    {
+                        6,
+                        new RecoveryMessage.PreparationPayloadCompact
+                        {
+                            ValidatorIndex = 6,
+                            InvocationScript = new[] { (byte)'3', (byte)'!' }
+                        }
+                    }
+                },
+                CommitMessages = new Dictionary<ushort, RecoveryMessage.CommitPayloadCompact>()
+            };
 
             var copiedMsg = TestUtils.CopyMsgBySerialization(msg, new RecoveryMessage());;
 
-            copiedMsg.ChangeViewWitnessInvocationScripts.ShouldAllBeEquivalentTo(null);
-            copiedMsg.ChangeViewTimestamps.ShouldAllBeEquivalentTo(null);
+            copiedMsg.ChangeViewMessages.Count.Should().Be(0);
             copiedMsg.PrepareRequestMessage.ShouldBeEquivalentTo(msg.PrepareRequestMessage);
             copiedMsg.PreparationHash.Should().Be(null);
-            copiedMsg.PrepareWitnessInvocationScripts.ShouldAllBeEquivalentTo(msg.PrepareWitnessInvocationScripts);
-            (copiedMsg.CommitSignatures == null).Should().Be(true);
+            copiedMsg.PreparationMessages.ShouldAllBeEquivalentTo(msg.PreparationMessages);
+            copiedMsg.CommitMessages.Count.Should().Be(0);
         }
 
         [TestMethod]
         public void TestSerializeAndDeserializeRecoveryMessageWithoutChangeViewsWithCommits()
         {
-            var msg = new RecoveryMessage();
-            int txCountToInlcude = 5;
-            var prepareRequest = new PrepareRequest();
-            prepareRequest.TransactionHashes = new UInt256[txCountToInlcude];
-            Transaction[] txs = new Transaction[txCountToInlcude];
+            Transaction[] txs = new Transaction[5];
             txs[0] = TestUtils.CreateRandomMockMinerTransaction().Object;
-            prepareRequest.TransactionHashes[0] = txs[0].Hash;
-            for (int i = 1; i < txCountToInlcude; i++)
-            {
+            for (int i = 1; i < txs.Length; i++)
                 txs[i] = TestUtils.CreateRandomHashInvocationMockTransaction().Object;
-                prepareRequest.TransactionHashes[i] = txs[i].Hash;
-            }
-            prepareRequest.Nonce = UInt64.MaxValue;
-            prepareRequest.NextConsensus = UInt160.Parse("5555AAAA5555AAAA5555AAAA5555AAAA5555AAAA");
-            prepareRequest.MinerTransaction = (MinerTransaction) txs[0];
-            msg.PrepareRequestMessage = prepareRequest;
-            msg.PrepareWitnessInvocationScripts = new byte[7][];
-            msg.PrepareWitnessInvocationScripts[0] = new [] {(byte)'t', (byte)'e'};
-            msg.PrepareWitnessInvocationScripts[1] = new [] {(byte)'s', (byte)'t'};
-            msg.PrepareWitnessInvocationScripts[2] = null;
-            msg.PrepareWitnessInvocationScripts[3] = new [] {(byte)'1', (byte)'2'};
-            msg.PrepareWitnessInvocationScripts[4] = null;
-            msg.PrepareWitnessInvocationScripts[5] = null;
-            msg.PrepareWitnessInvocationScripts[6] = new [] {(byte)'3', (byte)'!'};
-            msg.CommitSignatures = new byte[7][];
-            msg.CommitSignatures[0] = null;
-            msg.CommitSignatures[1] = new [] {(byte)'1', (byte)'2'};
-            msg.CommitSignatures[6] = new [] {(byte)'3', (byte)'D', (byte)'R', (byte)'I', (byte)'N', (byte)'K'};
+            var msg = new RecoveryMessage
+            {
+                ChangeViewMessages = new Dictionary<ushort, RecoveryMessage.ChangeViewPayloadCompact>(),
+                PrepareRequestMessage = new PrepareRequest
+                {
+                    TransactionHashes = txs.Select(p => p.Hash).ToArray(),
+                    Nonce = ulong.MaxValue,
+                    NextConsensus = UInt160.Parse("5555AAAA5555AAAA5555AAAA5555AAAA5555AAAA"),
+                    MinerTransaction = (MinerTransaction)txs[0]
+                },
+                PreparationMessages = new Dictionary<ushort, RecoveryMessage.PreparationPayloadCompact>()
+                {
+                    {
+                        0,
+                        new RecoveryMessage.PreparationPayloadCompact
+                        {
+                            ValidatorIndex = 0,
+                            InvocationScript = new[] { (byte)'t', (byte)'e' }
+                        }
+                    },
+                    {
+                        1,
+                        new RecoveryMessage.PreparationPayloadCompact
+                        {
+                            ValidatorIndex = 1,
+                            InvocationScript = new[] { (byte)'s', (byte)'t' }
+                        }
+                    },
+                    {
+                        3,
+                        new RecoveryMessage.PreparationPayloadCompact
+                        {
+                            ValidatorIndex = 3,
+                            InvocationScript = new[] { (byte)'1', (byte)'2' }
+                        }
+                    },
+                    {
+                        6,
+                        new RecoveryMessage.PreparationPayloadCompact
+                        {
+                            ValidatorIndex = 6,
+                            InvocationScript = new[] { (byte)'3', (byte)'!' }
+                        }
+                    }
+                },
+                CommitMessages = new Dictionary<ushort, RecoveryMessage.CommitPayloadCompact>
+                {
+                    {
+                        1,
+                        new RecoveryMessage.CommitPayloadCompact
+                        {
+                            ValidatorIndex = 1,
+                            Signature = new byte[64] { (byte)'1', (byte)'2', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }
+                        }
+                    },
+                    {
+                        6,
+                        new RecoveryMessage.CommitPayloadCompact
+                        {
+                            ValidatorIndex = 6,
+                            Signature = new byte[64] { (byte)'3', (byte)'D', (byte)'R', (byte)'I', (byte)'N', (byte)'K', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }
+                        }
+                    }
+                }
+            };
 
             var copiedMsg = TestUtils.CopyMsgBySerialization(msg, new RecoveryMessage());;
 
-            copiedMsg.ChangeViewWitnessInvocationScripts.ShouldAllBeEquivalentTo(null);
-            copiedMsg.ChangeViewTimestamps.ShouldAllBeEquivalentTo(null);
+            copiedMsg.ChangeViewMessages.Count.Should().Be(0);
             copiedMsg.PrepareRequestMessage.ShouldBeEquivalentTo(msg.PrepareRequestMessage);
             copiedMsg.PreparationHash.Should().Be(null);
-            copiedMsg.PrepareWitnessInvocationScripts.ShouldAllBeEquivalentTo(msg.PrepareWitnessInvocationScripts);
-            copiedMsg.CommitSignatures.ShouldAllBeEquivalentTo(msg.CommitSignatures);
+            copiedMsg.PreparationMessages.ShouldAllBeEquivalentTo(msg.PreparationMessages);
+            copiedMsg.CommitMessages.ShouldAllBeEquivalentTo(msg.CommitMessages);
         }
     }
 }

--- a/neo/Consensus/ConsensusContext.cs
+++ b/neo/Consensus/ConsensusContext.cs
@@ -254,13 +254,13 @@ namespace Neo.Consensus
             }
             return MakeSignedPayload(new RecoveryMessage()
             {
-                ChangeViewMessages = (changeViewPayloads ?? new ConsensusPayload[0]).Where(p => p != null).Select(p => RecoveryMessage.ChangeViewPayloadCompact.FromPayload(p)).ToDictionary(p => p.ValidatorIndex),
+                ChangeViewMessages = (changeViewPayloads ?? new ConsensusPayload[0]).Where(p => p != null).Select(p => RecoveryMessage.ChangeViewPayloadCompact.FromPayload(p)).ToDictionary(p => (int)p.ValidatorIndex),
                 PrepareRequestMessage = prepareRequestMessage,
                 // We only need a PreparationHash set if we don't have the PrepareRequest information.
                 PreparationHash = TransactionHashes == null ? PreparationPayloads.Where(p => p != null).GroupBy(p => p.GetDeserializedMessage<PrepareResponse>().PreparationHash, (k, g) => new { Hash = k, Count = g.Count() }).OrderByDescending(p => p.Count).Select(p => p.Hash).FirstOrDefault() : null,
-                PreparationMessages = PreparationPayloads.Where(p => p != null).Select(p => RecoveryMessage.PreparationPayloadCompact.FromPayload(p)).ToDictionary(p => p.ValidatorIndex),
+                PreparationMessages = PreparationPayloads.Where(p => p != null).Select(p => RecoveryMessage.PreparationPayloadCompact.FromPayload(p)).ToDictionary(p => (int)p.ValidatorIndex),
                 CommitMessages = State.HasFlag(ConsensusState.CommitSent)
-                    ? Commits.Select((s, i) => new RecoveryMessage.CommitPayloadCompact { Signature = s, ValidatorIndex = (ushort)i }).Where(p => p.Signature != null).ToDictionary(p => p.ValidatorIndex)
+                    ? Commits.Select((s, i) => new RecoveryMessage.CommitPayloadCompact { Signature = s, ValidatorIndex = (ushort)i }).Where(p => p.Signature != null).ToDictionary(p => (int)p.ValidatorIndex)
                     : null
             });
         }

--- a/neo/Consensus/RecoveryMessage.ChangeViewPayloadCompact.cs
+++ b/neo/Consensus/RecoveryMessage.ChangeViewPayloadCompact.cs
@@ -1,0 +1,51 @@
+﻿using Neo.IO;
+using Neo.Network.P2P.Payloads;
+using System.IO;
+
+namespace Neo.Consensus
+{
+    partial class RecoveryMessage
+    {
+        public class ChangeViewPayloadCompact : ISerializable
+        {
+            public ushort ValidatorIndex;
+            public byte OriginalViewNumber;
+            public uint Timestamp;
+            public byte[] InvocationScript;
+
+            int ISerializable.Size =>
+                sizeof(ushort) +                //ValidatorIndex
+                sizeof(byte) +                  //OriginalViewNumber
+                sizeof(uint) +                  //Timestamp
+                InvocationScript.GetVarSize();  //InvocationScript
+
+            void ISerializable.Deserialize(BinaryReader reader)
+            {
+                ValidatorIndex = reader.ReadUInt16();
+                OriginalViewNumber = reader.ReadByte();
+                Timestamp = reader.ReadUInt32();
+                InvocationScript = reader.ReadVarBytes(1024);
+            }
+
+            public static ChangeViewPayloadCompact FromPayload(ConsensusPayload payload)
+            {
+                ChangeView message = payload.GetDeserializedMessage<ChangeView>();
+                return new ChangeViewPayloadCompact
+                {
+                    ValidatorIndex = payload.ValidatorIndex,
+                    OriginalViewNumber = message.ViewNumber,
+                    Timestamp = message.Timestamp,
+                    InvocationScript = payload.Witness.InvocationScript
+                };
+            }
+
+            void ISerializable.Serialize(BinaryWriter writer)
+            {
+                writer.Write(ValidatorIndex);
+                writer.Write(OriginalViewNumber);
+                writer.Write(Timestamp);
+                writer.WriteVarBytes(InvocationScript);
+            }
+        }
+    }
+}

--- a/neo/Consensus/RecoveryMessage.CommitPayloadCompact.cs
+++ b/neo/Consensus/RecoveryMessage.CommitPayloadCompact.cs
@@ -1,0 +1,42 @@
+﻿using Neo.IO;
+using Neo.Network.P2P.Payloads;
+using System.IO;
+
+namespace Neo.Consensus
+{
+    partial class RecoveryMessage
+    {
+        public class CommitPayloadCompact : ISerializable
+        {
+            public ushort ValidatorIndex;
+            public byte[] Signature;
+            //public byte[] InvocationScript;
+
+            int ISerializable.Size =>
+                sizeof(ushort) +    //ValidatorIndex
+                Signature.Length;   //Signature
+
+            void ISerializable.Deserialize(BinaryReader reader)
+            {
+                ValidatorIndex = reader.ReadUInt16();
+                Signature = reader.ReadBytes(64);
+            }
+
+            public static CommitPayloadCompact FromPayload(ConsensusPayload payload)
+            {
+                Commit message = payload.GetDeserializedMessage<Commit>();
+                return new CommitPayloadCompact
+                {
+                    ValidatorIndex = payload.ValidatorIndex,
+                    Signature = message.Signature,
+                };
+            }
+
+            void ISerializable.Serialize(BinaryWriter writer)
+            {
+                writer.Write(ValidatorIndex);
+                writer.Write(Signature);
+            }
+        }
+    }
+}

--- a/neo/Consensus/RecoveryMessage.PreparationPayloadCompact.cs
+++ b/neo/Consensus/RecoveryMessage.PreparationPayloadCompact.cs
@@ -1,0 +1,40 @@
+﻿using Neo.IO;
+using Neo.Network.P2P.Payloads;
+using System.IO;
+
+namespace Neo.Consensus
+{
+    partial class RecoveryMessage
+    {
+        public class PreparationPayloadCompact : ISerializable
+        {
+            public ushort ValidatorIndex;
+            public byte[] InvocationScript;
+
+            int ISerializable.Size =>
+                sizeof(ushort) +                //ValidatorIndex
+                InvocationScript.GetVarSize();  //InvocationScript
+
+            void ISerializable.Deserialize(BinaryReader reader)
+            {
+                ValidatorIndex = reader.ReadUInt16();
+                InvocationScript = reader.ReadVarBytes(1024);
+            }
+
+            public static PreparationPayloadCompact FromPayload(ConsensusPayload payload)
+            {
+                return new PreparationPayloadCompact
+                {
+                    ValidatorIndex = payload.ValidatorIndex,
+                    InvocationScript = payload.Witness.InvocationScript
+                };
+            }
+
+            void ISerializable.Serialize(BinaryWriter writer)
+            {
+                writer.Write(ValidatorIndex);
+                writer.WriteVarBytes(InvocationScript);
+            }
+        }
+    }
+}

--- a/neo/Consensus/RecoveryMessage.cs
+++ b/neo/Consensus/RecoveryMessage.cs
@@ -8,13 +8,13 @@ namespace Neo.Consensus
 {
     internal partial class RecoveryMessage : ConsensusMessage
     {
-        public Dictionary<ushort, ChangeViewPayloadCompact> ChangeViewMessages;
+        public Dictionary<int, ChangeViewPayloadCompact> ChangeViewMessages;
         public PrepareRequest PrepareRequestMessage;
         /// The PreparationHash in case the PrepareRequest hasn't been received yet.
         /// This can be null if the PrepareRequest information is present, since it can be derived in that case.
         public UInt256 PreparationHash;
-        public Dictionary<ushort, PreparationPayloadCompact> PreparationMessages;
-        public Dictionary<ushort, CommitPayloadCompact> CommitMessages;
+        public Dictionary<int, PreparationPayloadCompact> PreparationMessages;
+        public Dictionary<int, CommitPayloadCompact> CommitMessages;
 
         public RecoveryMessage() : base(ConsensusMessageType.RecoveryMessage)
         {
@@ -23,13 +23,13 @@ namespace Neo.Consensus
         public override void Deserialize(BinaryReader reader)
         {
             base.Deserialize(reader);
-            ChangeViewMessages = reader.ReadSerializableArray<ChangeViewPayloadCompact>(Blockchain.MaxValidators).ToDictionary(p => p.ValidatorIndex);
+            ChangeViewMessages = reader.ReadSerializableArray<ChangeViewPayloadCompact>(Blockchain.MaxValidators).ToDictionary(p => (int)p.ValidatorIndex);
             if (reader.ReadBoolean())
                 PrepareRequestMessage = reader.ReadSerializable<PrepareRequest>();
             else
                 PreparationHash = reader.ReadSerializable<UInt256>();
-            PreparationMessages = reader.ReadSerializableArray<PreparationPayloadCompact>(Blockchain.MaxValidators).ToDictionary(p => p.ValidatorIndex);
-            CommitMessages = reader.ReadSerializableArray<CommitPayloadCompact>(Blockchain.MaxValidators).ToDictionary(p => p.ValidatorIndex);
+            PreparationMessages = reader.ReadSerializableArray<PreparationPayloadCompact>(Blockchain.MaxValidators).ToDictionary(p => (int)p.ValidatorIndex);
+            CommitMessages = reader.ReadSerializableArray<CommitPayloadCompact>(Blockchain.MaxValidators).ToDictionary(p => (int)p.ValidatorIndex);
         }
 
         public override void Serialize(BinaryWriter writer)

--- a/neo/Consensus/RecoveryMessage.cs
+++ b/neo/Consensus/RecoveryMessage.cs
@@ -1,20 +1,20 @@
-﻿using System.IO;
-using Neo.IO;
+﻿using Neo.IO;
+using Neo.Ledger;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 
 namespace Neo.Consensus
 {
-    internal class RecoveryMessage : ConsensusMessage
+    internal partial class RecoveryMessage : ConsensusMessage
     {
-        public byte[][] ChangeViewWitnessInvocationScripts;
-        public uint[] ChangeViewTimestamps;
-        public byte[] OriginalChangeViewNumbers;
+        public Dictionary<ushort, ChangeViewPayloadCompact> ChangeViewMessages;
         public PrepareRequest PrepareRequestMessage;
-
         /// The PreparationHash in case the PrepareRequest hasn't been received yet.
         /// This can be null if the PrepareRequest information is present, since it can be derived in that case.
         public UInt256 PreparationHash;
-        public byte[][] PrepareWitnessInvocationScripts;
-        public byte[][] CommitSignatures;
+        public Dictionary<ushort, PreparationPayloadCompact> PreparationMessages;
+        public Dictionary<ushort, CommitPayloadCompact> CommitMessages;
 
         public RecoveryMessage() : base(ConsensusMessageType.RecoveryMessage)
         {
@@ -23,42 +23,27 @@ namespace Neo.Consensus
         public override void Deserialize(BinaryReader reader)
         {
             base.Deserialize(reader);
-            ChangeViewWitnessInvocationScripts = reader.ReadVarBytesArray();
-            if (ChangeViewWitnessInvocationScripts != null)
-            {
-                ChangeViewTimestamps = reader.ReadUIntArray(ChangeViewWitnessInvocationScripts.Length);
-                OriginalChangeViewNumbers = reader.ReadVarBytes(ConsensusService.MaxValidatorsCount);
-            }
-
-            if (reader.ReadBoolean()) PrepareRequestMessage = reader.ReadSerializable<PrepareRequest>();
-            PreparationHash = reader.ReadVarInt(32) == 0 ? null : reader.ReadSerializable<UInt256>();
-            PrepareWitnessInvocationScripts = reader.ReadVarBytesArray(ConsensusService.MaxValidatorsCount);
-            CommitSignatures = reader.ReadVarBytesArray(ConsensusService.MaxValidatorsCount);
+            ChangeViewMessages = reader.ReadSerializableArray<ChangeViewPayloadCompact>(Blockchain.MaxValidators).ToDictionary(p => p.ValidatorIndex);
+            if (reader.ReadBoolean())
+                PrepareRequestMessage = reader.ReadSerializable<PrepareRequest>();
+            else
+                PreparationHash = reader.ReadSerializable<UInt256>();
+            PreparationMessages = reader.ReadSerializableArray<PreparationPayloadCompact>(Blockchain.MaxValidators).ToDictionary(p => p.ValidatorIndex);
+            CommitMessages = reader.ReadSerializableArray<CommitPayloadCompact>(Blockchain.MaxValidators).ToDictionary(p => p.ValidatorIndex);
         }
 
         public override void Serialize(BinaryWriter writer)
         {
             base.Serialize(writer);
-            writer.WriteVarBytesArray(ChangeViewWitnessInvocationScripts);
-            if (ChangeViewWitnessInvocationScripts != null)
-            {
-                writer.Write(ChangeViewTimestamps);
-                writer.WriteVarBytes(OriginalChangeViewNumbers);
-            }
-
+            writer.Write(ChangeViewMessages.Values.ToArray());
             bool hasPrepareRequestMessage = PrepareRequestMessage != null;
             writer.Write(hasPrepareRequestMessage);
             if (hasPrepareRequestMessage)
                 writer.Write(PrepareRequestMessage);
-            if (PreparationHash == null)
-                writer.WriteVarInt(0);
             else
-            {
-                writer.WriteVarInt(PreparationHash.Size);
                 writer.Write(PreparationHash);
-            }
-            writer.WriteVarBytesArray(PrepareWitnessInvocationScripts);
-            writer.WriteVarBytesArray(CommitSignatures);
+            writer.Write(PreparationMessages.Values.ToArray());
+            writer.Write(CommitMessages.Values.ToArray());
         }
     }
 }

--- a/neo/IO/Helper.cs
+++ b/neo/IO/Helper.cs
@@ -129,38 +129,9 @@ namespace Neo.IO
             return array;
         }
 
-        public static uint[] ReadUIntArray(this BinaryReader reader, int max = 0x1000000)
-        {
-            uint[] array = new uint[reader.ReadVarInt((ulong) max)];
-            for (int i = 0; i < array.Length; i++) array[i] = reader.ReadUInt32();
-            return array;
-        }
-
         public static byte[] ReadVarBytes(this BinaryReader reader, int max = 0x1000000)
         {
             return reader.ReadBytes((int)reader.ReadVarInt((ulong)max));
-        }
-
-        public static byte[][] ReadVarBytesArray(this BinaryReader reader, int maxItems=255, int maxItemLen = 1024,
-            bool shouldReturnNullIfEmpty=true)
-        {
-            int items = (int) reader.ReadVarInt((ulong)maxItems);
-            if (items > 0)
-            {
-                byte[][] output = new byte[items][];
-                for (int i = 0; i < items; i++)
-                {
-                    int bytes = (int) reader.ReadVarInt((ulong)maxItemLen);
-                    if (bytes == 0)
-                        output[i] = null;
-                    else
-                        output[i] = reader.ReadBytes(bytes);
-                }
-
-                return output;
-            }
-
-            return shouldReturnNullIfEmpty ? null : new byte[0][];
         }
 
         public static ulong ReadVarInt(this BinaryReader reader, ulong max = ulong.MaxValue)
@@ -211,12 +182,6 @@ namespace Neo.IO
             value.Serialize(writer);
         }
 
-        public static void Write(this BinaryWriter writer, uint[] values)
-        {
-            writer.WriteVarInt(values.Length);
-            foreach (var val in values) writer.Write(val);
-        }
-
         public static void Write<T>(this BinaryWriter writer, T[] value) where T : ISerializable
         {
             writer.WriteVarInt(value.Length);
@@ -264,23 +229,6 @@ namespace Neo.IO
         {
             writer.WriteVarInt(value.Length);
             writer.Write(value);
-        }
-
-        public static void WriteVarBytesArray(this BinaryWriter writer, byte[][] values)
-        {
-            if (values == null)
-                writer.WriteVarInt(0);
-            else
-            {
-                writer.WriteVarInt(values.Length);
-                foreach (var value in values)
-                {
-                    if (value == null)
-                        writer.WriteVarInt(0);
-                    else
-                        writer.WriteVarBytes(value);
-                }
-            }
         }
 
         public static void WriteVarInt(this BinaryWriter writer, long value)

--- a/neo/Ledger/Blockchain.cs
+++ b/neo/Ledger/Blockchain.cs
@@ -27,7 +27,7 @@ namespace Neo.Ledger
 
         public static readonly uint SecondsPerBlock = ProtocolSettings.Default.SecondsPerBlock;
         public const uint DecrementInterval = 2000000;
-        public const uint MaxValidators = 1024;
+        public const int MaxValidators = 1024;
         public static readonly uint[] GenerationAmount = { 8, 7, 6, 5, 4, 3, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 };
         public static readonly TimeSpan TimePerBlock = TimeSpan.FromSeconds(SecondsPerBlock);
         public static readonly ECPoint[] StandbyValidators = ProtocolSettings.Default.StandbyValidators.OfType<string>().Select(p => ECPoint.DecodePoint(p.HexToBytes(), ECCurve.Secp256r1)).ToArray();


### PR DESCRIPTION
I've created three sub classes for `RecoveryMessage` to simplify it:

- RecoveryMessage.ChangeViewPayloadCompact
- RecoveryMessage.PreparationPayloadCompact
- RecoveryMessage.CommitPayloadCompact