### PR TITLE
Fine tunning view 0 timeouts based on last block timestamp (limited by a maximum offset)

### DIFF
--- a/neo/Consensus/ConsensusService.cs
+++ b/neo/Consensus/ConsensusService.cs
@@ -274,7 +274,7 @@ namespace Neo.Consensus
             Log($"persist block: {block.Hash}");
             reference_block_time = TimeProvider.Current.UtcNow;        
             theoreticalDelay = calcNetworkDelayOrClockDriftWithLimits(reference_block_time.ToTimestamp(), block.Timestamp);
-            reference_block_time.AddSeconds((long)-theoreticalDelay);
+            reference_block_time.AddSeconds((double)-theoreticalDelay);
             knownHashes.Clear();
             InitializeConsensus(0);
         }
@@ -283,14 +283,14 @@ namespace Neo.Consensus
         {
             if (localClockTimestamp > lastBlockTimestamp)
             {
-                var currentClockDelay = localClockTimestamp - lastBlockTimestamp;
+                var currentTheoreticalDelay = localClockTimestamp - lastBlockTimestamp;
                 Log($"localClock:{localClockTimestamp}\nlastBlockTimestamp:{lastBlockTimestamp}");
                 Log($"diff:{localClockTimestamp - lastBlockTimestamp}");
                 // maximum expected delay 30% of block time - currently 4,5s
                 uint maxDelayToAdvance = Blockchain.SecondsPerBlock / 100 * 30;
-                currentClockDelay = currentClockDelay > maxDelayToAdvance ? maxDelayToAdvance : currentClockDelay;
-                Log($"-theoreticalDelay:{-currentClockDelay}");
-                return currentClockDelay;
+                currentTheoreticalDelay = currentTheoreticalDelay > maxDelayToAdvance ? maxDelayToAdvance : currentTheoreticalDelay;
+                Log($"-currentTheoreticalDelay:{-currentTheoreticalDelay}");
+                return currentTheoreticalDelay;
             }
             return 0;
         }

--- a/neo/Consensus/ConsensusService.cs
+++ b/neo/Consensus/ConsensusService.cs
@@ -529,7 +529,7 @@ namespace Neo.Consensus
                 foreach (InvPayload payload in InvPayload.CreateGroup(InventoryType.TX, context.TransactionHashes.Skip(1).ToArray()))
                     localNode.Tell(Message.Create("inv", payload));
             }
-            ChangeTimer(TimeSpan.FromSeconds((Blockchain.SecondsPerBlock << (context.ViewNumber + 1)) - Blockchain.SecondsPerBlock));
+            ChangeTimer(TimeSpan.FromSeconds(Blockchain.SecondsPerBlock << (context.ViewNumber + 1)));
         }
 
         private bool VerifyRequest()

--- a/neo/Consensus/ConsensusService.cs
+++ b/neo/Consensus/ConsensusService.cs
@@ -520,7 +520,7 @@ namespace Neo.Consensus
                 foreach (InvPayload payload in InvPayload.CreateGroup(InventoryType.TX, context.TransactionHashes.Skip(1).ToArray()))
                     localNode.Tell(Message.Create("inv", payload));
             }
-            ChangeTimer(TimeSpan.FromSeconds(Blockchain.SecondsPerBlock << (context.ViewNumber + 1)));
+            ChangeTimer(TimeSpan.FromSeconds((Blockchain.SecondsPerBlock << (context.ViewNumber + 1)) - Blockchain.SecondsPerBlock));
         }
 
         private bool VerifyRequest()

--- a/neo/Consensus/ConsensusService.cs
+++ b/neo/Consensus/ConsensusService.cs
@@ -273,19 +273,19 @@ namespace Neo.Consensus
         {
             Log($"persist block: {block.Hash}");
             reference_block_time = TimeProvider.Current.UtcNow;        
-            theoreticalDelay = getNetworkDelayOrClockDrift(reference_block_time.ToTimestamp(), block.Timestamp);
+            theoreticalDelay = calcNetworkDelayOrClockDriftWithLimits(reference_block_time.ToTimestamp(), block.Timestamp);
             reference_block_time.AddSeconds((long)-theoreticalDelay);
             knownHashes.Clear();
             InitializeConsensus(0);
         }
 
