### PR TITLE
Prevent Commit after ChangeView

### DIFF
--- a/neo/Consensus/ConsensusContext.cs
+++ b/neo/Consensus/ConsensusContext.cs
@@ -61,7 +61,7 @@ namespace Neo.Consensus
                 ContractParametersContext sc = new ContractParametersContext(Block);
                 for (int i = 0, j = 0; i < Validators.Length && j < this.M(); i++)
                 {
-                    if (CommitPayloads[i] == null || CommitPayloads[i].ConsensusMessage.ViewNumber != ViewNumber) continue;
+                    if (CommitPayloads[i]?.ConsensusMessage.ViewNumber != ViewNumber) continue;
                     sc.AddSignature(contract, Validators[i], CommitPayloads[i].GetDeserializedMessage<Commit>().Signature);
                     j++;
                 }

--- a/neo/Consensus/ConsensusContext.cs
+++ b/neo/Consensus/ConsensusContext.cs
@@ -61,7 +61,7 @@ namespace Neo.Consensus
                 ContractParametersContext sc = new ContractParametersContext(Block);
                 for (int i = 0, j = 0; i < Validators.Length && j < this.M(); i++)
                 {
-                    if (CommitPayloads[i] == null) continue;
+                    if (CommitPayloads[i] == null || CommitPayloads[i].ConsensusMessage.ViewNumber != ViewNumber) continue;
                     sc.AddSignature(contract, Validators[i], CommitPayloads[i].GetDeserializedMessage<Commit>().Signature);
                     j++;
                 }
@@ -146,12 +146,10 @@ namespace Neo.Consensus
 
         public ConsensusPayload MakeCommit()
         {
-            if (CommitPayloads[MyIndex] == null)
-                CommitPayloads[MyIndex] = MakeSignedPayload(new Commit
-                {
-                    Signature = MakeHeader()?.Sign(keyPair)
-                });
-            return CommitPayloads[MyIndex];
+            return CommitPayloads[MyIndex] ?? (CommitPayloads[MyIndex] = MakeSignedPayload(new Commit
+            {
+                Signature = MakeHeader()?.Sign(keyPair)
+            }));
         }
 
         private Block _header = null;
@@ -267,6 +265,7 @@ namespace Neo.Consensus
                 MyIndex = -1;
                 ChangeViewPayloads = new ConsensusPayload[Validators.Length];
                 LastChangeViewPayloads = new ConsensusPayload[Validators.Length];
+                CommitPayloads = new ConsensusPayload[Validators.Length];
                 keyPair = null;
                 for (int i = 0; i < Validators.Length; i++)
                 {
@@ -290,7 +289,6 @@ namespace Neo.Consensus
             Timestamp = 0;
             TransactionHashes = null;
             PreparationPayloads = new ConsensusPayload[Validators.Length];
-            CommitPayloads = new ConsensusPayload[Validators.Length];
             _header = null;
         }
 

--- a/neo/Consensus/ConsensusService.cs
+++ b/neo/Consensus/ConsensusService.cs
@@ -293,24 +293,21 @@ namespace Neo.Consensus
                         ReverifyAndProcessPayload(changeViewPayload);
                 }
                 if (message.ViewNumber != context.ViewNumber) return;
