### PR TITLE
Save 1 byte per storage entry

### DIFF
--- a/neo.UnitTests/TestBlockchain.cs
+++ b/neo.UnitTests/TestBlockchain.cs
@@ -26,6 +26,7 @@ namespace Neo.UnitTests
                 mockSnapshot.SetupGet(p => p.Transactions).Returns(new TestDataCache<UInt256, TransactionState>());
                 mockSnapshot.SetupGet(p => p.Contracts).Returns(new TestDataCache<UInt160, ContractState>());
                 mockSnapshot.SetupGet(p => p.Storages).Returns(new TestDataCache<StorageKey, StorageItem>());
+                mockSnapshot.SetupGet(p => p.ConstantStorages).Returns(new TestDataCache<StorageKey, StorageItem>());
                 mockSnapshot.SetupGet(p => p.HeaderHashList).Returns(new TestDataCache<UInt32Wrapper, HeaderHashList>());
                 mockSnapshot.SetupGet(p => p.BlockHashIndex).Returns(new TestMetaDataCache<HashIndexState>());
                 mockSnapshot.SetupGet(p => p.HeaderHashIndex).Returns(new TestMetaDataCache<HashIndexState>());
@@ -43,6 +44,7 @@ namespace Neo.UnitTests
 
                 _Store.Setup(p => p.GetContracts()).Returns(new TestDataCache<UInt160, ContractState>());
                 _Store.Setup(p => p.GetStorages()).Returns(new TestDataCache<StorageKey, StorageItem>());
+                _Store.Setup(p => p.GetConstantStorages()).Returns(new TestDataCache<StorageKey, StorageItem>());
                 _Store.Setup(p => p.GetHeaderHashList()).Returns(new TestDataCache<UInt32Wrapper, HeaderHashList>());
                 _Store.Setup(p => p.GetBlockHashIndex()).Returns(new TestMetaDataCache<HashIndexState>());
                 _Store.Setup(p => p.GetHeaderHashIndex()).Returns(new TestMetaDataCache<HashIndexState>());

--- a/neo.UnitTests/UT_NeoToken.cs
+++ b/neo.UnitTests/UT_NeoToken.cs
@@ -339,7 +339,6 @@ namespace Neo.UnitTests
             st.Should().Be(0);
 
             trackable.Key.Key.Should().BeEquivalentTo(new byte[] { 33 }.Concat(eCPoint.EncodePoint(true)));
-            trackable.Item.IsConstant.Should().Be(false);
         }
 
         internal static void CheckBalance(byte[] account, DataCache<StorageKey, StorageItem>.Trackable trackable, BigInteger balance, BigInteger height, ECPoint[] votes)
@@ -354,7 +353,6 @@ namespace Neo.UnitTests
             (st[2].GetByteArray().AsSerializableArray<ECPoint>(Blockchain.MaxValidators)).Should().BeEquivalentTo(votes);  // Votes
 
             trackable.Key.Key.Should().BeEquivalentTo(new byte[] { 20 }.Concat(account));
-            trackable.Item.IsConstant.Should().Be(false);
         }
     }
 }

--- a/neo.UnitTests/UT_StorageItem.cs
+++ b/neo.UnitTests/UT_StorageItem.cs
@@ -38,14 +38,14 @@ namespace Neo.UnitTests
         public void Size_Get()
         {
             uut.Value = TestUtils.GetByteArray(10, 0x42);
-            uut.Size.Should().Be(12); // 2 + 10
+            uut.Size.Should().Be(11); // 1 + 10
         }
 
         [TestMethod]
         public void Size_Get_Larger()
         {
-            uut.Value = TestUtils.GetByteArray(88, 0x42);
-            uut.Size.Should().Be(90); // 2 + 88
+            uut.Value = TestUtils.GetByteArray(87, 0x42);
+            uut.Size.Should().Be(88); // 1 + 87
         }
 
         [TestMethod]
@@ -97,7 +97,7 @@ namespace Neo.UnitTests
                 }
             }
 
-            byte[] requiredData = new byte[] { 10, 66, 32, 32, 32, 32, 32, 32, 32, 32, 32, 0 };
+            byte[] requiredData = new byte[] { 10, 66, 32, 32, 32, 32, 32, 32, 32, 32, 32 };
 
             data.Length.Should().Be(requiredData.Length);
             for (int i = 0; i < requiredData.Length; i++)

--- a/neo/Ledger/StorageItem.cs
+++ b/neo/Ledger/StorageItem.cs
@@ -6,35 +6,30 @@ namespace Neo.Ledger
     public class StorageItem : ICloneable<StorageItem>, ISerializable
     {
         public byte[] Value;
-        public bool IsConstant;
 
-        public int Size => Value.GetVarSize() + sizeof(bool);
+        public int Size => Value.GetVarSize();
 
         StorageItem ICloneable<StorageItem>.Clone()
         {
             return new StorageItem
             {
-                Value = Value,
-                IsConstant = IsConstant
+                Value = Value
             };
         }
 
         public void Deserialize(BinaryReader reader)
         {
             Value = reader.ReadVarBytes();
-            IsConstant = reader.ReadBoolean();
         }
 
         void ICloneable<StorageItem>.FromReplica(StorageItem replica)
         {
             Value = replica.Value;
-            IsConstant = replica.IsConstant;
         }
 
         public void Serialize(BinaryWriter writer)
         {
             writer.WriteVarBytes(Value);
-            writer.Write(IsConstant);
         }
     }
 }

