### PR TITLE
Move Store variable from ConsensusService to ConsensusContext

### DIFF
--- a/neo.UnitTests/UT_Consensus.cs
+++ b/neo.UnitTests/UT_Consensus.cs
@@ -126,8 +126,6 @@ namespace Neo.UnitTests
 
             mockConsensusContext.Setup(mr => mr.MakePrepareRequest()).Returns(prepPayload);
 
-            mockConsensusContext.SetupGet(mr => mr.Store).Returns(mockStore.Object);
-
             // ============================================================================
             //                      creating ConsensusService actor
             // ============================================================================

--- a/neo.UnitTests/UT_Consensus.cs
+++ b/neo.UnitTests/UT_Consensus.cs
@@ -126,12 +126,14 @@ namespace Neo.UnitTests
 
             mockConsensusContext.Setup(mr => mr.MakePrepareRequest()).Returns(prepPayload);
 
+            mockConsensusContext.SetupGet(mr => mr.Store).Returns(mockStore.Object);
+
             // ============================================================================
             //                      creating ConsensusService actor
             // ============================================================================
 
             TestActorRef<ConsensusService> actorConsensus = ActorOfAsTestActorRef<ConsensusService>(
-                                     Akka.Actor.Props.Create(() => new ConsensusService(subscriber, subscriber, mockStore.Object, mockConsensusContext.Object))
+                                     Akka.Actor.Props.Create(() => new ConsensusService(subscriber, subscriber, mockConsensusContext.Object))
                                      );
 
             Console.WriteLine("will trigger OnPersistCompleted!");
@@ -175,7 +177,7 @@ namespace Neo.UnitTests
         [TestMethod]
         public void TestSerializeAndDeserializeConsensusContext()
         {
-            var consensusContext = new ConsensusContext(null);
+            var consensusContext = new ConsensusContext(null, null);
             consensusContext.PrevHash = UInt256.Parse("0xd42561e3d30e15be6400b6df2f328e02d2bf6354c41dce433bc57687c82144bf");
             consensusContext.BlockIndex = 1;
             consensusContext.ViewNumber = 2;
@@ -248,7 +250,7 @@ namespace Neo.UnitTests
 
             consensusContext.LastChangeViewPayloads = new ConsensusPayload[consensusContext.Validators.Length];
 
-            var copiedContext = TestUtils.CopyMsgBySerialization(consensusContext, new ConsensusContext(null));
+            var copiedContext = TestUtils.CopyMsgBySerialization(consensusContext, new ConsensusContext(null, null));
 
             copiedContext.PrevHash.Should().Be(consensusContext.PrevHash);
             copiedContext.BlockIndex.Should().Be(consensusContext.BlockIndex);

--- a/neo/Consensus/ConsensusContext.cs
+++ b/neo/Consensus/ConsensusContext.cs
@@ -37,7 +37,7 @@ namespace Neo.Consensus
         private KeyPair keyPair;
         private readonly Wallet wallet;
         public Store Store { get; }
-        public bool IsRecovering { get; set; }
+        public bool Recovering { get; set; }
 
         public int Size => throw new NotImplementedException();
 
@@ -45,7 +45,7 @@ namespace Neo.Consensus
         {
             this.wallet = wallet;
             this.Store = store;
-            this.IsRecovering = false;
+            this.Recovering = false;
             this.KnownHashes = new HashSet<UInt256>();
         }
 

--- a/neo/Consensus/ConsensusContext.cs
+++ b/neo/Consensus/ConsensusContext.cs
@@ -36,7 +36,7 @@ namespace Neo.Consensus
         public Snapshot Snapshot { get; private set; }
         private KeyPair keyPair;
         private readonly Wallet wallet;
-        public Store Store { get; };
+        public Store Store { get; }
         public bool IsRecovering { get; set; }
         public HashSet<UInt256> KnownHashes { get; }
 

--- a/neo/Consensus/ConsensusContext.cs
+++ b/neo/Consensus/ConsensusContext.cs
@@ -46,7 +46,6 @@ namespace Neo.Consensus
             this.wallet = wallet;
             this.Store = store;
             this.Recovering = false;
-            this.KnownHashes = new HashSet<UInt256>();
         }
 
         public Block CreateBlock()

