### PR TITLE
Enabling RPCserver call from plugins

### DIFF
--- a/neo/Network/RPC/RpcServer.cs
+++ b/neo/Network/RPC/RpcServer.cs
@@ -310,7 +310,7 @@ namespace Neo.Network.RPC
             await context.Response.WriteAsync(response.ToString(), Encoding.UTF8);
         }
 
-        private JObject ProcessRequest(HttpContext context, JObject request)
+        public JObject ProcessRequest(HttpContext context, JObject request)
         {
             if (!request.ContainsProperty("id")) return null;
             if (!request.ContainsProperty("method") || !request.ContainsProperty("params") || !(request["params"] is JArray))


### PR DESCRIPTION
We are currently export/import plugin with TX's state (Fault or Halt - #712).
It works in parallel with AppLog Plugin.