### PR TITLE
[DRAFT] Require locking agreement to ChangeView and allowing committed nodes to move to higher views

### DIFF
--- a/neo/Consensus/ChangeView.cs
+++ b/neo/Consensus/ChangeView.cs
@@ -7,14 +7,22 @@ namespace Neo.Consensus
         public byte NewViewNumber;
         /// <summary>
         /// Timestamp of when the ChangeView message was created. This allows receiving nodes to ensure
-        // they only respond once to a specific ChangeView request (it thus prevents replay of the ChangeView
-        // message from repeatedly broadcasting RecoveryMessages).
+        /// they only respond once to a specific ChangeView request (it thus prevents replay of the ChangeView
+        /// message from repeatedly broadcasting RecoveryMessages).
         /// </summary>
         public uint Timestamp;
+        /// <summary>
+        /// Flag whether the node is locked/committed to change view from it's current view.
+        /// If not set, this indicates this is a request to change view, but not a commitment, and therefore it may
+        /// still accept further preparations and commit to generate a block in the current view.
+        /// If set, this node is locked to change view, and will not accept further preparations in the current view.
+        /// </summary>
+        public bool Locked;
 
         public override int Size => base.Size
             + sizeof(byte)  //NewViewNumber
-            + sizeof(uint); //Timestamp
+            + sizeof(uint)  //Timestamp
+            + sizeof(bool); //Committed
 
         public ChangeView()
             : base(ConsensusMessageType.ChangeView)
@@ -26,6 +34,7 @@ namespace Neo.Consensus
             base.Deserialize(reader);
             NewViewNumber = reader.ReadByte();
             Timestamp = reader.ReadUInt32();
+            Locked = reader.ReadBoolean();
         }
 
         public override void Serialize(BinaryWriter writer)
@@ -33,6 +42,7 @@ namespace Neo.Consensus
             base.Serialize(writer);
             writer.Write(NewViewNumber);
             writer.Write(Timestamp);
+            writer.Write(Locked);
         }
     }
 }

--- a/neo/Consensus/ConsensusContext.cs
+++ b/neo/Consensus/ConsensusContext.cs
@@ -144,7 +144,7 @@ namespace Neo.Consensus
             {
                 NewViewNumber = newViewNumber,
                 Timestamp = TimeProvider.Current.UtcNow.ToTimestamp(),
-                Locked = changeViewLockedCount >= this.M() && !this.ResponseSent() && !(this.IsPrimary() && this.RequestSentOrReceived())
+                Locked = changeViewLockedCount >= this.M() && !(this.ResponseSent() || this.IsPrimary())
             });
         }
 

--- a/neo/Consensus/ConsensusContext.cs
+++ b/neo/Consensus/ConsensusContext.cs
@@ -145,7 +145,6 @@ namespace Neo.Consensus
                 NewViewNumber = newViewNumber,
                 Timestamp = TimeProvider.Current.UtcNow.ToTimestamp(),
                 // Primary will just change view after seing M guys locked to change view, as well as those who agreed with the current PrepReq
-                // NOTE: This may reduce liveness of dBFT, because the remainder locked nodes will be responsible for changing view by themselves
                 Locked = changeViewLockedCount >= this.M() && !(this.ResponseSent() || this.IsPrimary())
             });
         }

--- a/neo/Consensus/ConsensusContext.cs
+++ b/neo/Consensus/ConsensusContext.cs
@@ -144,7 +144,7 @@ namespace Neo.Consensus
             {
                 NewViewNumber = newViewNumber,
                 Timestamp = TimeProvider.Current.UtcNow.ToTimestamp(),
-                Locked = changeViewLockedCount >= this.M()
+                Locked = changeViewLockedCount >= this.M() && !this.ResponseSent() && !(this.IsPrimary() && this.RequestSentOrReceived())
             });
         }
 

--- a/neo/Consensus/ConsensusContext.cs
+++ b/neo/Consensus/ConsensusContext.cs
@@ -144,6 +144,8 @@ namespace Neo.Consensus
             {
                 NewViewNumber = newViewNumber,
                 Timestamp = TimeProvider.Current.UtcNow.ToTimestamp(),
+                // Primary will just change view after seing M guys locked to change view, as well as those who agreed with the current PrepReq
+                // NOTE: This may reduce liveness of dBFT, because the remainder locked nodes will be responsible for changing view by themselves
                 Locked = changeViewLockedCount >= this.M() && !(this.ResponseSent() || this.IsPrimary())
             });
         }

