### PR TITLE
Support backward compatibility with older consensus payloads for seed nodes

### DIFF
--- a/neo/Consensus/ConsensusContext.cs
+++ b/neo/Consensus/ConsensusContext.cs
@@ -16,7 +16,7 @@ namespace Neo.Consensus
 {
     internal class ConsensusContext : IConsensusContext
     {
-        public const uint Version = 0;
+        public const uint Version = 1;
         public uint BlockIndex { get; set; }
         public UInt256 PrevHash { get; set; }
         public byte ViewNumber { get; set; }


### PR DESCRIPTION
Changes for dBFT 2.0 need to be able to run on seed nodes before the CN nodes are upgraded. This fixes incompatibilities staying connected to other nodes in the network when running in a network where the CN nodes are running the original dBFT implementation.