--- a/neo/Persistence/CloneSnapshot.cs
+++ b/neo/Persistence/CloneSnapshot.cs
@@ -10,6 +10,7 @@ namespace Neo.Persistence
         public override DataCache<UInt256, TransactionState> Transactions { get; }
         public override DataCache<UInt160, ContractState> Contracts { get; }
         public override DataCache<StorageKey, StorageItem> Storages { get; }
+        public override DataCache<StorageKey, StorageItem> ConstantStorages { get; }
         public override DataCache<UInt32Wrapper, HeaderHashList> HeaderHashList { get; }
         public override MetaDataCache<HashIndexState> BlockHashIndex { get; }
         public override MetaDataCache<HashIndexState> HeaderHashIndex { get; }
@@ -21,6 +22,7 @@ namespace Neo.Persistence
             this.Transactions = snapshot.Transactions.CreateSnapshot();
             this.Contracts = snapshot.Contracts.CreateSnapshot();
             this.Storages = snapshot.Storages.CreateSnapshot();
+            this.ConstantStorages = snapshot.ConstantStorages.CreateSnapshot();
             this.HeaderHashList = snapshot.HeaderHashList.CreateSnapshot();
             this.BlockHashIndex = snapshot.BlockHashIndex.CreateSnapshot();
             this.HeaderHashIndex = snapshot.HeaderHashIndex.CreateSnapshot();

--- a/neo/Persistence/IPersistence.cs
+++ b/neo/Persistence/IPersistence.cs
@@ -9,6 +9,7 @@ namespace Neo.Persistence
         DataCache<UInt256, TrimmedBlock> Blocks { get; }
         DataCache<UInt256, TransactionState> Transactions { get; }
         DataCache<UInt160, ContractState> Contracts { get; }
+        DataCache<StorageKey, StorageItem> ConstantStorages { get; }
         DataCache<StorageKey, StorageItem> Storages { get; }
         DataCache<UInt32Wrapper, HeaderHashList> HeaderHashList { get; }
         MetaDataCache<HashIndexState> BlockHashIndex { get; }

--- a/neo/Persistence/LevelDB/DbSnapshot.cs
+++ b/neo/Persistence/LevelDB/DbSnapshot.cs
@@ -16,6 +16,7 @@ namespace Neo.Persistence.LevelDB
         public override DataCache<UInt256, TransactionState> Transactions { get; }
         public override DataCache<UInt160, ContractState> Contracts { get; }
         public override DataCache<StorageKey, StorageItem> Storages { get; }
+        public override DataCache<StorageKey, StorageItem> ConstantStorages { get; }
         public override DataCache<UInt32Wrapper, HeaderHashList> HeaderHashList { get; }
         public override MetaDataCache<HashIndexState> BlockHashIndex { get; }
         public override MetaDataCache<HashIndexState> HeaderHashIndex { get; }
@@ -30,6 +31,7 @@ namespace Neo.Persistence.LevelDB
             Transactions = new DbCache<UInt256, TransactionState>(db, options, batch, Prefixes.DATA_Transaction);
             Contracts = new DbCache<UInt160, ContractState>(db, options, batch, Prefixes.ST_Contract);
             Storages = new DbCache<StorageKey, StorageItem>(db, options, batch, Prefixes.ST_Storage);
+            ConstantStorages = new DbCache<StorageKey, StorageItem>(db, options, batch, Prefixes.ST_ConstantStorage);
             HeaderHashList = new DbCache<UInt32Wrapper, HeaderHashList>(db, options, batch, Prefixes.IX_HeaderHashList);
             BlockHashIndex = new DbMetaDataCache<HashIndexState>(db, options, batch, Prefixes.IX_CurrentBlock);
             HeaderHashIndex = new DbMetaDataCache<HashIndexState>(db, options, batch, Prefixes.IX_CurrentHeader);

--- a/neo/Persistence/LevelDB/LevelDBStore.cs
+++ b/neo/Persistence/LevelDB/LevelDBStore.cs
@@ -61,6 +61,11 @@ namespace Neo.Persistence.LevelDB
             return new DbCache<StorageKey, StorageItem>(db, null, null, Prefixes.ST_Storage);
         }
 
