### PR TITLE
Plugin dll load method change.

### DIFF
--- a/neo/Plugins/Plugin.cs
+++ b/neo/Plugins/Plugin.cs
@@ -97,7 +97,8 @@ namespace Neo.Plugins
             if (!Directory.Exists(pluginsPath)) return;
             foreach (string filename in Directory.EnumerateFiles(pluginsPath, "*.dll", SearchOption.TopDirectoryOnly))
             {
-                Assembly assembly = Assembly.LoadFile(filename);
+                var file = File.ReadAllBytes(filename);
+                Assembly assembly = Assembly.Load(file);
                 foreach (Type type in assembly.ExportedTypes)
                 {
                     if (!type.IsSubclassOf(typeof(Plugin))) continue;


### PR DESCRIPTION
Currently neo load plugin dll file directly, which will lock dll files and result in "uninstall" command fails.
So I change load method to load a copied dll file to resolve this issue.