-                if (!context.ViewChanging())
+                if (!context.ViewChanging() && !context.CommitSent())
                 {
-                    if (!context.CommitSent())
+                    if (!context.RequestSentOrReceived())
                     {
-                        if (!context.RequestSentOrReceived())
-                        {
-                            ConsensusPayload prepareRequestPayload = message.GetPrepareRequestPayload(context, payload);
-                            if (prepareRequestPayload != null)
-                                ReverifyAndProcessPayload(prepareRequestPayload);
-                            else if (context.IsPrimary())
-                                SendPrepareRequest();
-                        }
-
-                        ConsensusPayload[] prepareResponsePayloads =
-                            message.GetPrepareResponsePayloads(context, payload);
-                        foreach (ConsensusPayload prepareResponsePayload in prepareResponsePayloads)
-                            ReverifyAndProcessPayload(prepareResponsePayload);
+                        ConsensusPayload prepareRequestPayload = message.GetPrepareRequestPayload(context, payload);
+                        if (prepareRequestPayload != null)
+                            ReverifyAndProcessPayload(prepareRequestPayload);
+                        else if (context.IsPrimary())
+                            SendPrepareRequest();
                     }
+
+                    ConsensusPayload[] prepareResponsePayloads =
+                        message.GetPrepareResponsePayloads(context, payload);
+                    foreach (ConsensusPayload prepareResponsePayload in prepareResponsePayloads)
+                        ReverifyAndProcessPayload(prepareResponsePayload);
                 }
                 ConsensusPayload[] commitPayloads = message.GetCommitPayloadsFromRecoveryMessage(context, payload);
                 foreach (ConsensusPayload commitPayload in commitPayloads)

