### PR TITLE
Fix crash on consensus watch-only nodes

### DIFF
--- a/neo/Consensus/ConsensusService.cs
+++ b/neo/Consensus/ConsensusService.cs
@@ -152,10 +152,10 @@ namespace Neo.Consensus
         private void InitializeConsensus(byte viewNumber)
         {
             context.Reset(viewNumber);
-            if (context.MyIndex < 0) return;
             if (viewNumber > 0)
                 Log($"changeview: view={viewNumber} primary={context.Validators[context.GetPrimaryIndex((byte)(viewNumber - 1u))]}", LogLevel.Warning);
             Log($"initialize: height={context.BlockIndex} view={viewNumber} index={context.MyIndex} role={(context.IsPrimary() ? "Primary" : "Backup")}");
+            if (context.MyIndex < 0) return;
             if (context.IsPrimary())
             {
                 if (isRecovering)
@@ -588,3 +588,4 @@ namespace Neo.Consensus
         }
     }
 }
+

--- a/neo/Consensus/ConsensusService.cs
+++ b/neo/Consensus/ConsensusService.cs
@@ -285,7 +285,6 @@ namespace Neo.Consensus
         {
             if (message.ViewNumber < context.ViewNumber) return;
             Log($"{nameof(OnRecoveryMessageReceived)}: height={payload.BlockIndex} view={message.ViewNumber} index={payload.ValidatorIndex}");
-            if (context.WatchOnly()) return;
             // isRecovering is always set to false again after OnRecoveryMessageReceived
             isRecovering = true;
             int validChangeViews = 0, totalChangeViews = 0, validPrepReq = 0, totalPrepReq = 0;

--- a/neo/Consensus/ConsensusService.cs
+++ b/neo/Consensus/ConsensusService.cs
@@ -459,7 +459,7 @@ namespace Neo.Consensus
             }
             InitializeConsensus(0);
             // Issue a ChangeView with NewViewNumber of 0 to request recovery messages on start-up.
-            if (context.BlockIndex == Blockchain.Singleton.HeaderHeight + 1)
+            if (context.BlockIndex == Blockchain.Singleton.HeaderHeight + 1 && !context.WatchOnly())
                 localNode.Tell(new LocalNode.SendDirectly { Inventory = context.MakeChangeView(0) });
         }
 

--- a/neo/Consensus/Helper.cs
+++ b/neo/Consensus/Helper.cs
@@ -15,19 +15,21 @@ namespace Neo.Consensus
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsBackup(this IConsensusContext context) => context.MyIndex >= 0 && context.MyIndex != context.PrimaryIndex;
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool WatchOnly(this IConsensusContext context) => context.MyIndex < 0;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Header PrevHeader(this IConsensusContext context) => context.Snapshot.GetHeader(context.PrevHash);
 
         // Consensus States
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool RequestSentOrReceived(this IConsensusContext context) => context.PreparationPayloads[context.PrimaryIndex] != null;
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool ResponseSent(this IConsensusContext context) => context.PreparationPayloads[context.MyIndex] != null;
+        public static bool ResponseSent(this IConsensusContext context) => !context.WatchOnly() && context.PreparationPayloads[context.MyIndex] != null;
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool CommitSent(this IConsensusContext context) => !context.WatchOnly() && context.CommitPayloads[context.MyIndex] != null;
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool BlockSent(this IConsensusContext context) => context.Block != null;
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool ViewChanging(this IConsensusContext context) => context.ChangeViewPayloads[context.MyIndex]?.GetDeserializedMessage<ChangeView>().NewViewNumber > context.ViewNumber;
+        public static bool ViewChanging(this IConsensusContext context) => !context.WatchOnly() && context.ChangeViewPayloads[context.MyIndex]?.GetDeserializedMessage<ChangeView>().NewViewNumber > context.ViewNumber;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static uint GetPrimaryIndex(this IConsensusContext context, byte viewNumber)
@@ -35,8 +37,5 @@ namespace Neo.Consensus
             int p = ((int)context.BlockIndex - viewNumber) % context.Validators.Length;
             return p >= 0 ? (uint)p : (uint)(p + context.Validators.Length);
         }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool WatchOnly(this IConsensusContext context) => context.MyIndex == -1;
     }
 }

