### PR TITLE
Declaring timeout variables for connection

### DIFF
--- a/neo/Network/P2P/Connection.cs
+++ b/neo/Network/P2P/Connection.cs
@@ -19,12 +19,20 @@ namespace Neo.Network.P2P
         private readonly IActorRef tcp;
         private readonly WebSocket ws;
         private bool disconnected = false;
+        /// <summary>
+        /// connection initial timeout, in seconds, before any package has been accepted
+        /// </summary>
+        private double connectionTimeoutLimitStart = 10;
+        /// <summary>
+        /// connection initial timeout, in seconds
+        /// </summary>
+        private double connectionTimeoutLimit = 60;
 
         protected Connection(object connection, IPEndPoint remote, IPEndPoint local)
         {
             this.Remote = remote;
             this.Local = local;
-            this.timer = Context.System.Scheduler.ScheduleTellOnceCancelable(TimeSpan.FromSeconds(10), Self, Timer.Instance, ActorRefs.NoSender);
+            this.timer = Context.System.Scheduler.ScheduleTellOnceCancelable(TimeSpan.FromSeconds(connectionTimeoutLimitStart), Self, Timer.Instance, ActorRefs.NoSender);
             switch (connection)
             {
                 case IActorRef tcp:
@@ -100,7 +108,7 @@ namespace Neo.Network.P2P
         private void OnReceived(ByteString data)
         {
             timer.CancelIfNotNull();
-            timer = Context.System.Scheduler.ScheduleTellOnceCancelable(TimeSpan.FromMinutes(1), Self, Timer.Instance, ActorRefs.NoSender);
+            timer = Context.System.Scheduler.ScheduleTellOnceCancelable(TimeSpan.FromSeconds(connectionTimeoutLimit), Self, Timer.Instance, ActorRefs.NoSender);
             try
             {
                 OnData(data);

--- a/neo/Network/P2P/Connection.cs
+++ b/neo/Network/P2P/Connection.cs
@@ -20,11 +20,11 @@ namespace Neo.Network.P2P
         private readonly WebSocket ws;
         private bool disconnected = false;
         /// <summary>
-        /// connection initial timeout, in seconds, before any package has been accepted
+        /// connection initial timeout (in seconds) before any package has been accepted
         /// </summary>
         private double connectionTimeoutLimitStart = 10;
         /// <summary>
-        /// connection initial timeout, in seconds
+        /// connection timeout (in seconds) after every `OnReceived(ByteString data)` event
         /// </summary>
         private double connectionTimeoutLimit = 60;
 


### PR DESCRIPTION
We are starting an effort for cleaning and improving the P2P classes.

@erikzhang, it is not related to this PR, but the `ack = false;` happens in `SendMessage(Message message)` function of the `RemoteNode.cs`.
After that, an `OnAck()` event is needed for returning it to `true` and enabling another `sendmessage`. Can this be improved?