### PR TITLE
RPC call to get timestamp of last blocks

### DIFF
--- a/neo/Network/RPC/RpcServer.cs
+++ b/neo/Network/RPC/RpcServer.cs
@@ -167,7 +167,7 @@ namespace Neo.Network.RPC
                     {
                         return GetPeers();
                     }
-                case "getlastblockstime":
+                case "gettimestamplastblocks":
                     {
                         uint nBlocks = (uint)_params[0].AsNumber();
                         return GetBlocksTime(nBlocks);

--- a/neo/Network/RPC/RpcServer.cs
+++ b/neo/Network/RPC/RpcServer.cs
@@ -544,17 +544,18 @@ namespace Neo.Network.RPC
 
         private JObject GetBlocksTime(uint nBlocks)
         {           
+            // It is currently limited to query blocks generated in the last 24hours (86400 seconds)
             uint maxNBlocksPerDay = 86400 / Blockchain.SecondsPerBlock;
             if (nBlocks >= Blockchain.Singleton.Height || nBlocks > maxNBlocksPerDay)
             {
                 JObject json = new JObject();
-                return json["error"] = "Requested number of blocks exceeds " + maxNBlocksPerDay;
+                return json["error"] = "Requested number of blocks timestamps exceeds " + maxNBlocksPerDay;
             }
 
             if (nBlocks >= Blockchain.Singleton.Height)
             {
                 JObject json = new JObject();
-                return json["error"] = "Requested number of blocks exceeds last known height " + Blockchain.Singleton.Height;
+                return json["error"] = "Requested number of blocks timestamps exceeds quantity of known blocks" + Blockchain.Singleton.Height;
             }
 
             if (nBlocks <= 0)

--- a/neo/Network/RPC/RpcServer.cs
+++ b/neo/Network/RPC/RpcServer.cs
@@ -570,6 +570,7 @@ namespace Neo.Network.RPC
                 JObject json = new JObject();
                 Header header = Blockchain.Singleton.Store.GetHeader(i);
                 json["blocktime"] = header.Timestamp;
+                json["height"] = i;
                 array.Add(json);
             }
 


### PR DESCRIPTION
With this call we gonna be able to get an array with the timestamps of the last `X` blocks, limited to 24 hours.

We believe it is an useful api call that can reduce load on RPCs and also be an easy way to get such information.

@shargon, can you give us a help in the security of this call?