--- a/neo/Consensus/Helper.cs
+++ b/neo/Consensus/Helper.cs
@@ -1,4 +1,4 @@
-﻿using Neo.Network.P2P.Payloads;
+using Neo.Network.P2P.Payloads;
 using Neo.Persistence;
 using System.Runtime.CompilerServices;
 
@@ -23,7 +23,7 @@ namespace Neo.Consensus
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool ResponseSent(this IConsensusContext context) => context.PreparationPayloads[context.MyIndex] != null;
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool CommitSent(this IConsensusContext context) => context.CommitPayloads[context.MyIndex] != null;
+        public static bool CommitSent(this IConsensusContext context) => !context.WatchOnly() && context.CommitPayloads[context.MyIndex] != null;
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool BlockSent(this IConsensusContext context) => context.Block != null;
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -35,5 +35,8 @@ namespace Neo.Consensus
             int p = ((int)context.BlockIndex - viewNumber) % context.Validators.Length;
             return p >= 0 ? (uint)p : (uint)(p + context.Validators.Length);
         }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool WatchOnly(this IConsensusContext context) => context.MyIndex == -1;
     }
 }


### PR DESCRIPTION
@hal0x2328 reported and error when monitoring consensus message at neo-cli version 2.10.0.
This PR fix this by avoiding normal nodes to relay any type of Consensus Payloads.

```cs
neo> start consensus
[19:31:17.171] OnStart
[19:31:17.189] OnStop
[ERROR][03/19/2019 19:31:17][Thread 0020][akka://NeoSystem/user/$d] Index was outside the bounds of the array.
Cause: System.IndexOutOfRangeException: Index was outside the bounds of the array.
   at Neo.Consensus.ConsensusContext.MakeChangeView(Byte newViewNumber)
   at Neo.Consensus.ConsensusService.OnStart(Start options)
   at Akka.Actor.UntypedActor.Receive(Object message)
   at Akka.Actor.ActorBase.AroundReceive(Receive receive, Object message)
   at Akka.Actor.ActorCell.ReceiveMessage(Object message)
   at Akka.Actor.ActorCell.Invoke(Envelope envelope)
```

With this change watch-only nodes can even relay blocks. From a scientific perspective, it is a great achievement towards Multi-Agent Systems!
Any kind of consensus algorithms can be seen as that, thus, as better as we highlight our ability to provide such autonomous agents we are ahead.

I suggest the team to motivate the use of this kind of nodes along with pure RPC seed nodes @PeterLinX.
```cs
[20:28:33.761] OnCommitReceived: height=23 view=0 index=0
[20:28:33.771] OnCommitReceived: height=23 view=0 index=3
[20:28:33.772] OnCommitReceived: height=23 view=0 index=2
[20:28:33.781] relay block: 0x116a557b37415082517c60c4bd646948b4eff2270b0d92321fd6c9b092a1ed35
[20:28:33.795] persist block: 0x116a557b37415082517c60c4bd646948b4eff2270b0d92321fd6c9b092a1ed35
[20:28:34.798] OnPrepareRequestReceived: height=24 view=0 index=0 tx=1
[20:28:34.799] send prepare response
[20:28:34.809] OnPrepareResponseReceived: height=24 view=0 index=2
[20:28:34.817] OnPrepareResponseReceived: height=24 view=0 index=1
[20:28:34.823] OnPrepareResponseReceived: height=24 view=0 index=3
[20:28:34.826] OnCommitReceived: height=24 view=0 index=3
[20:28:34.829] OnCommitReceived: height=24 view=0 index=1
[20:28:34.840] OnCommitReceived: height=24 view=0 index=2
[20:28:34.843] relay block: 0x29319d14a685295f2cdc9f6ac693d68dc1216455413d668c9bfe287d7e6b9433
[20:28:34.851] persist block: 0x29319d14a685295f2cdc9f6ac693d68dc1216455413d668c9bfe287d7e6b9433
```