--- a/neo/Consensus/ConsensusService.cs
+++ b/neo/Consensus/ConsensusService.cs
@@ -81,7 +81,9 @@ namespace Neo.Consensus
                 {
                     // If our view is already changing we cannot send a prepare response, since we can never send both
                     // a change view and a commit message for the same view without potentially forking the network.
-                    if (context.ViewChanging()) return true;
+                    // When recovering though, in the case we have a block containing only the miner transaction,
+                    // this check is made during the recovery code that handles receiving the prepare request.
+                    if (context.ViewChanging() && !isRecovering) return true;
 
                     // if we are the primary for this view, but acting as a backup because we recovered our own
                     // previously sent prepare request, then we don't want to send a prepare response.
@@ -364,7 +366,7 @@ namespace Neo.Consensus
                             validPreparations++;
                     }
 
-                    if (validPreparations >= context.F())
+                    if (validPreparations > context.F())
                         overrideViewChangingCheckDueToMoreThanFNodesPrepared = true;
                 }
                 if (!context.CommitSent() && (overrideViewChangingCheckDueToMoreThanFNodesPrepared || !context.ViewChanging()) )

--- a/neo/Consensus/ConsensusService.cs
+++ b/neo/Consensus/ConsensusService.cs
@@ -125,7 +125,7 @@ namespace Neo.Consensus
             if (!context.WatchOnly())
             {
                 ChangeView message = context.ChangeViewPayloads[context.MyIndex]?.GetDeserializedMessage<ChangeView>();
-                if (!context.CommitSent() && (message is null || message.NewViewNumber < viewNumber || !message.Locked))
+                if (!context.CommitSent() && !context.ResponseSent() && !context.IsPrimary() && (message is null || message.NewViewNumber < viewNumber || !message.Locked))
                     localNode.Tell(new LocalNode.SendDirectly { Inventory = context.MakeChangeView(viewNumber) });
             }
 
@@ -220,7 +220,7 @@ namespace Neo.Consensus
                 // Limit recovery to sending from `f` nodes when the request is from a lower view number.
                 if (!shouldRecoverCommitInSameView && !(context.IsPrimary() && shouldRecoverPrepareResponseInSameView) && !IsRecoveryAllowed(payload.ValidatorIndex, message.NewViewNumber, context.F())) return;
 
-                Log($"send recovery from view: {message.ViewNumber} to view: {context.ViewNumber}");
+                Log($"send recovery from view: {message.ViewNumber} to view: {context.ViewNumber} for index={payload.ValidatorIndex}");
                 localNode.Tell(new LocalNode.SendDirectly { Inventory = context.MakeRecoveryMessage() });
             }
 

--- a/neo/Consensus/ConsensusService.cs
+++ b/neo/Consensus/ConsensusService.cs
@@ -207,7 +207,8 @@ namespace Neo.Consensus
             // again; however replay attacks of the ChangeView message from arbitrary nodes will not trigger an
             // additional recovery message response.
             if (!knownHashes.Add(payload.Hash)) return;
-            if (message.NewViewNumber <= context.ViewNumber)
+            if (message.NewViewNumber <= context.ViewNumber || message.ViewNumber < context.ViewNumber ||
+                (message.ViewNumber == context.ViewNumber && (context.ResponseSent() || context.IsPrimary()) && !message.Locked && context.PreparationPayloads[payload.ValidatorIndex] == null))
             {
                 if (context.WatchOnly()) return;
 

--- a/neo/Consensus/ConsensusService.cs
+++ b/neo/Consensus/ConsensusService.cs
@@ -593,7 +593,8 @@ namespace Neo.Consensus
             expectedView++;
             Log($"request change view: height={context.BlockIndex} view={context.ViewNumber} nv={expectedView}");
             ChangeTimer(TimeSpan.FromSeconds(Blockchain.SecondsPerBlock << (expectedView + 1)));
-            localNode.Tell(new LocalNode.SendDirectly { Inventory = context.MakeChangeView(expectedView) });
+            if (!context.IsPrimary())
+                localNode.Tell(new LocalNode.SendDirectly { Inventory = context.MakeChangeView(expectedView) });
             CheckExpectedView(expectedView);
         }
 

