### PR TITLE
Expose DbCache (for plugins, etc.) + useful Neo.IO.Helper methods

### DIFF
--- a/neo/Persistence/LevelDB/DbCache.cs
+++ b/neo/Persistence/LevelDB/DbCache.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 
 namespace Neo.Persistence.LevelDB
 {
-    internal class DbCache<TKey, TValue> : DataCache<TKey, TValue>
+    public class DbCache<TKey, TValue> : DataCache<TKey, TValue>
         where TKey : IEquatable<TKey>, ISerializable, new()
         where TValue : class, ICloneable<TValue>, ISerializable, new()
     {


### PR DESCRIPTION
Plugins that persist to a separate LevelDB store may want to use the `DbCache` in order to cache data they will be writing to disk and exposing through RPC. One example is moving #569 to a plugin, and there are other plugins I am working on that will need it.