### PR TITLE
Load plugins before initializing the system and call OnPluginsLoaded afterward.

### DIFF
--- a/neo/NeoSystem.cs
+++ b/neo/NeoSystem.cs
@@ -34,10 +34,11 @@ namespace Neo
         public NeoSystem(Store store)
         {
             this.store = store;
+            Plugin.LoadPlugins(this);
             this.Blockchain = ActorSystem.ActorOf(Ledger.Blockchain.Props(this, store));
             this.LocalNode = ActorSystem.ActorOf(Network.P2P.LocalNode.Props(this));
             this.TaskManager = ActorSystem.ActorOf(Network.P2P.TaskManager.Props(this));
-            Plugin.LoadPlugins(this);
+            Plugin.NotifyPluginsLoadedAfterSystemConstructed();
         }
 
         public void Dispose()

--- a/neo/Plugins/Plugin.cs
+++ b/neo/Plugins/Plugin.cs
@@ -67,10 +67,6 @@ namespace Neo.Plugins
 
         public abstract void Configure();
 
-        public virtual void OnNeoSystemInitialized()
-        {
-        }
-
         public virtual void OnPluginsLoaded()
         {
         }
@@ -120,8 +116,6 @@ namespace Neo.Plugins
 
         internal static void NotifyPluginsLoadedAfterSystemConstructed()
         {
-            foreach (var plugin in Plugins)
-                plugin.OnNeoSystemInitialized();
             foreach (var plugin in Plugins)
                 plugin.OnPluginsLoaded();
         }

--- a/neo/Plugins/Plugin.cs
+++ b/neo/Plugins/Plugin.cs
@@ -67,7 +67,7 @@ namespace Neo.Plugins
 
         public abstract void Configure();
 
-        public virtual void OnPluginsLoaded()
+        protected virtual void OnPluginsLoaded()
         {
         }
 

--- a/neo/Plugins/Plugin.cs
+++ b/neo/Plugins/Plugin.cs
@@ -53,8 +53,6 @@ namespace Neo.Plugins
             if (this is IRpcPlugin rpc) RpcPlugins.Add(rpc);
             if (this is IPersistencePlugin persistence) PersistencePlugins.Add(persistence);
             if (this is IMemoryPoolTxObserverPlugin txObserver) TxObserverPlugins.Add(txObserver);
-
-            Configure();
         }
 
         public static bool CheckPolicy(Transaction tx)
@@ -66,6 +64,10 @@ namespace Neo.Plugins
         }
 
         public abstract void Configure();
+
+        public virtual void OnPluginsLoaded()
+        {
+        }
 
         private static void ConfigWatcher_Changed(object sender, FileSystemEventArgs e)
         {
@@ -108,6 +110,14 @@ namespace Neo.Plugins
                     }
                 }
             }
+        }
+
+        internal static void NotifyPluginsLoadedAfterSystemConstructed()
+        {
+            foreach (var plugin in Plugins)
+                plugin.Configure();
+            foreach (var plugin in Plugins)
+                plugin.OnPluginsLoaded();
         }
 
         protected void Log(string message, LogLevel level = LogLevel.Info)

--- a/neo/Plugins/Plugin.cs
+++ b/neo/Plugins/Plugin.cs
@@ -53,6 +53,8 @@ namespace Neo.Plugins
             if (this is IRpcPlugin rpc) RpcPlugins.Add(rpc);
             if (this is IPersistencePlugin persistence) PersistencePlugins.Add(persistence);
             if (this is IMemoryPoolTxObserverPlugin txObserver) TxObserverPlugins.Add(txObserver);
+
+            Configure();
         }
 
         public static bool CheckPolicy(Transaction tx)
@@ -114,8 +116,6 @@ namespace Neo.Plugins
 
         internal static void NotifyPluginsLoadedAfterSystemConstructed()
         {
-            foreach (var plugin in Plugins)
-                plugin.Configure();
             foreach (var plugin in Plugins)
                 plugin.OnPluginsLoaded();
         }

--- a/neo/Plugins/Plugin.cs
+++ b/neo/Plugins/Plugin.cs
@@ -67,6 +67,10 @@ namespace Neo.Plugins
 
         public abstract void Configure();
 
+        public virtual void OnNeoSystemInitialized()
+        {
+        }
+
         public virtual void OnPluginsLoaded()
         {
         }
@@ -116,6 +120,8 @@ namespace Neo.Plugins
 
         internal static void NotifyPluginsLoadedAfterSystemConstructed()
         {
+            foreach (var plugin in Plugins)
+                plugin.OnNeoSystemInitialized();
             foreach (var plugin in Plugins)
                 plugin.OnPluginsLoaded();
         }


### PR DESCRIPTION
The plugins need to be loaded first in order to facilitate:
1. Persist plugins receiving the genesis block.
2. Import blocks plugin ability to wait to load blocks until after other plugins are loaded. (neo-project/neo-plugins/pull/53)

This is also needed by neo-project/neo-plugins/pull/52

This change also requires the following change in the ApplicationLogs plugin:
neo-project/neo-plugins/pull/55