--- a/neo/Consensus/ConsensusContext.cs
+++ b/neo/Consensus/ConsensusContext.cs
@@ -36,12 +36,14 @@ namespace Neo.Consensus
         public Snapshot Snapshot { get; private set; }
         private KeyPair keyPair;
         private readonly Wallet wallet;
+        public Store Store { get; };
 
         public int Size => throw new NotImplementedException();
 
-        public ConsensusContext(Wallet wallet)
+        public ConsensusContext(Wallet wallet, Store store)
         {
             this.wallet = wallet;
+            this.Store = store;
         }
 
         public Block CreateBlock()

--- a/neo/Consensus/ConsensusContext.cs
+++ b/neo/Consensus/ConsensusContext.cs
@@ -38,7 +38,6 @@ namespace Neo.Consensus
         private readonly Wallet wallet;
         public Store Store { get; }
         public bool IsRecovering { get; set; }
-        public HashSet<UInt256> KnownHashes { get; }
 
         public int Size => throw new NotImplementedException();
 

--- a/neo/Consensus/ConsensusContext.cs
+++ b/neo/Consensus/ConsensusContext.cs
@@ -37,6 +37,7 @@ namespace Neo.Consensus
         private KeyPair keyPair;
         private readonly Wallet wallet;
         public Store Store { get; };
+        public bool IsRecovering { get; set; }
 
         public int Size => throw new NotImplementedException();
 
@@ -44,6 +45,7 @@ namespace Neo.Consensus
         {
             this.wallet = wallet;
             this.Store = store;
+            this.IsRecovering = false; 
         }
 
         public Block CreateBlock()

--- a/neo/Consensus/ConsensusContext.cs
+++ b/neo/Consensus/ConsensusContext.cs
@@ -37,7 +37,6 @@ namespace Neo.Consensus
         private KeyPair keyPair;
         private readonly Wallet wallet;
         public Store Store { get; }
-        public bool Recovering { get; set; }
 
         public int Size => throw new NotImplementedException();
 
@@ -45,7 +44,6 @@ namespace Neo.Consensus
         {
             this.wallet = wallet;
             this.Store = store;
-            this.Recovering = false;
         }
 
         public Block CreateBlock()

--- a/neo/Consensus/ConsensusContext.cs
+++ b/neo/Consensus/ConsensusContext.cs
@@ -38,6 +38,7 @@ namespace Neo.Consensus
         private readonly Wallet wallet;
         public Store Store { get; };
         public bool IsRecovering { get; set; }
+        public HashSet<UInt256> KnownHashes { get; }
 
         public int Size => throw new NotImplementedException();
 
@@ -45,7 +46,8 @@ namespace Neo.Consensus
         {
             this.wallet = wallet;
             this.Store = store;
-            this.IsRecovering = false; 
+            this.IsRecovering = false;
+            this.KnownHashes = new HashSet<UInt256>();
         }
 
         public Block CreateBlock()

--- a/neo/Consensus/ConsensusService.cs
+++ b/neo/Consensus/ConsensusService.cs
@@ -46,6 +46,7 @@ namespace Neo.Consensus
             this.taskManager = taskManager;
             this.store = store;
             this.context = context;
+            Context.System.EventStream.Subscribe(Self, typeof(Blockchain.PersistCompleted));
         }
 
         private bool AddTransaction(Transaction tx, bool verify)
@@ -482,6 +483,7 @@ namespace Neo.Consensus
         {
             Log("OnStop");
             started = false;
+            Context.System.EventStream.Unsubscribe(Self);
             context.Dispose();
             base.PostStop();
         }

