### PR TITLE
Adding more logs to OnRecovery payload

### DIFF
--- a/neo/Consensus/ConsensusService.cs
+++ b/neo/Consensus/ConsensusService.cs
@@ -323,7 +323,7 @@ namespace Neo.Consensus
             finally
             {
                 Log($"{nameof(OnRecoveryMessageReceived)}: finished (valid/total) " +
-                    $"ChVw: {validChangeViews}/{totalChangeViews} " +
+                    $"ChgView: {validChangeViews}/{totalChangeViews} " +
                     $"PrepReq: {validPrepReq}/{totalPrepReq} " +
                     $"PrepResp: {validPrepResponses}/{totalPrepResponses}" +
                     $"Commits: {validCommits}/{totalCommits}");

--- a/neo/Consensus/ConsensusService.cs
+++ b/neo/Consensus/ConsensusService.cs
@@ -304,7 +304,7 @@ namespace Neo.Consensus
                         ConsensusPayload prepareRequestPayload = message.GetPrepareRequestPayload(context, payload);
                         if (prepareRequestPayload != null)
                         {
-                            totalPrepReq++;
+                            totalPrepReq = 1;
                             if (ReverifyAndProcessPayload(prepareRequestPayload)) validPrepReq++;
                         }
                         else if (context.IsPrimary())

--- a/neo/Consensus/ConsensusService.cs
+++ b/neo/Consensus/ConsensusService.cs
@@ -288,8 +288,10 @@ namespace Neo.Consensus
                     if (context.CommitSent()) return;
                     ConsensusPayload[] changeViewPayloads = message.GetChangeViewPayloads(context, payload);
                     foreach (ConsensusPayload changeViewPayload in changeViewPayloads)
-                        ReverifyAndProcessPayload(changeViewPayload);
+                        ReverifyAndProcessPayload(changeViewPayload);                        
+                    Log($"{nameof(OnRecoveryMessageReceived)}: changeViewPayloads were processed.");
                 }
+
                 if (message.ViewNumber != context.ViewNumber) return;
                 if (!context.CommitSent())
                 {
@@ -304,10 +306,12 @@ namespace Neo.Consensus
                     ConsensusPayload[] prepareResponsePayloads = message.GetPrepareResponsePayloads(context, payload);
                     foreach (ConsensusPayload prepareResponsePayload in prepareResponsePayloads)
                         ReverifyAndProcessPayload(prepareResponsePayload);
+                    Log($"{nameof(OnRecoveryMessageReceived)}: prepareResponsePayloads were processed.");
                 }
                 ConsensusPayload[] commitPayloads = message.GetCommitPayloadsFromRecoveryMessage(context, payload);
                 foreach (ConsensusPayload commitPayload in commitPayloads)
                     ReverifyAndProcessPayload(commitPayload);
+                Log($"{nameof(OnRecoveryMessageReceived)}: node should be recovered.");                    
             }
             finally
             {

--- a/neo/Consensus/ConsensusService.cs
+++ b/neo/Consensus/ConsensusService.cs
@@ -283,14 +283,18 @@ namespace Neo.Consensus
             Log($"{nameof(OnRecoveryMessageReceived)}: height={payload.BlockIndex} view={message.ViewNumber} index={payload.ValidatorIndex}");
             // isRecovering is always set to false again after OnRecoveryMessageReceived
             isRecovering = true;
+            int validChangeViews = 0, totalChangeViews = 0, validPrepReq=0, totalPrepReq = 0;
+            int validPrepResponses = 0, totalPrepResponses = 0, validCommits = 0, totalCommits = 0;
+
             try
             {
                 if (message.ViewNumber > context.ViewNumber)
                 {
                     if (context.CommitSent()) return;
                     ConsensusPayload[] changeViewPayloads = message.GetChangeViewPayloads(context, payload);
+                    totalChangeViews = changeViewPayloads.Length;
                     foreach (ConsensusPayload changeViewPayload in changeViewPayloads)
-                        ReverifyAndProcessPayload(changeViewPayload);
+                        if (ReverifyAndProcessPayload(changeViewPayload)) validChangeViews++;
                 }
                 if (message.ViewNumber != context.ViewNumber) return;
                 if (!context.CommitSent())
@@ -299,21 +303,30 @@ namespace Neo.Consensus
                     {
                         ConsensusPayload prepareRequestPayload = message.GetPrepareRequestPayload(context, payload);
                         if (prepareRequestPayload != null)
-                            ReverifyAndProcessPayload(prepareRequestPayload);
+                        {
+                            totalPrepReq++;
+                            if (ReverifyAndProcessPayload(prepareRequestPayload)) validPrepReq++;
+                        }
                         else if (context.IsPrimary())
                             SendPrepareRequest();
                     }
                     ConsensusPayload[] prepareResponsePayloads = message.GetPrepareResponsePayloads(context, payload);
+                    totalPrepResponses = prepareResponsePayloads.Length;
                     foreach (ConsensusPayload prepareResponsePayload in prepareResponsePayloads)
-                        ReverifyAndProcessPayload(prepareResponsePayload);
+                        if (ReverifyAndProcessPayload(prepareResponsePayload)) validPrepResponses++;
                 }
                 ConsensusPayload[] commitPayloads = message.GetCommitPayloadsFromRecoveryMessage(context, payload);
+                totalCommits = commitPayloads.Length;
                 foreach (ConsensusPayload commitPayload in commitPayloads)
-                    ReverifyAndProcessPayload(commitPayload);
+                    if (ReverifyAndProcessPayload(commitPayload)) validCommits++;
             }
             finally
             {
-                Log($"{nameof(OnRecoveryMessageReceived)}: finished.");
+                Log($"{nameof(OnRecoveryMessageReceived)}: finished (valid/total) " +
+                    $"ChVw: {validChangeViews}/{totalChangeViews} " +
+                    $"PrepReq: {validPrepReq}/{totalPrepReq} " +
+                    $"PrepResp: {validPrepResponses}/{totalPrepResponses}" +
+                    $"Commits: {validCommits}/{totalCommits}");
                 isRecovering = false;
             }
         }
