### PR TITLE
Reset Block reference in context after block persisted

### DIFF
--- a/neo/Consensus/ConsensusContext.cs
+++ b/neo/Consensus/ConsensusContext.cs
@@ -232,6 +232,7 @@ namespace Neo.Consensus
         {
             if (viewNumber == 0)
             {
+                Block = null;
                 Snapshot?.Dispose();
                 Snapshot = Blockchain.Singleton.GetSnapshot();
                 PrevHash = Snapshot.CurrentBlockHash;


### PR DESCRIPTION
#604 added a reference to the block being persisted in the `ConsensusContext`. Resetting the block reference back to null was overlooked during review. I was going to push this small adjustment directly on the `constnesus/improved_dbft` branch, but it seems something is broken with Travis and permissions on the branch:
```
remote: error: GH006: Protected branch update failed for refs/heads/consensus/improved_dbft.
remote: error: Required status check "continuous-integration/travis-ci" is expected.
```
So I opened this PR instead for the one line change.