-        private uint getNetworkDelayOrClockDrift(uint timestampReferenceBlock, uint timestampLastBlock)
+        private uint calcNetworkDelayOrClockDriftWithLimits(uint localClockTimestamp, uint lastBlockTimestamp)
         {
-            if (timestampReferenceBlock > timestampLastBlock)
+            if (localClockTimestamp > lastBlockTimestamp)
             {
-                var currentClockDelay = timestampReferenceBlock - timestampLastBlock;
-                Log($"localClock:{reference_block_time.ToTimestamp()}\nlastBlockTimestamp:{timestampLastBlock}");
-                Log($"diff:{timestampReferenceBlock - timestampLastBlock}");
+                var currentClockDelay = localClockTimestamp - lastBlockTimestamp;
+                Log($"localClock:{localClockTimestamp}\nlastBlockTimestamp:{lastBlockTimestamp}");
+                Log($"diff:{localClockTimestamp - lastBlockTimestamp}");
                 // maximum expected delay 30% of block time - currently 4,5s
                 uint maxDelayToAdvance = Blockchain.SecondsPerBlock / 100 * 30;
                 currentClockDelay = currentClockDelay > maxDelayToAdvance ? maxDelayToAdvance : currentClockDelay;

--- a/neo/Consensus/ConsensusService.cs
+++ b/neo/Consensus/ConsensusService.cs
@@ -272,8 +272,10 @@ namespace Neo.Consensus
         private void OnPersistCompleted(Block block)
         {
             Log($"persist block: {block.Hash}");
-            reference_block_time = TimeProvider.Current.UtcNow;
+            reference_block_time = TimeProvider.Current.UtcNow;        
             theoreticalDelay = reference_block_time.ToTimestamp() - block.Timestamp;
+            Log($"current:{reference_block_time.ToTimestamp()} previous:{block.Timestamp}");
+            Log($"diff:{reference_block_time.ToTimestamp()-block.Timestamp}");               
             // maximum expected delay is 5 seconds (this can be moved as a configuration parameter along with block time
             uint maxDelayToAdvance = 5;
             theoreticalDelay = theoreticalDelay > maxDelayToAdvance ? maxDelayToAdvance : theoreticalDelay;

--- a/neo/Consensus/ConsensusService.cs
+++ b/neo/Consensus/ConsensusService.cs
@@ -276,8 +276,8 @@ namespace Neo.Consensus
             theoreticalDelay = reference_block_time.ToTimestamp() - block.Timestamp;
             Log($"current:{reference_block_time.ToTimestamp()} previous:{block.Timestamp}");
             Log($"diff:{reference_block_time.ToTimestamp()-block.Timestamp}");               
-            // maximum expected delay is 5 seconds (this can be moved as a configuration parameter along with block time
-            uint maxDelayToAdvance = 5;
+            // maximum expected delay 30% of block time - currently 
+            uint maxDelayToAdvance = 0.3 * Blockchain.SecondsPerBlock;
             theoreticalDelay = theoreticalDelay > maxDelayToAdvance ? maxDelayToAdvance : theoreticalDelay;
             // unsigned int does not need the need the next line, right? TODO
             theoreticalDelay = theoreticalDelay < 0 ? 0 : theoreticalDelay;

--- a/neo/Consensus/ConsensusService.cs
+++ b/neo/Consensus/ConsensusService.cs
@@ -268,7 +268,6 @@ namespace Neo.Consensus
         private void OnPersistCompleted(Block block)
         {
             Log($"persist block: {block.Hash}");
-            block_received_time = TimeProvider.Current.UtcNow;
             reference_block_time = TimeProvider.Current.UtcNow;
             uint theoreticalDelay = reference_block_time.ToTimestamp() - block.Timestamp;
             // maximum expected delay is 5 seconds (this can be moved as a configuration parameter along with block time

--- a/neo/Consensus/ConsensusService.cs
+++ b/neo/Consensus/ConsensusService.cs
@@ -285,17 +285,17 @@ namespace Neo.Consensus
         // variable maxDelayToAdvance limits the offset adjustment to 30% of block time - currently 4.5s for 15s blocks
         private uint calcNetworkLatencyOrClockDriftWithMaxOffset(uint localClockTimestamp, uint lastBlockTimestamp)
         {
-            if (localClockTimestamp > lastBlockTimestamp)
-            {
-                var currentTheoreticalDelay = localClockTimestamp - lastBlockTimestamp;
-                Log($"localClock:{localClockTimestamp}\nlastBlockTimestamp:{lastBlockTimestamp}");
-                Log($"diff:{localClockTimestamp - lastBlockTimestamp}");
-                uint maxDelayToAdvance = Blockchain.SecondsPerBlock / 100 * 30;
-                currentTheoreticalDelay = currentTheoreticalDelay > maxDelayToAdvance ? maxDelayToAdvance : currentTheoreticalDelay;
-                Log($"-currentTheoreticalDelay:{-currentTheoreticalDelay}");
-                return currentTheoreticalDelay;
-            }
-            return 0;
+            if (localClockTimestamp <= lastBlockTimestamp)
+                return 0;
+            
+            var currentTheoreticalDelay = localClockTimestamp - lastBlockTimestamp;
+            Log($"localClock:{localClockTimestamp}\nlastBlockTimestamp:{lastBlockTimestamp}");
+            Log($"diff:{currentTheoreticalDelay}");
+            double maxTimeoutOffset = Math.Ceiling(Blockchain.SecondsPerBlock * 0.3);
+            Log($"maxTimeoutOffset:{maxTimeoutOffset}");
+            currentTheoreticalDelay = currentTheoreticalDelay > (uint) maxTimeoutOffset? (uint)maxTimeoutOffset : currentTheoreticalDelay;
+            Log($"-currentTheoreticalDelay:{-currentTheoreticalDelay}");
+            return currentTheoreticalDelay;
         }
 
         private void OnRecoveryMessageReceived(ConsensusPayload payload, RecoveryMessage message)

--- a/neo/Consensus/ConsensusService.cs
+++ b/neo/Consensus/ConsensusService.cs
@@ -170,7 +170,7 @@ namespace Neo.Consensus
             }
             else
             {
-                ChangeTimer(TimeSpan.FromSeconds(Blockchain.SecondsPerBlock << (viewNumber + 1)));
+                ChangeTimer(TimeSpan.FromSeconds((Blockchain.SecondsPerBlock << (viewNumber + 1)) -  theoreticalDelay));
             }
         }
 


### PR DESCRIPTION
Currently, the formula is the following:

 Considering 15 second blocks: 15 << 1 is 30; 15 << 2 is 60; 15 << 3 is 120; 15 << 4 is 240

![image](https://user-images.githubusercontent.com/17395762/54372946-2d732580-465b-11e9-87f2-296aa96c2073.png)

Figure extracted from the draft of the [Yellow Paper](https://github.com/NeoResearch/yellowpaper/).

In the first round all backups timeout with 30s.
Primary has 2 different timeouts:
1. The first one currently happens after 15s (fixed block time) after it receives the previous block;
2. Its second timeout is currently also happening equal to the backups, what makes primary to timeout after all other backups, which, approximately, will be in the second 45s when Primary timeout.

This is a draft of the idea, we also would like to include a modification at the OnPersistCompleted function (which could be in another PR), focusing on considering last block timestamp instead of current time when blocks are received.

By printing both timestamps we can see a delay between real timestamp that the last block was created and the one used:
``
[19:44:40.405] persist block: currentLocalTimeStamp:1551987883 previousBlockTimeStamp:1551987880
[19:44:40.405] persist block: diff:3
``

We could have a logic that uses the previousBlockTimeStamp if it is lower than a maximum value, let's say 4-5 seconds.

```cs
            last_block_time = TimeProvider.Current.UtcNow;
            uint theoreticalDelay = TimeProvider.Current.UtcNow.ToTimestamp() - block.Timestamp;
            // maximum expected delay is 5 seconds (this can be moved as a configuration parameter along with block time
            uint maxDelayToAdvance = 5;
            theoreticalDelay = theoreticalDelay > maxDelayToAdvance ? maxDelayToAdvance : theoreticalDelay;
            // unsigned int does not need the need the next line, right? TODO
            theoreticalDelay = theoreticalDelay < 0 ? 0 : theoreticalDelay;
            last_block_time.AddSeconds(-theoreticalDelay);
            InitializeConsensus(0);
```

For the Mainnet we could consider this limit close to the average delay that we are seeing on real operation, close to 5seconds.
5 seconds also sounds reasonable in accordance with some statistics avaialable.
Checking some websites( https://www.dotcom-tools.com/internet-backbone-latency.aspx and https://wondernetwork.com/pings) we found the worse case between Beijing around 400ms and Australia to Johannesburg around this as well.
Currently, we have around 3~4 necessary messages (prepReq+prepBackups+Commits+Block(if you did not relay it)) to achieve consensus plus the different sources that we need to receive.
In this sense, we could consider 1.2 seconds as a standard for ping, but we also have some clocks that are really synchronized plus our payloads that are heavier than a normal ping.
Considering http://monitor.cityofzion.io/ we can consider cases where pings of 1000ms can be seen.
