### PR TITLE
Write synchronously in LevelDBSnapshot.Commit and prevent data loss.

### DIFF
--- a/neo/IO/Data/LevelDB/WriteOptions.cs
+++ b/neo/IO/Data/LevelDB/WriteOptions.cs
@@ -5,6 +5,7 @@ namespace Neo.IO.Data.LevelDB
     public class WriteOptions
     {
         public static readonly WriteOptions Default = new WriteOptions();
+        public static readonly WriteOptions DefaultSync = new WriteOptions { Sync = true };
         internal readonly IntPtr handle = Native.leveldb_writeoptions_create();
 
         public bool Sync

--- a/neo/Persistence/LevelDB/DbSnapshot.cs
+++ b/neo/Persistence/LevelDB/DbSnapshot.cs
@@ -51,7 +51,8 @@ namespace Neo.Persistence.LevelDB
         public override void Commit()
         {
             base.Commit();
-            db.Write(WriteOptions.Default, batch);
+
+            db.Write(WriteOptions.DefaultSync, batch);
         }
 
         public override void Dispose()

--- a/neo/Persistence/LevelDB/LevelDBStore.cs
+++ b/neo/Persistence/LevelDB/LevelDBStore.cs
@@ -119,7 +119,7 @@ namespace Neo.Persistence.LevelDB
 
         public override void PutSync(byte prefix, byte[] key, byte[] value)
         {
-            db.Put(new WriteOptions { Sync = true }, SliceBuilder.Begin(prefix).Add(key), value);
+            db.Put(WriteOptions.DefaultSync, SliceBuilder.Begin(prefix).Add(key), value);
         }
     }
 }


### PR DESCRIPTION
I have been puzzled for a while on an issue where syncing MainNet continued to throw exceptions when I sync the chain using machines with high performance cpu and lower disk performance. I discovered the batch write in commit was not being performed synchronously, which seems to lead to the LevelDB current snapshot for the block being created with missing data, which potentially leads to data loss upon persisting the next block. Usually this surfaces as some exception when trying to persist the block.

This may be the fix to the root cause issue I reported way back [here](https://github.com/neo-project/neo-vm/issues/53) as what I thought was a `neo-vm` issue at the time: neo-project/neo-vm/issues/53

*Note: this does reduce syncing speed, but it is a small price to pay for consistency.*