--- a/neo/Consensus/ConsensusService.cs
+++ b/neo/Consensus/ConsensusService.cs
@@ -99,7 +99,7 @@ namespace Neo.Consensus
 
         private void CheckCommits()
         {
-            if (context.CommitPayloads.Count(p => p != null && p.ConsensusMessage.ViewNumber == context.ViewNumber) >= context.M() && context.TransactionHashes.All(p => context.Transactions.ContainsKey(p)))
+            if (context.CommitPayloads.Count(p => p?.ConsensusMessage.ViewNumber == context.ViewNumber) >= context.M() && context.TransactionHashes.All(p => context.Transactions.ContainsKey(p)))
             {
                 Block block = context.CreateBlock();
                 Log($"relay block: {block.Hash}");
@@ -299,7 +299,7 @@ namespace Neo.Consensus
         {
             // isRecovering is always set to false again after OnRecoveryMessageReceived
             isRecovering = true;
-            int validChangeViews = 0, totalChangeViews = 0, validPrepReq=0, totalPrepReq = 0;
+            int validChangeViews = 0, totalChangeViews = 0, validPrepReq = 0, totalPrepReq = 0;
             int validPrepResponses = 0, totalPrepResponses = 0, validCommits = 0, totalCommits = 0;
 
             Log($"{nameof(OnRecoveryMessageReceived)}: height={payload.BlockIndex} view={message.ViewNumber} index={payload.ValidatorIndex}");

--- a/neo/Consensus/ConsensusService.cs
+++ b/neo/Consensus/ConsensusService.cs
@@ -223,6 +223,7 @@ namespace Neo.Consensus
             ref ConsensusPayload existingCommitPayload = ref context.CommitPayloads[payload.ValidatorIndex];
             if (commit.ViewNumber == context.ViewNumber)
             {
+                if (existingCommitPayload != null && context.ViewNumber == existingCommitPayload.ConsensusMessage.ViewNumber) return;
                 Log($"{nameof(OnCommitReceived)}: height={payload.BlockIndex} view={commit.ViewNumber} index={payload.ValidatorIndex}");
 
                 byte[] hashData = context.MakeHeader()?.GetHashData();

--- a/neo/Consensus/ConsensusService.cs
+++ b/neo/Consensus/ConsensusService.cs
@@ -324,7 +324,7 @@ namespace Neo.Consensus
                         if (ReverifyAndProcessPayload(changeViewPayload)) validChangeViews++;
                 }
                 if (message.ViewNumber != context.ViewNumber) return;
-                if (!context.ViewChangingIfAllowed() && !context.CommitSent())
+                if (!context.NotAcceptingPayloadsDueToViewChanging() && !context.CommitSent())
                 {
                     if (!context.RequestSentOrReceived())
                     {
@@ -360,7 +360,7 @@ namespace Neo.Consensus
 
         private void OnPrepareRequestReceived(ConsensusPayload payload, PrepareRequest message)
         {
-            if (context.RequestSentOrReceived() || context.ViewChangingIfAllowed()) return;
+            if (context.RequestSentOrReceived() || context.NotAcceptingPayloadsDueToViewChanging()) return;
             if (payload.ValidatorIndex != context.PrimaryIndex) return;
             Log($"{nameof(OnPrepareRequestReceived)}: height={payload.BlockIndex} view={message.ViewNumber} index={payload.ValidatorIndex} tx={message.TransactionHashes.Length}");
             if (message.Timestamp <= context.PrevHeader().Timestamp || message.Timestamp > TimeProvider.Current.UtcNow.AddMinutes(10).ToTimestamp())
@@ -421,7 +421,7 @@ namespace Neo.Consensus
 
         private void OnPrepareResponseReceived(ConsensusPayload payload, PrepareResponse message)
         {
-            if (context.PreparationPayloads[payload.ValidatorIndex] != null || context.ViewChangingIfAllowed()) return;
+            if (context.PreparationPayloads[payload.ValidatorIndex] != null || context.NotAcceptingPayloadsDueToViewChanging()) return;
             if (context.PreparationPayloads[context.PrimaryIndex] != null && !message.PreparationHash.Equals(context.PreparationPayloads[context.PrimaryIndex].Hash))
                 return;
             Log($"{nameof(OnPrepareResponseReceived)}: height={payload.BlockIndex} view={message.ViewNumber} index={payload.ValidatorIndex}");
@@ -515,7 +515,7 @@ namespace Neo.Consensus
         private void OnTransaction(Transaction transaction)
         {
             if (transaction.Type == TransactionType.MinerTransaction) return;
-            if (!context.IsBackup() || context.ViewChangingIfAllowed() || !context.RequestSentOrReceived() || context.ResponseSent() || context.BlockSent())
+            if (!context.IsBackup() || context.NotAcceptingPayloadsDueToViewChanging() || !context.RequestSentOrReceived() || context.ResponseSent() || context.BlockSent())
                 return;
             if (context.Transactions.ContainsKey(transaction.Hash)) return;
             if (!context.TransactionHashes.Contains(transaction.Hash)) return;

--- a/neo/Consensus/ConsensusService.cs
+++ b/neo/Consensus/ConsensusService.cs
@@ -303,9 +303,7 @@ namespace Neo.Consensus
                         else if (context.IsPrimary())
                             SendPrepareRequest();
                     }
-
-                    ConsensusPayload[] prepareResponsePayloads =
-                        message.GetPrepareResponsePayloads(context, payload);
+                    ConsensusPayload[] prepareResponsePayloads = message.GetPrepareResponsePayloads(context, payload);
                     foreach (ConsensusPayload prepareResponsePayload in prepareResponsePayloads)
                         ReverifyAndProcessPayload(prepareResponsePayload);
                 }

--- a/neo/Consensus/ConsensusService.cs
+++ b/neo/Consensus/ConsensusService.cs
@@ -239,15 +239,9 @@ namespace Neo.Consensus
                 return;
             }
             // Receiving commit from another view
+            if (existingCommitPayload != null) return;
             Log($"{nameof(OnCommitReceived)}: record commit for different view={commit.ViewNumber} index={payload.ValidatorIndex} height={payload.BlockIndex}");
-            if (existingCommitPayload == null)
-                existingCommitPayload = payload;
-            else
-            {
-                var existingViewNumber = existingCommitPayload.ConsensusMessage.ViewNumber;
-                if (existingViewNumber == context.ViewNumber || commit.ViewNumber <= existingViewNumber) return;
-                existingCommitPayload = payload;
-            }
+            existingCommitPayload = payload;
         }
 
         private void OnConsensusPayload(ConsensusPayload payload)

--- a/neo/Consensus/ConsensusService.cs
+++ b/neo/Consensus/ConsensusService.cs
@@ -116,7 +116,6 @@ namespace Neo.Consensus
                 if (message is null || message.NewViewNumber < viewNumber)
                     localNode.Tell(new LocalNode.SendDirectly { Inventory = context.MakeChangeView(viewNumber) });
                 InitializeConsensus(viewNumber);
-                context.Save();
             }
         }
 
@@ -441,14 +440,11 @@ namespace Neo.Consensus
                     CheckPreparations();
                     return;
                 }
-                InitializeConsensus(context.ViewNumber);
             }