--- a/neo/Consensus/ConsensusService.cs
+++ b/neo/Consensus/ConsensusService.cs
@@ -32,7 +32,6 @@ namespace Neo.Consensus
         /// responding to the same message.
         /// </summary>
         private readonly HashSet<UInt256> knownHashes = new HashSet<UInt256>();
-        private bool isRecovering = false;
 
         public ConsensusService(IActorRef localNode, IActorRef taskManager, Store store, Wallet wallet)
             : this(localNode, taskManager, new ConsensusContext(wallet, store))
@@ -147,7 +146,7 @@ namespace Neo.Consensus
             Log($"initialize: height={context.BlockIndex} view={viewNumber} index={context.MyIndex} role={(context.IsPrimary() ? "Primary" : "Backup")}");
             if (context.IsPrimary())
             {
-                if (isRecovering)
+                if (context.IsRecovering)
                 {
                     ChangeTimer(TimeSpan.FromSeconds(Blockchain.SecondsPerBlock << (viewNumber + 1)));
                 }
@@ -275,7 +274,7 @@ namespace Neo.Consensus
         {
             if (message.ViewNumber < context.ViewNumber) return;
             Log($"{nameof(OnRecoveryMessageReceived)}: height={payload.BlockIndex} view={message.ViewNumber} index={payload.ValidatorIndex}");
-            isRecovering = true;
+            context.IsRecovering = true;
             try
             {
                 if (message.ViewNumber > context.ViewNumber)
@@ -306,7 +305,7 @@ namespace Neo.Consensus
             }
             finally
             {
-                isRecovering = false;
+                context.IsRecovering = false;
             }
         }
 

--- a/neo/Consensus/ConsensusService.cs
+++ b/neo/Consensus/ConsensusService.cs
@@ -27,11 +27,6 @@ namespace Neo.Consensus
         private ICancelable timer_token;
         private DateTime block_received_time;
         private bool started = false;
-        /// <summary>
-        /// This will be cleared every block (so it will not grow out of control, but is used to prevent repeatedly
-        /// responding to the same message.
-        /// </summary>
-        private readonly HashSet<UInt256> knownHashes = new HashSet<UInt256>();
 
         public ConsensusService(IActorRef localNode, IActorRef taskManager, Store store, Wallet wallet)
             : this(localNode, taskManager, new ConsensusContext(wallet, store))
@@ -178,7 +173,7 @@ namespace Neo.Consensus
             // and issues a change view for the same view, it will have a different hash and will correctly respond
             // again; however replay attacks of the ChangeView message from arbitrary nodes will not trigger an
             // additonal recovery message response.
-            if (!knownHashes.Add(payload.Hash)) return;
+            if (!context.KnownHashes.Add(payload.Hash)) return;
             if (message.NewViewNumber <= context.ViewNumber)
             {
                 bool shouldSendRecovery = false;
@@ -266,7 +261,7 @@ namespace Neo.Consensus
         {
             Log($"persist block: {block.Hash}");
             block_received_time = TimeProvider.Current.UtcNow;
-            knownHashes.Clear();
+            context.KnownHashes.Clear();
             InitializeConsensus(0);
         }
 

--- a/neo/Consensus/ConsensusService.cs
+++ b/neo/Consensus/ConsensusService.cs
@@ -147,7 +147,7 @@ namespace Neo.Consensus
             Log($"initialize: height={context.BlockIndex} view={viewNumber} index={context.MyIndex} role={(context.IsPrimary() ? "Primary" : "Backup")}");
             if (context.IsPrimary())
             {
-                if (context.IsRecovering)
+                if (context.IsRecovering())
                 {
                     ChangeTimer(TimeSpan.FromSeconds(Blockchain.SecondsPerBlock << (viewNumber + 1)));
                 }
@@ -275,7 +275,7 @@ namespace Neo.Consensus
         {
             if (message.ViewNumber < context.ViewNumber) return;
             Log($"{nameof(OnRecoveryMessageReceived)}: height={payload.BlockIndex} view={message.ViewNumber} index={payload.ValidatorIndex}");
-            context.IsRecovering = true;
+            context.Recovering = true;
             try
             {
                 if (message.ViewNumber > context.ViewNumber)
@@ -306,7 +306,7 @@ namespace Neo.Consensus
             }
             finally
             {
-                context.IsRecovering = false;
+                context.Recovering = false;
             }
         }
 

--- a/neo/Consensus/Helper.cs
+++ b/neo/Consensus/Helper.cs
@@ -41,14 +41,14 @@ namespace Neo.Consensus
             return p >= 0 ? (uint)p : (uint)(p + context.Validators.Length);
         }
 
-        public static void Save(this IConsensusContext context, Store store)
+        public static void Save(this IConsensusContext context)
         {
-            store.PutSync(CN_Context, new byte[0], context.ToArray());
+            context.Store.PutSync(CN_Context, new byte[0], context.ToArray());
         }
 
-        public static bool Load(this IConsensusContext context, Store store)
+        public static bool Load(this IConsensusContext context)
         {
-            byte[] data = store.Get(CN_Context, new byte[0]);
+            byte[] data = context.Store.Get(CN_Context, new byte[0]);
 
             if (data is null || data.Length == 0) return false;
 

--- a/neo/Consensus/Helper.cs
+++ b/neo/Consensus/Helper.cs
@@ -23,6 +23,8 @@ namespace Neo.Consensus
         public static bool IsBackup(this IConsensusContext context) => context.MyIndex >= 0 && context.MyIndex != context.PrimaryIndex;
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Header PrevHeader(this IConsensusContext context) => context.Snapshot.GetHeader(context.PrevHash);
+
+        // Consensus States
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool RequestSentOrReceived(this IConsensusContext context) => context.PreparationPayloads[context.PrimaryIndex] != null;
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -33,7 +35,8 @@ namespace Neo.Consensus
         public static bool BlockSent(this IConsensusContext context) => context.Block != null;
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool ViewChanging(this IConsensusContext context) => context.ChangeViewPayloads[context.MyIndex]?.GetDeserializedMessage<ChangeView>().NewViewNumber > context.ViewNumber;
-
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsRecovering(this IConsensusContext context) => context.Recovering;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static uint GetPrimaryIndex(this IConsensusContext context, byte viewNumber)

--- a/neo/Consensus/Helper.cs
+++ b/neo/Consensus/Helper.cs
@@ -35,8 +35,6 @@ namespace Neo.Consensus
         public static bool BlockSent(this IConsensusContext context) => context.Block != null;
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool ViewChanging(this IConsensusContext context) => context.ChangeViewPayloads[context.MyIndex]?.GetDeserializedMessage<ChangeView>().NewViewNumber > context.ViewNumber;
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool IsRecovering(this IConsensusContext context) => context.Recovering;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static uint GetPrimaryIndex(this IConsensusContext context, byte viewNumber)

--- a/neo/Consensus/Helper.cs
+++ b/neo/Consensus/Helper.cs
@@ -34,6 +34,7 @@ namespace Neo.Consensus
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool ViewChanging(this IConsensusContext context) => context.ChangeViewPayloads[context.MyIndex]?.GetDeserializedMessage<ChangeView>().NewViewNumber > context.ViewNumber;
 
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static uint GetPrimaryIndex(this IConsensusContext context, byte viewNumber)
         {

--- a/neo/Consensus/Helper.cs
+++ b/neo/Consensus/Helper.cs
@@ -1,18 +1,11 @@
-﻿using Neo.IO;
-using Neo.Network.P2P.Payloads;
+﻿using Neo.Network.P2P.Payloads;
 using Neo.Persistence;
-using System.IO;
 using System.Runtime.CompilerServices;
 
 namespace Neo.Consensus
 {
     internal static class Helper
     {
-        /// <summary>
-        /// Prefix for saving consensus state.
-        /// </summary>
-        public const byte CN_Context = 0xf4;
-
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int F(this IConsensusContext context) => (context.Validators.Length - 1) / 3;
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -41,32 +34,6 @@ namespace Neo.Consensus
         {
             int p = ((int)context.BlockIndex - viewNumber) % context.Validators.Length;
             return p >= 0 ? (uint)p : (uint)(p + context.Validators.Length);
-        }
-
-        public static void Save(this IConsensusContext context)
-        {
-            context.Store.PutSync(CN_Context, new byte[0], context.ToArray());
-        }
-
-        public static bool Load(this IConsensusContext context)
-        {
-            byte[] data = context.Store.Get(CN_Context, new byte[0]);
-
-            if (data is null || data.Length == 0) return false;
-
-            using (MemoryStream ms = new MemoryStream(data, false))
-            using (BinaryReader reader = new BinaryReader(ms))
-            {
-                try
-                {
-                    context.Deserialize(reader);
-                }
-                catch
-                {
-                    return false;
-                }
-                return true;
-            }
         }
     }
 }

--- a/neo/Consensus/IConsensusContext.cs
+++ b/neo/Consensus/IConsensusContext.cs
@@ -27,7 +27,7 @@ namespace Neo.Consensus
         Block Block { get; set; }
         Snapshot Snapshot { get; }
         Store Store { get; }
-        bool IsRecovering { get; set; }
+        bool Recovering { get; set; }
 
         Block CreateBlock();
 

--- a/neo/Consensus/IConsensusContext.cs
+++ b/neo/Consensus/IConsensusContext.cs
@@ -26,11 +26,10 @@ namespace Neo.Consensus
         ConsensusPayload[] ChangeViewPayloads { get; set; }
         Block Block { get; set; }
         Snapshot Snapshot { get; }
-        Store Store { get; }
 
         Block CreateBlock();
 
-        //void Dispose();
+        bool Load();
 
         ConsensusPayload MakeChangeView(byte newViewNumber);
 
@@ -45,5 +44,7 @@ namespace Neo.Consensus
         ConsensusPayload MakePrepareResponse();
 
         void Reset(byte viewNumber);
+
+        void Save();
     }
 }

--- a/neo/Consensus/IConsensusContext.cs
+++ b/neo/Consensus/IConsensusContext.cs
@@ -27,7 +27,6 @@ namespace Neo.Consensus
         Block Block { get; set; }
         Snapshot Snapshot { get; }
         Store Store { get; }
-        bool Recovering { get; set; }
 
         Block CreateBlock();
 

--- a/neo/Consensus/IConsensusContext.cs
+++ b/neo/Consensus/IConsensusContext.cs
@@ -27,6 +27,7 @@ namespace Neo.Consensus
         Block Block { get; set; }
         Snapshot Snapshot { get; }
         Store Store { get; }
+        bool IsRecovering { get; set; }
 
         Block CreateBlock();
 

--- a/neo/Consensus/IConsensusContext.cs
+++ b/neo/Consensus/IConsensusContext.cs
@@ -29,12 +29,6 @@ namespace Neo.Consensus
         Store Store { get; }
         bool IsRecovering { get; set; }
 
-        /// <summary>
-        /// This will be cleared every block (so it will not grow out of control, but is used to prevent repeatedly
-        /// responding to the same message.
-        /// </summary>
-        HashSet<UInt256> KnownHashes { get; }
-
         Block CreateBlock();
 
         //void Dispose();

--- a/neo/Consensus/IConsensusContext.cs
+++ b/neo/Consensus/IConsensusContext.cs
@@ -29,6 +29,12 @@ namespace Neo.Consensus
         Store Store { get; }
         bool IsRecovering { get; set; }
 
+        /// <summary>
+        /// This will be cleared every block (so it will not grow out of control, but is used to prevent repeatedly
+        /// responding to the same message.
+        /// </summary>
+        HashSet<UInt256> KnownHashes { get; }
+
         Block CreateBlock();
 
         //void Dispose();

--- a/neo/Consensus/IConsensusContext.cs
+++ b/neo/Consensus/IConsensusContext.cs
@@ -26,6 +26,7 @@ namespace Neo.Consensus
         ConsensusPayload[] ChangeViewPayloads { get; set; }
         Block Block { get; set; }
         Snapshot Snapshot { get; }
+        Store Store { get; }
 
         Block CreateBlock();
 

--- a/neo/Ledger/Blockchain.cs
+++ b/neo/Ledger/Blockchain.cs
@@ -19,7 +19,6 @@ namespace Neo.Ledger
 {
     public sealed class Blockchain : UntypedActor
     {
-        public class Register { }
         public class ApplicationExecuted { public Transaction Transaction; public ApplicationExecutionResult[] ExecutionResults; }
         public class PersistCompleted { public Block Block; }
         public class Import { public IEnumerable<Block> Blocks; }
@@ -122,7 +121,6 @@ namespace Neo.Ledger
         private readonly Dictionary<UInt256, Block> block_cache = new Dictionary<UInt256, Block>();
         private readonly Dictionary<uint, LinkedList<Block>> block_cache_unverified = new Dictionary<uint, LinkedList<Block>>();
         internal readonly RelayCache RelayCache = new RelayCache(100);
-        private readonly HashSet<IActorRef> subscribers = new HashSet<IActorRef>();
         private Snapshot currentSnapshot;
 
         public Store Store { get; }
@@ -193,12 +191,6 @@ namespace Neo.Ledger
         {
             if (MemPool.ContainsKey(hash)) return true;
             return Store.ContainsTransaction(hash);
-        }
-
-        private void Distribute(object message)
-        {
-            foreach (IActorRef subscriber in subscribers)
-                subscriber.Tell(message);
         }
 
         public Block GetBlock(UInt256 hash)
@@ -421,18 +413,13 @@ namespace Neo.Ledger
         {
             block_cache.Remove(block.Hash);
             MemPool.UpdatePoolForBlockPersisted(block, currentSnapshot);
-            PersistCompleted completed = new PersistCompleted { Block = block };
-            system.Consensus?.Tell(completed);
-            Distribute(completed);
+            Context.System.EventStream.Publish(new PersistCompleted { Block = block });
         }
 
         protected override void OnReceive(object message)
         {
             switch (message)
             {
-                case Register _:
-                    OnRegister();
-                    break;
                 case Import import:
                     OnImport(import.Blocks);
                     break;
@@ -455,16 +442,7 @@ namespace Neo.Ledger
                     if (MemPool.ReVerifyTopUnverifiedTransactionsIfNeeded(MaxTxToReverifyPerIdle, currentSnapshot))
                         Self.Tell(Idle.Instance, ActorRefs.NoSender);
                     break;
-                case Terminated terminated:
-                    subscribers.Remove(terminated.ActorRef);
-                    break;
             }
-        }
-
-        private void OnRegister()
-        {
-            subscribers.Add(Sender);
-            Context.Watch(Sender);
         }
 
         private void Persist(Block block)
@@ -628,7 +606,7 @@ namespace Neo.Ledger
                             Transaction = tx,
                             ExecutionResults = execution_results.ToArray()
                         };
-                        Distribute(application_executed);
+                        Context.System.EventStream.Publish(application_executed);
                         all_application_executed.Add(application_executed);
                     }
                 }


### PR DESCRIPTION
Guys, I'm moving some variables that I consider 'state related' from ConsensusService to ConsensusContext. I think this helps keeping ConsensusService class short and easier to understand at first sight.

Let's discuss this further, if you think that's a good idea.