### PR TITLE
Allow for programmatic configuration of protocol settings

### DIFF
--- a/neo.UnitTests/UT_ProtocolSettings.cs
+++ b/neo.UnitTests/UT_ProtocolSettings.cs
@@ -1,0 +1,96 @@
+﻿using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+
+namespace Neo.UnitTests
+{
+    [TestClass]
+    public class UT_ProtocolSettings
+    {
+        // since ProtocolSettings.Default is designed to be writable only once, use reflection to 
+        // reset the underlying _default field to null before and after running tests in this class.
+        static void ResetProtocolSettings()
+        {
+            var defaultField = typeof(ProtocolSettings)
+                .GetField("_default", BindingFlags.Static | BindingFlags.NonPublic);
+            defaultField.SetValue(null, null);
+        }
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            ResetProtocolSettings();
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            ResetProtocolSettings();
+        }
+
+        [TestMethod]
+        public void Default_Magic_should_be_mainnet_Magic_value()
+        {
+            var mainNetMagic = 0x4F454Eu;
+            ProtocolSettings.Default.Magic.Should().Be(mainNetMagic);
+        }
+
+        [TestMethod]
+        public void Can_initialize_ProtocolSettings()
+        {
+            var expectedMagic = 12345u;
+
+            var dict = new Dictionary<string, string>()
+            {
+                { "ProtocolConfiguration:Magic", $"{expectedMagic}" }
+            };
+
+            var config = new ConfigurationBuilder().AddInMemoryCollection(dict).Build();
+            ProtocolSettings.Initialize(config).Should().BeTrue();
+            ProtocolSettings.Default.Magic.Should().Be(expectedMagic);
+        }
+
+        [TestMethod]
+        public void Cant_initialize_ProtocolSettings_after_default_settings_used()
+        {
+            var mainNetMagic = 0x4F454Eu;
+            ProtocolSettings.Default.Magic.Should().Be(mainNetMagic);
+
+            var updatedMagic = 54321u;
+            var dict = new Dictionary<string, string>()
+            {
+                { "ProtocolConfiguration:Magic", $"{updatedMagic}" }
+            };
+
+            var config = new ConfigurationBuilder().AddInMemoryCollection(dict).Build();
+            ProtocolSettings.Initialize(config).Should().BeFalse();
+            ProtocolSettings.Default.Magic.Should().Be(mainNetMagic);
+        }
+
+        [TestMethod]
+        public void Cant_initialize_ProtocolSettings_twice()
+        {
+            var expectedMagic = 12345u;
+            var dict = new Dictionary<string, string>()
+            {
+                { "ProtocolConfiguration:Magic", $"{expectedMagic}" }
+            };
+
+            var config = new ConfigurationBuilder().AddInMemoryCollection(dict).Build();
+            ProtocolSettings.Initialize(config).Should().BeTrue();
+
+            var updatedMagic = 54321u;
+            dict = new Dictionary<string, string>()
+            {
+                { "ProtocolConfiguration:Magic", $"{updatedMagic}" }
+            };
+            config = new ConfigurationBuilder().AddInMemoryCollection(dict).Build();
+            ProtocolSettings.Initialize(config).Should().BeFalse();
+            ProtocolSettings.Default.Magic.Should().Be(expectedMagic);
+        }
+    }
+}

--- a/neo/ProtocolSettings.cs
+++ b/neo/ProtocolSettings.cs
@@ -11,12 +11,30 @@ namespace Neo
         public string[] SeedList { get; }
         public uint SecondsPerBlock { get; }
 
-        public static ProtocolSettings Default { get; }
+        static ProtocolSettings _default;
 
-        static ProtocolSettings()
+        static void UpdateDefault(IConfigurationSection section)
         {
-            IConfigurationSection section = new ConfigurationBuilder().AddJsonFile("protocol.json", true).Build().GetSection("ProtocolConfiguration");
-            Default = new ProtocolSettings(section);
+            System.Threading.Interlocked.CompareExchange(ref _default, new ProtocolSettings(section), null);
+        }
+
+        public static void Initialize(IConfiguration configuration)
+        {
+            UpdateDefault(configuration.GetSection("ProtocolConfiguration"));
+        }
+
+        public static ProtocolSettings Default
+        {
+            get
+            {
+                if (_default == null)
+                {
+                    IConfigurationSection section = new ConfigurationBuilder().AddJsonFile("protocol.json", true).Build().GetSection("ProtocolConfiguration");
+                    UpdateDefault(section);
+                }
+
+                return _default;
+            }
         }
 
         private ProtocolSettings(IConfigurationSection section)

--- a/neo/ProtocolSettings.cs
+++ b/neo/ProtocolSettings.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.Configuration;
 using System.Linq;
+using System.Threading;
 
 namespace Neo
 {
@@ -13,14 +14,15 @@ namespace Neo
 
         static ProtocolSettings _default;
 
-        static void UpdateDefault(IConfigurationSection section)
+        static bool UpdateDefault(IConfiguration configuration)
         {
-            System.Threading.Interlocked.CompareExchange(ref _default, new ProtocolSettings(section), null);
+            var settings = new ProtocolSettings(configuration.GetSection("ProtocolConfiguration"));
+            return null == Interlocked.CompareExchange(ref _default, settings, null);
         }
 
-        public static void Initialize(IConfiguration configuration)
+        public static bool Initialize(IConfiguration configuration)
         {
-            UpdateDefault(configuration.GetSection("ProtocolConfiguration"));
+            return UpdateDefault(configuration);
         }
 
         public static ProtocolSettings Default
@@ -29,8 +31,8 @@ namespace Neo
             {
                 if (_default == null)
                 {
-                    IConfigurationSection section = new ConfigurationBuilder().AddJsonFile("protocol.json", true).Build().GetSection("ProtocolConfiguration");
-                    UpdateDefault(section);
+                    var configuration = new ConfigurationBuilder().AddJsonFile("protocol.json", true).Build();
+                    UpdateDefault(configuration);
                 }
 
                 return _default;


### PR DESCRIPTION
This PR adds a mechanism to configure the protocol settings programmatically. This enhancement is needed to enable automatic configuration of the privatenet blockchain, 

This change adds an Initialize static function to ProtocolSettings, enabling the host process to pass custom protocol configuration information without needing to write a protocol.json file to disk. [ASP.NET Configuration](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/configuration/) already supports multiple configuration providers. The caller of Initialize is free to use whatever configuration provider they wish, including in-memory .NET objects.

If Initialize method is not called, the first time the ProtocolSettings.Default get function is called, protocol configuration is loaded exactly as it loaded today - the protocol.json file is used as a configuration provider if available with mainnet defaults used for any configuration settings not provided. Again, as today these settings are cached for later use.

ProtocolSettings.Initialize must be called before the ProtocolSettings.Default property is ever accessed. Initialize will not overwrite existing loaded protocol settings - regardless if those settings were loaded by an earlier call to Initialize or by the first time the Default property is accessed. CompareExchange is used to ensure protocol settings are only initialized once, even in the face of multiple threads possibly accessing ProtocolSettings.

PR also includes unit tests for ProtocolSettings initialization. All unit tests pass locally.