### PR TITLE
Fix accepting own prepare request. 

### DIFF
--- a/neo/Consensus/ConsensusContext.cs
+++ b/neo/Consensus/ConsensusContext.cs
@@ -372,8 +372,6 @@ namespace Neo.Consensus
 
         public bool VerifyRequest()
         {
-            if (!State.HasFlag(ConsensusState.RequestReceived))
-                return false;
             if (!Blockchain.GetConsensusAddress(Snapshot.GetValidators(Transactions.Values).ToArray()).Equals(NextConsensus))
                 return false;
             Transaction minerTx = Transactions.Values.FirstOrDefault(p => p.Type == TransactionType.MinerTransaction);


### PR DESCRIPTION
Testing showed the primary was still changing view too soon when recovering it's own prepare request after the merge of #594

```
[18:51:28.234] initialize: height=22 view=4 index=2 role=Primary
[18:51:28.235] Attempt recover of prepare request from index=2
[18:51:28.236] OnPrepareRequestReceived: height=22 view=4 index=2 tx=1
[18:51:28.263] request change view: height=22 view=4 nv=5 state=Primary, RequestSent, ViewChanging
```

The check in `VerifyRequest()` needed to either check additionally for whether the request was sent in addition to being received or just have these checks removed. I checked all places this is called, and it is just from `AddTransaction`, and all places that call `AddTransaction` already have verified that either the `RequestSent` or the `RequestReceived` flags are sent. So the check can just be removed inside of `VerifyRequest()`.