@@ -510,10 +523,11 @@ namespace Neo.Consensus
             CheckExpectedView(expectedView);
         }
 
-        private void ReverifyAndProcessPayload(ConsensusPayload payload)
+        private bool ReverifyAndProcessPayload(ConsensusPayload payload)
         {
-            if (!payload.Verify(context.Snapshot)) return;
+            if (!payload.Verify(context.Snapshot)) return false;
             OnConsensusPayload(payload);
+            return true;
         }
 
         private void SendPrepareRequest()

--- a/neo/Consensus/ConsensusService.cs
+++ b/neo/Consensus/ConsensusService.cs
@@ -290,8 +290,7 @@ namespace Neo.Consensus
                     if (context.CommitSent()) return;
                     ConsensusPayload[] changeViewPayloads = message.GetChangeViewPayloads(context, payload);
                     foreach (ConsensusPayload changeViewPayload in changeViewPayloads)
-                        ReverifyAndProcessPayload(changeViewPayload);                        
-                    Log($"{nameof(OnRecoveryMessageReceived)}: changeViewPayloads were processed.");
+                        ReverifyAndProcessPayload(changeViewPayload);
                 }
                 if (message.ViewNumber != context.ViewNumber) return;
                 if (!context.CommitSent())
@@ -307,15 +306,14 @@ namespace Neo.Consensus
                     ConsensusPayload[] prepareResponsePayloads = message.GetPrepareResponsePayloads(context, payload);
                     foreach (ConsensusPayload prepareResponsePayload in prepareResponsePayloads)
                         ReverifyAndProcessPayload(prepareResponsePayload);
-                    Log($"{nameof(OnRecoveryMessageReceived)}: prepareResponsePayloads were processed.");
                 }
                 ConsensusPayload[] commitPayloads = message.GetCommitPayloadsFromRecoveryMessage(context, payload);
                 foreach (ConsensusPayload commitPayload in commitPayloads)
                     ReverifyAndProcessPayload(commitPayload);
-                Log($"{nameof(OnRecoveryMessageReceived)}: node should be recovered.");                    
             }
             finally
             {
+                Log($"{nameof(OnRecoveryMessageReceived)}: finished.");
                 isRecovering = false;
             }
         }

--- a/neo/Consensus/ConsensusService.cs
+++ b/neo/Consensus/ConsensusService.cs
@@ -325,7 +325,7 @@ namespace Neo.Consensus
                 Log($"{nameof(OnRecoveryMessageReceived)}: finished (valid/total) " +
                     $"ChgView: {validChangeViews}/{totalChangeViews} " +
                     $"PrepReq: {validPrepReq}/{totalPrepReq} " +
-                    $"PrepResp: {validPrepResponses}/{totalPrepResponses}" +
+                    $"PrepResp: {validPrepResponses}/{totalPrepResponses} " +
                     $"Commits: {validCommits}/{totalCommits}");
                 isRecovering = false;
             }

--- a/neo/Consensus/ConsensusService.cs
+++ b/neo/Consensus/ConsensusService.cs
@@ -291,7 +291,6 @@ namespace Neo.Consensus
                         ReverifyAndProcessPayload(changeViewPayload);                        
                     Log($"{nameof(OnRecoveryMessageReceived)}: changeViewPayloads were processed.");
                 }
-
                 if (message.ViewNumber != context.ViewNumber) return;
                 if (!context.CommitSent())
                 {


### PR DESCRIPTION
We need more logs for completely understanding `OnRecoveryMessageReceived`, otherwise, we can get confused if we are processing the payload from the RecoverPayload or we are receiving another payload from the network.