### PR TITLE
support switch load different environment config file.

### DIFF
--- a/neo/Helper.cs
+++ b/neo/Helper.cs
@@ -317,7 +317,7 @@ namespace Neo
         /// <returns></returns>
         public static IConfigurationRoot LoadConfig(string config)
         {
-            var fileEnv = Environment.GetEnvironmentVariable("NEO_CONFIG_FILE");
+            var fileEnv = Environment.GetEnvironmentVariable($"NEO_{config.ToUpperInvariant()}_FILE");
             var configFile = string.IsNullOrWhiteSpace(fileEnv) ? $"{config}.json" : fileEnv;
             return new ConfigurationBuilder()
                 .AddJsonFile(configFile, true)

--- a/neo/Helper.cs
+++ b/neo/Helper.cs
@@ -9,6 +9,7 @@ using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
 using System.Text;
 using Microsoft.Extensions.Configuration;
+using Neo.Plugins;
 
 namespace Neo
 {
@@ -319,7 +320,7 @@ namespace Neo
         {
             var env = Environment.GetEnvironmentVariable("NEO_NETWORK");
             var configFile = string.IsNullOrWhiteSpace(env) ? $"{config}.json" : $"{config}.{env}.json";
-            Console.WriteLine($"Config loading:{configFile}");
+            Plugin.Log(nameof(LoadConfig),LogLevel.Info, $"Config loading:{configFile}");
             return new ConfigurationBuilder()
                 .AddJsonFile(configFile, true)
                 .Build();

--- a/neo/Helper.cs
+++ b/neo/Helper.cs
@@ -317,8 +317,8 @@ namespace Neo
         /// <returns></returns>
         public static IConfigurationRoot LoadConfig(string config)
         {
-            var env = Environment.GetEnvironmentVariable("NEO_ENV");
-            var configFile = string.IsNullOrWhiteSpace(env) ? $"{config}.json" : $"{config}.{env}.json";
+            var fileEnv = Environment.GetEnvironmentVariable("NEO_CONFIG_FILE");
+            var configFile = string.IsNullOrWhiteSpace(fileEnv) ? $"{config}.json" : fileEnv;
             return new ConfigurationBuilder()
                 .AddJsonFile(configFile, true)
                 .Build();

--- a/neo/Helper.cs
+++ b/neo/Helper.cs
@@ -317,8 +317,9 @@ namespace Neo
         /// <returns></returns>
         public static IConfigurationRoot LoadConfig(string config)
         {
-            var fileEnv = Environment.GetEnvironmentVariable($"NEO_{config.ToUpperInvariant()}_FILE");
-            var configFile = string.IsNullOrWhiteSpace(fileEnv) ? $"{config}.json" : fileEnv;
+            var env = Environment.GetEnvironmentVariable("NEO_ENV");
+            var configFile = string.IsNullOrWhiteSpace(env) ? $"{config}.json" : $"{config}.{env}.json";
+            Console.WriteLine($"Config loading:{configFile}");
             return new ConfigurationBuilder()
                 .AddJsonFile(configFile, true)
                 .Build();

--- a/neo/Helper.cs
+++ b/neo/Helper.cs
@@ -8,6 +8,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
 using System.Text;
+using Microsoft.Extensions.Configuration;
 
 namespace Neo
 {
@@ -306,6 +307,21 @@ namespace Neo
                 }
                 yield return resultSelector(item, weight);
             }
+        }
+
+
+        /// <summary>
+        /// load configuration with different Environment Variable
+        /// </summary>
+        /// <param name="config"></param>
+        /// <returns></returns>
+        public static IConfigurationRoot LoadConfig(string config)
+        {
+            var env = Environment.GetEnvironmentVariable("NEO_ENV");
+            var configFile = string.IsNullOrWhiteSpace(env) ? $"{config}.json" : $"{config}.{env}.json";
+            return new ConfigurationBuilder()
+                .AddJsonFile(configFile, true)
+                .Build();
         }
     }
 }

--- a/neo/Helper.cs
+++ b/neo/Helper.cs
@@ -317,7 +317,7 @@ namespace Neo
         /// <returns></returns>
         public static IConfigurationRoot LoadConfig(string config)
         {
-            var env = Environment.GetEnvironmentVariable("NEO_ENV");
+            var env = Environment.GetEnvironmentVariable("NEO_NETWORK");
             var configFile = string.IsNullOrWhiteSpace(env) ? $"{config}.json" : $"{config}.{env}.json";
             Console.WriteLine($"Config loading:{configFile}");
             return new ConfigurationBuilder()

--- a/neo/ProtocolSettings.cs
+++ b/neo/ProtocolSettings.cs
@@ -20,7 +20,7 @@ namespace Neo
 
         static ProtocolSettings()
         {
-            IConfigurationSection section = new ConfigurationBuilder().AddJsonFile("protocol.json", true).Build().GetSection("ProtocolConfiguration");
+            IConfigurationSection section = Helper.LoadConfig("protocol").GetSection("ProtocolConfiguration");
             Default = new ProtocolSettings(section);
         }
 


### PR DESCRIPTION
This feature could let developers switch different environment(mainnet/testnet) config more easily.
Just set the "NEO_ENV" environment variable value before run it. 
Please don't hesitate to let me know if there is any problem.