### PR TITLE
Wait for ActorSystem termination before returning from Dispose() of NeoSystem.

### DIFF
--- a/neo/NeoSystem.cs
+++ b/neo/NeoSystem.cs
@@ -42,7 +42,9 @@ namespace Neo
         {
             RpcServer?.Dispose();
             EnsureStoped(LocalNode);
+            // Dispose will call ActorSystem.Terminate()
             ActorSystem.Dispose();
+            ActorSystem.WhenTerminated.Wait();
         }
 
         public void EnsureStoped(IActorRef actor)


### PR DESCRIPTION
Fixes #603 
When using a pattern such as the following:

```
using (var store = new LevelDBStore(path))
using (var system = new NeoSystem(store)) {
    ...
}
```

The store needs to wait to be disposed until after the `ActorSystem` termination. This implements that.

Also, `neo-cli` was plagued by the same issue since it did the following on shutdown:
```
system.Dispose();
store.Dispose();
```

Fixes #607 