--- a/neo/Consensus/ConsensusService.cs
+++ b/neo/Consensus/ConsensusService.cs
@@ -207,15 +207,18 @@ namespace Neo.Consensus
             // again; however replay attacks of the ChangeView message from arbitrary nodes will not trigger an
             // additional recovery message response.
             if (!knownHashes.Add(payload.Hash)) return;
-            bool shouldRecoverPrepareResponseInSameView = message.ViewNumber == context.ViewNumber
-                && (context.ResponseSent() || context.IsPrimary()) && !message.Locked && context.PreparationPayloads[payload.ValidatorIndex] == null;
+            bool inSameViewAndUnlocked = message.ViewNumber == context.ViewNumber && !message.Locked;
+            bool shouldRecoverPrepareResponseInSameView = inSameViewAndUnlocked
+                 && (context.ResponseSent() || context.IsPrimary()) && context.PreparationPayloads[payload.ValidatorIndex] == null;
+            bool shouldRecoverCommitInSameView = inSameViewAndUnlocked
+                && context.CommitSent() && context.CommitPayloads[payload.ValidatorIndex] == null;
             if (message.NewViewNumber <= context.ViewNumber || message.ViewNumber < context.ViewNumber ||
-                shouldRecoverPrepareResponseInSameView)
+                shouldRecoverPrepareResponseInSameView || shouldRecoverCommitInSameView)
             {
                 if (context.WatchOnly()) return;
 
                 // Limit recovery to sending from `f` nodes when the request is from a lower view number.
-                if (!(context.IsPrimary() && shouldRecoverPrepareResponseInSameView) && !IsRecoveryAllowed(payload.ValidatorIndex, message.NewViewNumber, context.F())) return;
+                if (!shouldRecoverCommitInSameView || !(context.IsPrimary() && shouldRecoverPrepareResponseInSameView) && !IsRecoveryAllowed(payload.ValidatorIndex, message.NewViewNumber, context.F())) return;
 
                 Log($"send recovery from view: {message.ViewNumber} to view: {context.ViewNumber}");
                 localNode.Tell(new LocalNode.SendDirectly { Inventory = context.MakeRecoveryMessage() });

--- a/neo/Consensus/ConsensusService.cs
+++ b/neo/Consensus/ConsensusService.cs
@@ -125,7 +125,7 @@ namespace Neo.Consensus
             if (!context.WatchOnly())
             {
                 ChangeView message = context.ChangeViewPayloads[context.MyIndex]?.GetDeserializedMessage<ChangeView>();
-                if (!context.CommitSent() && !context.ResponseSent() && !context.IsPrimary() && (message is null || message.NewViewNumber < viewNumber || !message.Locked))
+                if (!context.ResponseSent() && !context.IsPrimary() && (message is null || message.NewViewNumber < viewNumber || !message.Locked))
                     localNode.Tell(new LocalNode.SendDirectly { Inventory = context.MakeChangeView(viewNumber) });
             }
 

--- a/neo/Consensus/ConsensusService.cs
+++ b/neo/Consensus/ConsensusService.cs
@@ -218,7 +218,7 @@ namespace Neo.Consensus
                 if (context.WatchOnly()) return;
 
                 // Limit recovery to sending from `f` nodes when the request is from a lower view number.
-                if (!shouldRecoverCommitInSameView && !(context.IsPrimary() && shouldRecoverPrepareResponseInSameView) && !IsRecoveryAllowed(payload.ValidatorIndex, message.NewViewNumber, context.F())) return;
+                if (!shouldRecoverCommitInSameView && !shouldRecoverPrepareResponseInSameView && !IsRecoveryAllowed(payload.ValidatorIndex, message.NewViewNumber, context.F())) return;
 
                 Log($"send recovery from view: {message.ViewNumber} to view: {context.ViewNumber} for index={payload.ValidatorIndex}");
                 localNode.Tell(new LocalNode.SendDirectly { Inventory = context.MakeRecoveryMessage() });

--- a/neo/Consensus/ConsensusService.cs
+++ b/neo/Consensus/ConsensusService.cs
@@ -218,7 +218,7 @@ namespace Neo.Consensus
                 if (context.WatchOnly()) return;
 
                 // Limit recovery to sending from `f` nodes when the request is from a lower view number.
-                if (!shouldRecoverCommitInSameView || !(context.IsPrimary() && shouldRecoverPrepareResponseInSameView) && !IsRecoveryAllowed(payload.ValidatorIndex, message.NewViewNumber, context.F())) return;
+                if (!shouldRecoverCommitInSameView && !(context.IsPrimary() && shouldRecoverPrepareResponseInSameView) && !IsRecoveryAllowed(payload.ValidatorIndex, message.NewViewNumber, context.F())) return;
 
                 Log($"send recovery from view: {message.ViewNumber} to view: {context.ViewNumber}");
                 localNode.Tell(new LocalNode.SendDirectly { Inventory = context.MakeRecoveryMessage() });

--- a/neo/Consensus/ConsensusService.cs
+++ b/neo/Consensus/ConsensusService.cs
@@ -208,17 +208,17 @@ namespace Neo.Consensus
             // additional recovery message response.
             if (!knownHashes.Add(payload.Hash)) return;
             bool inSameViewAndUnlocked = message.ViewNumber == context.ViewNumber && (!message.Locked || context.MoreThanFNodesPrepared());
-            bool shouldRecoverPrepareResponseInSameView = inSameViewAndUnlocked
+            bool shouldRecoverPreparationsInSameView = inSameViewAndUnlocked
                  && (context.ResponseSent() || context.IsPrimary()) && context.PreparationPayloads[payload.ValidatorIndex] == null;
-            bool shouldRecoverCommitInSameView = inSameViewAndUnlocked
+            bool shouldRecoverCommitsInSameView = inSameViewAndUnlocked
                 && context.CommitSent() && context.CommitPayloads[payload.ValidatorIndex] == null;
             if (message.NewViewNumber <= context.ViewNumber || message.ViewNumber < context.ViewNumber ||
-                shouldRecoverPrepareResponseInSameView || shouldRecoverCommitInSameView)
+                shouldRecoverPreparationsInSameView || shouldRecoverCommitsInSameView)
             {
                 if (context.WatchOnly()) return;
 
                 // Limit recovery to sending from `f` nodes when the request is from a lower view number.
-                if (!shouldRecoverCommitInSameView && !shouldRecoverPrepareResponseInSameView && !IsRecoveryAllowed(payload.ValidatorIndex, message.NewViewNumber, context.F())) return;
+                if (!shouldRecoverCommitsInSameView && !shouldRecoverPreparationsInSameView && !IsRecoveryAllowed(payload.ValidatorIndex, message.NewViewNumber, context.F())) return;
 
                 Log($"send recovery from view: {message.ViewNumber} to view: {context.ViewNumber} for index={payload.ValidatorIndex}");
                 localNode.Tell(new LocalNode.SendDirectly { Inventory = context.MakeRecoveryMessage() });

--- a/neo/Consensus/ConsensusService.cs
+++ b/neo/Consensus/ConsensusService.cs
@@ -234,7 +234,7 @@ namespace Neo.Consensus
                 if (message.NewViewNumber < expectedView) return;
             }
 
