### PR TITLE
Run Blockchain actor on its own thread using a PinnedDispatcher.

### DIFF
--- a/neo/IO/Data/LevelDB/WriteOptions.cs
+++ b/neo/IO/Data/LevelDB/WriteOptions.cs
@@ -5,6 +5,7 @@ namespace Neo.IO.Data.LevelDB
     public class WriteOptions
     {
         public static readonly WriteOptions Default = new WriteOptions();
+        public static readonly WriteOptions DefaultSync = new WriteOptions { Sync = true };
         internal readonly IntPtr handle = Native.leveldb_writeoptions_create();
 
         public bool Sync

--- a/neo/NeoSystem.cs
+++ b/neo/NeoSystem.cs
@@ -21,7 +21,7 @@ namespace Neo
             $"remote-node-mailbox {{ mailbox-type: \"{typeof(RemoteNodeMailbox).AssemblyQualifiedName}\" }}" +
             $"protocol-handler-mailbox {{ mailbox-type: \"{typeof(ProtocolHandlerMailbox).AssemblyQualifiedName}\" }}" +
             $"consensus-service-mailbox {{ mailbox-type: \"{typeof(ConsensusServiceMailbox).AssemblyQualifiedName}\" }}" +
-                $"blockchain-dispatcher {{ type = PinnedDispatcher }}");
+            $"blockchain-dispatcher {{ type = PinnedDispatcher }}");
         public IActorRef Blockchain { get; }
         public IActorRef LocalNode { get; }
         internal IActorRef TaskManager { get; }

--- a/neo/NeoSystem.cs
+++ b/neo/NeoSystem.cs
@@ -20,7 +20,8 @@ namespace Neo
             $"task-manager-mailbox {{ mailbox-type: \"{typeof(TaskManagerMailbox).AssemblyQualifiedName}\" }}" +
             $"remote-node-mailbox {{ mailbox-type: \"{typeof(RemoteNodeMailbox).AssemblyQualifiedName}\" }}" +
             $"protocol-handler-mailbox {{ mailbox-type: \"{typeof(ProtocolHandlerMailbox).AssemblyQualifiedName}\" }}" +
-            $"consensus-service-mailbox {{ mailbox-type: \"{typeof(ConsensusServiceMailbox).AssemblyQualifiedName}\" }}");
+            $"consensus-service-mailbox {{ mailbox-type: \"{typeof(ConsensusServiceMailbox).AssemblyQualifiedName}\" }}" +
+                $"blockchain-dispatcher {{ type = PinnedDispatcher }}");
         public IActorRef Blockchain { get; }
         public IActorRef LocalNode { get; }
         internal IActorRef TaskManager { get; }
@@ -35,7 +36,7 @@ namespace Neo
         {
             this.store = store;
             Plugin.LoadPlugins(this);
-            this.Blockchain = ActorSystem.ActorOf(Ledger.Blockchain.Props(this, store));
+            this.Blockchain = ActorSystem.ActorOf(Ledger.Blockchain.Props(this, store).WithDispatcher("blockchain-dispatcher"));
             this.LocalNode = ActorSystem.ActorOf(Network.P2P.LocalNode.Props(this));
             this.TaskManager = ActorSystem.ActorOf(Network.P2P.TaskManager.Props(this));
             Plugin.NotifyPluginsLoadedAfterSystemConstructed();

--- a/neo/Persistence/LevelDB/DbSnapshot.cs
+++ b/neo/Persistence/LevelDB/DbSnapshot.cs
@@ -51,7 +51,7 @@ namespace Neo.Persistence.LevelDB
         public override void Commit()
         {
             base.Commit();
-            db.Write(WriteOptions.Default, batch);
+            db.Write(WriteOptions.DefaultSync, batch);
         }
 
         public override void Dispose()

--- a/neo/Persistence/LevelDB/LevelDBStore.cs
+++ b/neo/Persistence/LevelDB/LevelDBStore.cs
@@ -119,7 +119,7 @@ namespace Neo.Persistence.LevelDB
 
         public override void PutSync(byte prefix, byte[] key, byte[] value)
         {
-            db.Put(new WriteOptions { Sync = true }, SliceBuilder.Begin(prefix).Add(key), value);
+            db.Put(WriteOptions.DefaultSync, SliceBuilder.Begin(prefix).Add(key), value);
         }
     }
 }


### PR DESCRIPTION
In testing the improved `ImportBlocks` plugin https://github.com/neo-project/neo-plugins/pull/66 I encountered similar issues as I had previously described here https://github.com/neo-project/neo-vm/issues/53. When I had encountered these issues in the past, it was also when using code that imported blocks using multiple `Import` messages. I've finally root caused the issue to be related to the `Blockchain` actor running on different OS threads, and I will describe the issue in more detail below.

Specifically, consider this line that gets a snapshot of the database:
https://github.com/neo-project/neo/blob/5ce0e4c3192cdcce700105030ed03197961e0466/neo/Ledger/Blockchain.cs#L450

This line works reliably to get the latest snapshot, when the same OS thread previously persisted the block through the following code:
https://github.com/neo-project/neo/blob/5ce0e4c3192cdcce700105030ed03197961e0466/neo/Ledger/Blockchain.cs#L623

However, if the actor switched threads between invocations, LevelDB does not ensure that the snapshot subsequently retrieved will be the latest snapshot (it doesn't guarantee atomic access to the latest snapshot last written across threads). By forcing the `Blockchain` to run on the same thread using a `PinnedDispatcher` the consistency is preserved and the updated `ImportBlocks` plugin from https://github.com/neo-project/neo-plugins/pull/66 works without any issues. Also, this as it is now in regular operation could have a bug if two blocks are persisted in fast succession.


