### PR TITLE
Revert TriggerType.Application requirement in syscalls

### DIFF
--- a/neo/SmartContract/Helper.cs
+++ b/neo/SmartContract/Helper.cs
@@ -111,7 +111,7 @@ namespace Neo.SmartContract
                 {
                     if (hashes[i] != verifiable.Witnesses[i].ScriptHash) return false;
                 }
-                using (ApplicationEngine engine = new ApplicationEngine(TriggerType.Verification, verifiable, snapshot, Fixed8.Zero))
+                using (ApplicationEngine engine = new ApplicationEngine(TriggerType.Verification, verifiable, snapshot.Clone(), Fixed8.Zero))
                 {
                     engine.LoadScript(verification);
                     engine.LoadScript(verifiable.Witnesses[i].InvocationScript);

--- a/neo/SmartContract/NeoService.cs
+++ b/neo/SmartContract/NeoService.cs
@@ -492,7 +492,6 @@ namespace Neo.SmartContract
 
         private bool Asset_Create(ExecutionEngine engine)
         {
-            if (Trigger != TriggerType.Application) return false;
             InvocationTransaction tx = (InvocationTransaction)engine.ScriptContainer;
             AssetType asset_type = (AssetType)(byte)engine.CurrentContext.EvaluationStack.Pop().GetBigInteger();
             if (!Enum.IsDefined(typeof(AssetType), asset_type) || asset_type == AssetType.CreditFlag || asset_type == AssetType.DutyFlag || asset_type == AssetType.GoverningToken || asset_type == AssetType.UtilityToken)
@@ -537,7 +536,6 @@ namespace Neo.SmartContract
 
         private bool Asset_Renew(ExecutionEngine engine)
         {
-            if (Trigger != TriggerType.Application) return false;
             if (engine.CurrentContext.EvaluationStack.Pop() is InteropInterface _interface)
             {
                 AssetState asset = _interface.GetInterface<AssetState>();
@@ -658,7 +656,6 @@ namespace Neo.SmartContract
 
         private bool Contract_Create(ExecutionEngine engine)
         {
-            if (Trigger != TriggerType.Application) return false;
             byte[] script = engine.CurrentContext.EvaluationStack.Pop().GetByteArray();
             if (script.Length > 1024 * 1024) return false;
             ContractParameterType[] parameter_list = engine.CurrentContext.EvaluationStack.Pop().GetByteArray().Select(p => (ContractParameterType)p).ToArray();
@@ -700,7 +697,6 @@ namespace Neo.SmartContract
 
         private bool Contract_Migrate(ExecutionEngine engine)
         {
-            if (Trigger != TriggerType.Application) return false;
             byte[] script = engine.CurrentContext.EvaluationStack.Pop().GetByteArray();
             if (script.Length > 1024 * 1024) return false;
             ContractParameterType[] parameter_list = engine.CurrentContext.EvaluationStack.Pop().GetByteArray().Select(p => (ContractParameterType)p).ToArray();

--- a/neo/SmartContract/StandardService.cs
+++ b/neo/SmartContract/StandardService.cs
@@ -641,7 +641,6 @@ namespace Neo.SmartContract
 
         protected bool Contract_Destroy(ExecutionEngine engine)
         {
-            if (Trigger != TriggerType.Application) return false;
             UInt160 hash = new UInt160(engine.CurrentContext.ScriptHash);
             ContractState contract = Snapshot.Contracts.TryGet(hash);
             if (contract == null) return true;
@@ -654,8 +653,6 @@ namespace Neo.SmartContract
 
         private bool PutEx(StorageContext context, byte[] key, byte[] value, StorageFlags flags)
         {
-            if (Trigger != TriggerType.Application && Trigger != TriggerType.ApplicationR)
-                return false;
             if (key.Length > 1024) return false;
             if (context.IsReadOnly) return false;
             if (!CheckStorageContext(context)) return false;
@@ -694,8 +691,6 @@ namespace Neo.SmartContract
 
         protected bool Storage_Delete(ExecutionEngine engine)
         {
-            if (Trigger != TriggerType.Application && Trigger != TriggerType.ApplicationR)
-                return false;
             if (engine.CurrentContext.EvaluationStack.Pop() is InteropInterface _interface)
             {
                 StorageContext context = _interface.GetInterface<StorageContext>();


### PR DESCRIPTION
##### Description of the Change
Revert TriggerType.Application requirement in syscalls as per #465 . 

##### Benefits
This will help allow typescript smart contracts compiled by neo-one to be deployed on the main neo network.
@dicarlo2

##### Applicable Issues 
#465