-            Log($"{nameof(OnChangeViewReceived)}: height={payload.BlockIndex} view={message.ViewNumber} index={payload.ValidatorIndex} nv={message.NewViewNumber} committed={message.Locked}");
+            Log($"{nameof(OnChangeViewReceived)}: height={payload.BlockIndex} view={message.ViewNumber} index={payload.ValidatorIndex} nv={message.NewViewNumber} locked={message.Locked}");
             context.ChangeViewPayloads[payload.ValidatorIndex] = payload;
             CheckExpectedView(message.NewViewNumber);
         }

--- a/neo/Consensus/ConsensusService.cs
+++ b/neo/Consensus/ConsensusService.cs
@@ -355,8 +355,14 @@ namespace Neo.Consensus
                     {
                         ConsensusPayload prepareRequestPayload = message.GetPrepareRequestPayload(context, payload);
                         if (prepareRequestPayload != null && prepareRequestPayload.Verify(context.Snapshot))
+                        {
                             validPreparations++; // NOTE: may want to add more validation that PrepReq here is valid.
+                            // Must set the preparation hash to be able ot get the prepare response payloads, since we are
+                            // not actually processing the message here.
+                            message.PreparationHash = prepareRequestPayload.Hash;
+                        }
                     }
+
                     ConsensusPayload[] prepareResponsePayloads = message.GetPrepareResponsePayloads(context, payload);
                     totalPrepResponses = prepareResponsePayloads.Length;
                     foreach (ConsensusPayload prepareResponsePayload in prepareResponsePayloads)