-            else
-                InitializeConsensus(0);
-
+            InitializeConsensus(0);
             // Issue a ChangeView with NewViewNumber of 0 to request recovery messages on start-up.
             if (context.BlockIndex == Blockchain.Singleton.HeaderHeight + 1)
-                localNode.Tell(new LocalNode.SendDirectly {Inventory = context.MakeChangeView(context.ViewNumber)});
+                localNode.Tell(new LocalNode.SendDirectly { Inventory = context.MakeChangeView(0) });
         }
 
         private void OnTimer(Timer timer)

--- a/neo/Consensus/ConsensusService.cs
+++ b/neo/Consensus/ConsensusService.cs
@@ -266,7 +266,11 @@ namespace Neo.Consensus
             foreach (IP2PPlugin plugin in Plugin.P2PPlugins)
                 if (!plugin.OnConsensusMessage(payload))
                     return;
-            switch (payload.ConsensusMessage)
+            ConsensusMessage message = payload.ConsensusMessage;
+            if (message.ViewNumber != context.ViewNumber && (message.Type == ConsensusMessageType.PrepareRequest ||
+                                                             message.Type == ConsensusMessageType.PrepareResponse))
+                return;
+            switch (message)
             {
                 case ChangeView view:
                     OnChangeViewReceived(payload, view);

--- a/neo/Consensus/ConsensusService.cs
+++ b/neo/Consensus/ConsensusService.cs
@@ -224,7 +224,7 @@ namespace Neo.Consensus
             if (existingCommitPayload != null)
             {
                 if (existingCommitPayload.Hash != payload.Hash)
-                    Log($"{nameof(OnCommitReceived)}: Warning, different commit from validator! height={payload.BlockIndex} index={payload.ValidatorIndex} view={commit.ViewNumber} existingView={existingCommitPayload.ConsensusMessage.ViewNumber}");
+                    Log($"{nameof(OnCommitReceived)}: different commit from validator! height={payload.BlockIndex} index={payload.ValidatorIndex} view={commit.ViewNumber} existingView={existingCommitPayload.ConsensusMessage.ViewNumber}", LogLevel.Warning);
                 return;
             }
 

--- a/neo/Consensus/ConsensusService.cs
+++ b/neo/Consensus/ConsensusService.cs
@@ -266,11 +266,7 @@ namespace Neo.Consensus
             foreach (IP2PPlugin plugin in Plugin.P2PPlugins)
                 if (!plugin.OnConsensusMessage(payload))
                     return;
-            ConsensusMessage message = payload.ConsensusMessage;
-            if (message.ViewNumber != context.ViewNumber && (message.Type == ConsensusMessageType.PrepareRequest ||
-                                                             message.Type == ConsensusMessageType.PrepareResponse))
-                return;
-            switch (message)
+            switch (payload.ConsensusMessage)
             {
                 case ChangeView view:
                     OnChangeViewReceived(payload, view);

--- a/neo/Consensus/ConsensusService.cs
+++ b/neo/Consensus/ConsensusService.cs
@@ -221,9 +221,15 @@ namespace Neo.Consensus
         private void OnCommitReceived(ConsensusPayload payload, Commit commit)
         {
             ref ConsensusPayload existingCommitPayload = ref context.CommitPayloads[payload.ValidatorIndex];
+            if (existingCommitPayload != null)
+            {
+                if (existingCommitPayload.Hash != payload.Hash)
+                    Log($"{nameof(OnCommitReceived)}: Warning, different commit from validator! height={payload.BlockIndex} index={payload.ValidatorIndex} view={commit.ViewNumber} existingView={existingCommitPayload.ConsensusMessage.ViewNumber}");
+                return;
+            }
+
             if (commit.ViewNumber == context.ViewNumber)
             {
-                if (existingCommitPayload != null && context.ViewNumber == existingCommitPayload.ConsensusMessage.ViewNumber) return;
                 Log($"{nameof(OnCommitReceived)}: height={payload.BlockIndex} view={commit.ViewNumber} index={payload.ValidatorIndex}");
 
                 byte[] hashData = context.MakeHeader()?.GetHashData();
@@ -240,7 +246,6 @@ namespace Neo.Consensus
                 return;
             }
             // Receiving commit from another view
-            if (existingCommitPayload != null) return;
             Log($"{nameof(OnCommitReceived)}: record commit for different view={commit.ViewNumber} index={payload.ValidatorIndex} height={payload.BlockIndex}");
             existingCommitPayload = payload;
         }

--- a/neo/Consensus/ConsensusService.cs
+++ b/neo/Consensus/ConsensusService.cs
@@ -377,9 +377,8 @@ namespace Neo.Consensus
             context.PreparationPayloads[payload.ValidatorIndex] = payload;
             byte[] hashData = context.MakeHeader().GetHashData();
             for (int i = 0; i < context.CommitPayloads.Length; i++)
-                if (context.CommitPayloads[i] != null)
-                    if (context.CommitPayloads[i].ConsensusMessage.ViewNumber == context.ViewNumber &&
-                        !Crypto.Default.VerifySignature(hashData, context.CommitPayloads[i].GetDeserializedMessage<Commit>().Signature, context.Validators[i].EncodePoint(false)))
+                if (context.CommitPayloads[i]?.ConsensusMessage.ViewNumber == context.ViewNumber)
+                    if (!Crypto.Default.VerifySignature(hashData, context.CommitPayloads[i].GetDeserializedMessage<Commit>().Signature, context.Validators[i].EncodePoint(false)))
                         context.CommitPayloads[i] = null;
             Dictionary<UInt256, Transaction> mempoolVerified = Blockchain.Singleton.MemPool.GetVerifiedTransactions().ToDictionary(p => p.Hash);
 

--- a/neo/Consensus/ConsensusService.cs
+++ b/neo/Consensus/ConsensusService.cs
@@ -302,7 +302,7 @@ namespace Neo.Consensus
                 ConsensusPayload[] commitPayloads;
                 if (message.ViewNumber < context.ViewNumber)
                 {
-                    // Ensure we know about all commits form lower view numbers.
+                    // Ensure we know about all commits from lower view numbers.
                     commitPayloads = message.GetCommitPayloadsFromRecoveryMessage(context, payload);
                     totalCommits = commitPayloads.Length;
                     foreach (ConsensusPayload commitPayload in commitPayloads)

--- a/neo/Consensus/Helper.cs
+++ b/neo/Consensus/Helper.cs
@@ -31,7 +31,7 @@ namespace Neo.Consensus
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool ViewChanging(this IConsensusContext context) => context.ChangeViewPayloads[context.MyIndex]?.GetDeserializedMessage<ChangeView>().NewViewNumber > context.ViewNumber;
 
-        public static bool ViewChangingIfAllowed(this IConsensusContext context) => context.ViewChanging() && !context.MoreThanFNodesCommitted();
+        public static bool NotAcceptingPayloadsDueToViewChanging(this IConsensusContext context) => context.ViewChanging() && !context.MoreThanFNodesCommitted();
 
         // A possible attack can happen if the last node to commit is malicious and either sends change view after his
         // commit to stall nodes in a higher view, or if he refuses to send recovery messages. In addition, if a node

--- a/neo/Consensus/Helper.cs
+++ b/neo/Consensus/Helper.cs
@@ -1,4 +1,5 @@
-﻿using Neo.Network.P2P.Payloads;
+﻿using System.Linq;
+using Neo.Network.P2P.Payloads;
 using Neo.Persistence;
 using System.Runtime.CompilerServices;
 
@@ -26,8 +27,11 @@ namespace Neo.Consensus
         public static bool CommitSent(this IConsensusContext context) => context.CommitPayloads[context.MyIndex] != null;
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool BlockSent(this IConsensusContext context) => context.Block != null;
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool ViewChanging(this IConsensusContext context) => context.ChangeViewPayloads[context.MyIndex]?.GetDeserializedMessage<ChangeView>().NewViewNumber > context.ViewNumber;
+        public static bool ViewChanging(this IConsensusContext context) => context.ChangeViewPayloads[context.MyIndex]?.GetDeserializedMessage<ChangeView>().NewViewNumber > context.ViewNumber && !context.FNodesValidCommitted();
+
+        public static bool FNodesValidCommitted(this IConsensusContext context) => context.CommitPayloads.Count(p => p != null) >= context.F();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static uint GetPrimaryIndex(this IConsensusContext context, byte viewNumber)

--- a/neo/Consensus/Helper.cs
+++ b/neo/Consensus/Helper.cs
@@ -38,7 +38,6 @@ namespace Neo.Consensus
         // asking change views loses network or crashes and comes back when nodes are committed in more than one higher
         // numbered view, it is possible for the node accepting recovery and commit in any of the higher views, thus
         // potentially splitting nodes among views and stalling the network.
-        // TODO: Fix this to properly count all committed payloads including at lower view numbers.
         public static bool MoreThanFNodesCommitted(this IConsensusContext context) => context.CommitPayloads.Count(p => p != null) > context.F();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/neo/Consensus/Helper.cs
+++ b/neo/Consensus/Helper.cs
@@ -36,7 +36,7 @@ namespace Neo.Consensus
         // asking change views loses network or crashes and comes back when nodes are committed in more than one higher
         // numbered view, it is possible for the node accepting recovery and commit in any of the higher views, thus
         // potentially splitting nodes among views and stalling the network.
-        public static bool FNodesCommitted(this IConsensusContext context) => context.CommitPayloads.Count(p => p != null) >= context.F();
+        public static bool FNodesCommitted(this IConsensusContext context) => context.CommitPayloads.Count(p => p != null) > context.F();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static uint GetPrimaryIndex(this IConsensusContext context, byte viewNumber)

--- a/neo/Consensus/Helper.cs
+++ b/neo/Consensus/Helper.cs
@@ -29,14 +29,14 @@ namespace Neo.Consensus
         public static bool BlockSent(this IConsensusContext context) => context.Block != null;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool ViewChanging(this IConsensusContext context) => context.ChangeViewPayloads[context.MyIndex]?.GetDeserializedMessage<ChangeView>().NewViewNumber > context.ViewNumber && !context.FNodesValidCommitted();
+        public static bool ViewChanging(this IConsensusContext context) => context.ChangeViewPayloads[context.MyIndex]?.GetDeserializedMessage<ChangeView>().NewViewNumber > context.ViewNumber && !context.FNodesCommitted();
 
         // A possible attack can happen if the last node to commit is malicious and either sends change view after his
         // commit to stall nodes in a higher view, or if he refuses to send recovery messages. In addition, if a node
         // asking change views loses network or crashes and comes back when nodes are committed in more than one higher
         // numbered view, it is possible for the node accepting recovery and commit in any of the higher views, thus
         // potentially splitting nodes among views and stalling the network.
-        public static bool FNodesValidCommitted(this IConsensusContext context) => context.CommitPayloads.Count(p => p != null) >= context.F();
+        public static bool FNodesCommitted(this IConsensusContext context) => context.CommitPayloads.Count(p => p != null) >= context.F();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static uint GetPrimaryIndex(this IConsensusContext context, byte viewNumber)

--- a/neo/Consensus/Helper.cs
+++ b/neo/Consensus/Helper.cs
@@ -33,9 +33,9 @@ namespace Neo.Consensus
 
         // A possible attack can happen if the last node to commit is malicious and either sends change view after his
         // commit to stall nodes in a higher view, or if he refuses to send recovery messages. In addition, if a node
-        // asking change views loses network or crashes and comes back when nodes are committed in more than one view,
-        // it is possible for that node to accept recovery from any committed node, thus potentially splitting nodes
-        // among views and stalling the network.
+        // asking change views loses network or crashes and comes back when nodes are committed in more than one higher
+        // numbered view, it is possible for the node accepting recovery and commit in any of the higher views, thus
+        // potentially splitting nodes among views and stalling the network.
         public static bool FNodesValidCommitted(this IConsensusContext context) => context.CommitPayloads.Count(p => p != null) >= context.F();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/neo/Consensus/Helper.cs
+++ b/neo/Consensus/Helper.cs
@@ -31,6 +31,11 @@ namespace Neo.Consensus
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool ViewChanging(this IConsensusContext context) => context.ChangeViewPayloads[context.MyIndex]?.GetDeserializedMessage<ChangeView>().NewViewNumber > context.ViewNumber && !context.FNodesValidCommitted();
 
+        // A possible attack can happen if the last node to commit is malicious and either sends change view after his
+        // commit to stall nodes in a higher view, or if he refuses to send recovery messages. In addition, if a node
+        // asking change views crashes and comes back when nodes are committed in more than one view, it is possible for
+        // the restart node to accept recovery from any committed node, thus potentially splitting nodes among views
+        // and stalling the network.
         public static bool FNodesValidCommitted(this IConsensusContext context) => context.CommitPayloads.Count(p => p != null) >= context.F();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/neo/Consensus/Helper.cs
+++ b/neo/Consensus/Helper.cs
@@ -29,14 +29,14 @@ namespace Neo.Consensus
         public static bool BlockSent(this IConsensusContext context) => context.Block != null;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool ViewChanging(this IConsensusContext context) => context.ChangeViewPayloads[context.MyIndex]?.GetDeserializedMessage<ChangeView>().NewViewNumber > context.ViewNumber && !context.FNodesCommitted();
+        public static bool ViewChanging(this IConsensusContext context) => context.ChangeViewPayloads[context.MyIndex]?.GetDeserializedMessage<ChangeView>().NewViewNumber > context.ViewNumber && !context.MoreThanFNodesCommitted();
 
         // A possible attack can happen if the last node to commit is malicious and either sends change view after his
         // commit to stall nodes in a higher view, or if he refuses to send recovery messages. In addition, if a node
         // asking change views loses network or crashes and comes back when nodes are committed in more than one higher
         // numbered view, it is possible for the node accepting recovery and commit in any of the higher views, thus
         // potentially splitting nodes among views and stalling the network.
-        public static bool FNodesCommitted(this IConsensusContext context) => context.CommitPayloads.Count(p => p != null) > context.F();
+        public static bool MoreThanFNodesCommitted(this IConsensusContext context) => context.CommitPayloads.Count(p => p != null) > context.F();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static uint GetPrimaryIndex(this IConsensusContext context, byte viewNumber)

--- a/neo/Consensus/Helper.cs
+++ b/neo/Consensus/Helper.cs
@@ -33,9 +33,9 @@ namespace Neo.Consensus
 
         // A possible attack can happen if the last node to commit is malicious and either sends change view after his
         // commit to stall nodes in a higher view, or if he refuses to send recovery messages. In addition, if a node
-        // asking change views crashes and comes back when nodes are committed in more than one view, it is possible for
-        // the restart node to accept recovery from any committed node, thus potentially splitting nodes among views
-        // and stalling the network.
+        // asking change views loses network or crashes and comes back when nodes are committed in more than one view,
+        // it is possible for that node to accept recovery from any committed node, thus potentially splitting nodes
+        // among views and stalling the network.
         public static bool FNodesValidCommitted(this IConsensusContext context) => context.CommitPayloads.Count(p => p != null) >= context.F();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/neo/Consensus/Helper.cs
+++ b/neo/Consensus/Helper.cs
@@ -29,13 +29,16 @@ namespace Neo.Consensus
         public static bool BlockSent(this IConsensusContext context) => context.Block != null;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool ViewChanging(this IConsensusContext context) => context.ChangeViewPayloads[context.MyIndex]?.GetDeserializedMessage<ChangeView>().NewViewNumber > context.ViewNumber && !context.MoreThanFNodesCommitted();
+        public static bool ViewChanging(this IConsensusContext context) => context.ChangeViewPayloads[context.MyIndex]?.GetDeserializedMessage<ChangeView>().NewViewNumber > context.ViewNumber;
+
+        public static bool ViewChangingIfAllowed(this IConsensusContext context) => context.ViewChanging() && !context.MoreThanFNodesCommitted();
 
         // A possible attack can happen if the last node to commit is malicious and either sends change view after his
         // commit to stall nodes in a higher view, or if he refuses to send recovery messages. In addition, if a node
         // asking change views loses network or crashes and comes back when nodes are committed in more than one higher
         // numbered view, it is possible for the node accepting recovery and commit in any of the higher views, thus
         // potentially splitting nodes among views and stalling the network.
+        // TODO: Fix this to properly count all committed payloads including at lower view numbers.
         public static bool MoreThanFNodesCommitted(this IConsensusContext context) => context.CommitPayloads.Count(p => p != null) > context.F();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/neo/Consensus/RecoveryMessage.CommitPayloadCompact.cs
+++ b/neo/Consensus/RecoveryMessage.CommitPayloadCompact.cs
@@ -8,17 +8,20 @@ namespace Neo.Consensus
     {
         public class CommitPayloadCompact : ISerializable
         {
+            public byte ViewNumber;
             public ushort ValidatorIndex;
             public byte[] Signature;
             public byte[] InvocationScript;
 
             int ISerializable.Size =>
+                sizeof(byte) +                  //ViewNumber
                 sizeof(ushort) +                //ValidatorIndex
                 Signature.Length +              //Signature
                 InvocationScript.GetVarSize();  //InvocationScript
 
             void ISerializable.Deserialize(BinaryReader reader)
             {
+                ViewNumber = reader.ReadByte();
                 ValidatorIndex = reader.ReadUInt16();
                 Signature = reader.ReadBytes(64);
                 InvocationScript = reader.ReadVarBytes(1024);
@@ -29,6 +32,7 @@ namespace Neo.Consensus
                 Commit message = payload.GetDeserializedMessage<Commit>();
                 return new CommitPayloadCompact
                 {
+                    ViewNumber = message.ViewNumber,
                     ValidatorIndex = payload.ValidatorIndex,
                     Signature = message.Signature,
                     InvocationScript = payload.Witness.InvocationScript
@@ -37,6 +41,7 @@ namespace Neo.Consensus
 
             void ISerializable.Serialize(BinaryWriter writer)
             {
+                writer.Write(ViewNumber);
                 writer.Write(ValidatorIndex);
                 writer.Write(Signature);
                 writer.WriteVarBytes(InvocationScript);

--- a/neo/Consensus/RecoveryMessage.cs
+++ b/neo/Consensus/RecoveryMessage.cs
@@ -71,7 +71,7 @@ namespace Neo.Consensus
                 ValidatorIndex = p.ValidatorIndex,
                 ConsensusMessage = new Commit
                 {
-                    ViewNumber = ViewNumber,
+                    ViewNumber = p.ViewNumber,
                     Signature = p.Signature
                 },
                 Witness = new Witness


### PR DESCRIPTION
Since we do not ever allow the view to jump backward during recovery, we cannot allow change view to occur after more than `F` nodes have committed to any view. Therefore, if a node has sent a change view message, it can not be allowed to reach commit in the view from which it has requested to change. This fix addresses the issue and prevents a stall.