+        public override DataCache<StorageKey, StorageItem> GetConstantStorages()
+        {
+            return new DbCache<StorageKey, StorageItem>(db, null, null, Prefixes.ST_ConstantStorage);
+        }
+
         public override DataCache<UInt256, TransactionState> GetTransactions()
         {
             return new DbCache<UInt256, TransactionState>(db, null, null, Prefixes.DATA_Transaction);

--- a/neo/Persistence/LevelDB/Prefixes.cs
+++ b/neo/Persistence/LevelDB/Prefixes.cs
@@ -7,6 +7,7 @@
 
         public const byte ST_Contract = 0x50;
         public const byte ST_Storage = 0x70;
+        public const byte ST_ConstantStorage = 0x71;
 
         public const byte IX_HeaderHashList = 0x80;
         public const byte IX_CurrentBlock = 0xc0;

--- a/neo/Persistence/Snapshot.cs
+++ b/neo/Persistence/Snapshot.cs
@@ -13,6 +13,7 @@ namespace Neo.Persistence
         public abstract DataCache<UInt256, TransactionState> Transactions { get; }
         public abstract DataCache<UInt160, ContractState> Contracts { get; }
         public abstract DataCache<StorageKey, StorageItem> Storages { get; }
+        public abstract DataCache<StorageKey, StorageItem> ConstantStorages { get; }
         public abstract DataCache<UInt32Wrapper, HeaderHashList> HeaderHashList { get; }
         public abstract MetaDataCache<HashIndexState> BlockHashIndex { get; }
         public abstract MetaDataCache<HashIndexState> HeaderHashIndex { get; }
@@ -33,13 +34,12 @@ namespace Neo.Persistence
             Transactions.Commit();
             Contracts.Commit();
             Storages.Commit();
+            ConstantStorages.Commit();
             HeaderHashList.Commit();
             BlockHashIndex.Commit();
             HeaderHashIndex.Commit();
         }
 
-        public virtual void Dispose()
-        {
-        }
+        public virtual void Dispose() { }
     }
 }

--- a/neo/Persistence/Store.cs
+++ b/neo/Persistence/Store.cs
@@ -10,6 +10,7 @@ namespace Neo.Persistence
         DataCache<UInt256, TransactionState> IPersistence.Transactions => GetTransactions();
         DataCache<UInt160, ContractState> IPersistence.Contracts => GetContracts();
         DataCache<StorageKey, StorageItem> IPersistence.Storages => GetStorages();
+        DataCache<StorageKey, StorageItem> IPersistence.ConstantStorages => GetConstantStorages();
         DataCache<UInt32Wrapper, HeaderHashList> IPersistence.HeaderHashList => GetHeaderHashList();
         MetaDataCache<HashIndexState> IPersistence.BlockHashIndex => GetBlockHashIndex();
         MetaDataCache<HashIndexState> IPersistence.HeaderHashIndex => GetHeaderHashIndex();
@@ -19,6 +20,7 @@ namespace Neo.Persistence
         public abstract DataCache<UInt256, TransactionState> GetTransactions();
         public abstract DataCache<UInt160, ContractState> GetContracts();
         public abstract DataCache<StorageKey, StorageItem> GetStorages();
+        public abstract DataCache<StorageKey, StorageItem> GetConstantStorages();
         public abstract DataCache<UInt32Wrapper, HeaderHashList> GetHeaderHashList();
         public abstract MetaDataCache<HashIndexState> GetBlockHashIndex();
         public abstract MetaDataCache<HashIndexState> GetHeaderHashIndex();

--- a/neo/SmartContract/InteropService.NEO.cs
+++ b/neo/SmartContract/InteropService.NEO.cs
@@ -289,8 +289,7 @@ namespace Neo.SmartContract
                             Key = pair.Key.Key
                         }, new StorageItem
                         {
-                            Value = pair.Value.Value,
-                            IsConstant = false
+                            Value = pair.Value.Value
                         });
                     }
                 }

--- a/neo/SmartContract/Native/Tokens/GasToken.cs
+++ b/neo/SmartContract/Native/Tokens/GasToken.cs
@@ -35,10 +35,9 @@ namespace Neo.SmartContract.Native.Tokens
             Mint(engine, primary, engine.Snapshot.PersistingBlock.Transactions.Sum(p => p.NetworkFee));
             BigInteger sys_fee = GetSysFeeAmount(engine.Snapshot, engine.Snapshot.PersistingBlock.Index - 1) + engine.Snapshot.PersistingBlock.Transactions.Sum(p => p.Gas);
             StorageKey key = CreateStorageKey(Prefix_SystemFeeAmount, BitConverter.GetBytes(engine.Snapshot.PersistingBlock.Index));
-            engine.Snapshot.Storages.Add(key, new StorageItem
+            engine.Snapshot.ConstantStorages.Add(key, new StorageItem
             {
                 Value = sys_fee.ToByteArray(),
-                IsConstant = true
             });
             return true;
         }
@@ -54,7 +53,7 @@ namespace Neo.SmartContract.Native.Tokens
         {
             if (index == 0) return Blockchain.GenesisBlock.Transactions.Sum(p => p.Gas);
             StorageKey key = CreateStorageKey(Prefix_SystemFeeAmount, BitConverter.GetBytes(index));
-            StorageItem storage = snapshot.Storages.TryGet(key);
+            StorageItem storage = snapshot.ConstantStorages.TryGet(key);
             if (storage is null) return BigInteger.Zero;
             return new BigInteger(storage.Value);
         }


### PR DESCRIPTION
If we separate constants and variables, with this change we can save 1 byte per entry and isolate the storages