--- a/neo/Consensus/ConsensusService.cs
+++ b/neo/Consensus/ConsensusService.cs
@@ -207,7 +207,7 @@ namespace Neo.Consensus
             // again; however replay attacks of the ChangeView message from arbitrary nodes will not trigger an
             // additional recovery message response.
             if (!knownHashes.Add(payload.Hash)) return;
-            bool inSameViewAndUnlocked = message.ViewNumber == context.ViewNumber && !message.Locked;
+            bool inSameViewAndUnlocked = message.ViewNumber == context.ViewNumber && (!message.Locked || context.MoreThanFNodesPrepared());
             bool shouldRecoverPrepareResponseInSameView = inSameViewAndUnlocked
                  && (context.ResponseSent() || context.IsPrimary()) && context.PreparationPayloads[payload.ValidatorIndex] == null;
             bool shouldRecoverCommitInSameView = inSameViewAndUnlocked

--- a/neo/Consensus/Helper.cs
+++ b/neo/Consensus/Helper.cs
@@ -32,20 +32,12 @@ namespace Neo.Consensus
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool ViewChanging(this IConsensusContext context)
         {
-            if (context.WatchOnly() || context.MoreThanFNodesCommitted()) return false;
+            if (context.WatchOnly() || context.MoreThanFNodesPrepared()) return false;
             var myChangeViewMessage = context.ChangeViewPayloads[context.MyIndex]?.GetDeserializedMessage<ChangeView>();
             if (myChangeViewMessage == null) return false;
 
             return myChangeViewMessage.Locked && myChangeViewMessage.NewViewNumber > context.ViewNumber;
         }
-
-        /// <summary>
-        /// More than F nodes committed in current view.
-        /// </summary>
-        /// <param name="context">consensus context</param>
-        /// <returns>true if more than F nodes have committed in the current view.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool MoreThanFNodesCommitted(this IConsensusContext context) => context.CommitPayloads.Count(p => p != null) > context.F();
 
         public static bool MoreThanFNodesPrepared(this IConsensusContext context) => context.PreparationPayloads.Count(p => p != null) > context.F();
 

--- a/neo/Consensus/Helper.cs
+++ b/neo/Consensus/Helper.cs
@@ -47,6 +47,8 @@ namespace Neo.Consensus
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool MoreThanFNodesCommitted(this IConsensusContext context) => context.CommitPayloads.Count(p => p != null) > context.F();
 
+        public static bool MoreThanFNodesPrepared(this IConsensusContext context) => context.PreparationPayloads.Count(p => p != null) > context.F();
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static uint GetPrimaryIndex(this IConsensusContext context, byte viewNumber)
         {

--- a/neo/Consensus/RecoveryMessage.cs
+++ b/neo/Consensus/RecoveryMessage.cs
@@ -100,7 +100,7 @@ namespace Neo.Consensus
         public ConsensusPayload GetPrepareRequestPayload(IConsensusContext context, ConsensusPayload payload)
         {
             if (PrepareRequestMessage == null) return null;
-            if (!PreparationMessages.TryGetValue((int)context.PrimaryIndex, out RecoveryMessage.PreparationPayloadCompact compact))
+            if (!PreparationMessages.TryGetValue((int)context.PrimaryIndex, out PreparationPayloadCompact compact))
                 return null;
             return new ConsensusPayload
             {


### PR DESCRIPTION
This change maintains liveness with up to `F` failed nodes and prevents stalls due to commits getting stuck in lower views. It is an alternative solution to #642 to prevent stalling.

This change adds a new concept/phase of locking change views. `>= M` change view messages must be known in order for a node to send `ChangeView` with a `Locked` flag set. In order for a node to move to a new view, it must see `>= M` change views with the `Locked` flag set and with a new view at or above the view to which it is changing.