### PR TITLE
add IDebuggerPlugin interface

### DIFF
--- a/neo/Ledger/Blockchain.cs
+++ b/neo/Ledger/Blockchain.cs
@@ -583,7 +583,18 @@ namespace Neo.Ledger
                             using (ApplicationEngine engine = new ApplicationEngine(TriggerType.Application, tx_invocation, snapshot.Clone(), tx_invocation.Gas))
                             {
                                 engine.LoadScript(tx_invocation.Script);
-                                engine.Execute();
+                                foreach (IDebuggerPlugin plugin in Plugin.DebuggerPlugins)
+                                {
+                                    if (plugin.DebuggerActive)
+                                    {
+                                        plugin.OnExecute(engine);
+                                        break;
+                                    }
+                                }
+                                if (engine.GasConsumed == Fixed8.Zero)
+                                {
+                                    engine.Execute();
+                                }
                                 if (!engine.State.HasFlag(VMState.FAULT))
                                 {
                                     engine.Service.Commit();

--- a/neo/Plugins/IDebuggerPlugin.cs
+++ b/neo/Plugins/IDebuggerPlugin.cs
@@ -1,0 +1,10 @@
+﻿using Neo.VM;
+
+namespace Neo.Plugins
+{
+    public interface IDebuggerPlugin
+    {
+        bool DebuggerActive { get; }
+        bool OnExecute(ExecutionEngine engine);
+    }
+}

--- a/neo/Plugins/Plugin.cs
+++ b/neo/Plugins/Plugin.cs
@@ -18,6 +18,7 @@ namespace Neo.Plugins
         internal static readonly List<IPersistencePlugin> PersistencePlugins = new List<IPersistencePlugin>();
         internal static readonly List<IP2PPlugin> P2PPlugins = new List<IP2PPlugin>();
         internal static readonly List<IMemoryPoolTxObserverPlugin> TxObserverPlugins = new List<IMemoryPoolTxObserverPlugin>();
+        internal static readonly List<IDebuggerPlugin> DebuggerPlugins = new List<IDebuggerPlugin>();
 
         private static readonly string pluginsPath = Path.Combine(Path.GetDirectoryName(Assembly.GetEntryAssembly().Location), "Plugins");
         private static readonly FileSystemWatcher configWatcher;
@@ -55,6 +56,7 @@ namespace Neo.Plugins
             if (this is IRpcPlugin rpc) RpcPlugins.Add(rpc);
             if (this is IPersistencePlugin persistence) PersistencePlugins.Add(persistence);
             if (this is IMemoryPoolTxObserverPlugin txObserver) TxObserverPlugins.Add(txObserver);
+            if (this is IDebuggerPlugin debugger) DebuggerPlugins.Add(debugger);
 
             Configure();
         }

--- a/neo/SmartContract/ApplicationEngine.cs
+++ b/neo/SmartContract/ApplicationEngine.cs
@@ -3,6 +3,7 @@ using Neo.Network.P2P.Payloads;
 using Neo.Persistence;
 using Neo.VM;
 using Neo.VM.Types;
+using Neo.Plugins;
 
 namespace Neo.SmartContract
 {
@@ -161,6 +162,14 @@ namespace Neo.SmartContract
             };
             ApplicationEngine engine = new ApplicationEngine(TriggerType.Application, container, snapshot, extraGAS, testMode);
             engine.LoadScript(script);
+            foreach (IDebuggerPlugin plugin in Plugin.DebuggerPlugins)
+            {
+                if (plugin.DebuggerActive)
+                {
+                    plugin.OnExecute(engine);
+                    return engine;
+                }
+            }
             engine.Execute();
             return engine;
         }


### PR DESCRIPTION
I'm working on a plugin to allow read-only debugging of live/historical invocations directly inside the neo-cli prompt (then later a possibly a plugin for remote debugging). This interface and its additions to the Blockchain and ApplicationEngine modules is designed to support that.