### PR TITLE
Fix memory leak on TaskManager due to continuous growth of knownHashes (2.x)

### DIFF
--- a/neo/IO/Caching/FIFOSet.cs
+++ b/neo/IO/Caching/FIFOSet.cs
@@ -38,7 +38,6 @@ namespace Neo.IO.Caching
                 }
             }
             dictionary.Add(item, null);
-
             return true;
         }
 

--- a/neo/IO/Caching/FIFOSet.cs
+++ b/neo/IO/Caching/FIFOSet.cs
@@ -24,45 +24,35 @@ namespace Neo.IO.Caching
 
         public bool Add(T item)
         {
-            lock (dictionary)
+            if (dictionary.Contains(item)) return false;
+            if (dictionary.Count >= maxCapacity)
             {
-                if (dictionary.Contains(item)) return false;
-                if (dictionary.Count >= maxCapacity)
+                if (removeCount == maxCapacity)
                 {
-                    if (removeCount == maxCapacity)
-                    {
-                        dictionary.Clear();
-                    }
-                    else
-                    {
-                        for (int i = 0; i < removeCount; i++)
-                            dictionary.RemoveAt(0);
-                    }
+                    dictionary.Clear();
                 }
-                dictionary.Add(item, null);
+                else
+                {
+                    for (int i = 0; i < removeCount; i++)
+                        dictionary.RemoveAt(0);
+                }
             }
+            dictionary.Add(item, null);
 
             return true;
         }
 
         public IEnumerator<T> GetEnumerator()
         {
-            T[] entries;
-
-            // Snapshot
-            lock (dictionary) { entries = dictionary.Values.Cast<T>().ToArray(); }
-
+            var entries = dictionary.Values.Cast<T>().ToArray();
             foreach (var entry in entries) yield return entry;
         }
 
         public void Remove(params UInt256[] hashes)
         {
-            lock (dictionary)
+            foreach (var hash in hashes)
             {
-                foreach (var hash in hashes)
-                {
-                    dictionary.Remove(hash);
-                }
+                dictionary.Remove(hash);
             }
         }
 

--- a/neo/IO/Caching/FIFOSet.cs
+++ b/neo/IO/Caching/FIFOSet.cs
@@ -41,18 +41,18 @@ namespace Neo.IO.Caching
             return true;
         }
 
-        public IEnumerator<T> GetEnumerator()
-        {
-            var entries = dictionary.Values.Cast<T>().ToArray();
-            foreach (var entry in entries) yield return entry;
-        }
-
-        public void Remove(params UInt256[] hashes)
+        public void ExceptWith(IEnumerable<UInt256> hashes)
         {
             foreach (var hash in hashes)
             {
                 dictionary.Remove(hash);
             }
+        }
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            var entries = dictionary.Values.Cast<T>().ToArray();
+            foreach (var entry in entries) yield return entry;
         }
 
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();

--- a/neo/IO/Caching/FIFOSet.cs
+++ b/neo/IO/Caching/FIFOSet.cs
@@ -49,12 +49,8 @@ namespace Neo.IO.Caching
         {
             T[] entries;
 
-            lock (dictionary)
-            {
-                // Snapshot
-
-                entries = dictionary.Values.Cast<T>().ToArray();
-            }
+            // Snapshot
+            lock (dictionary) { entries = dictionary.Values.Cast<T>().ToArray(); }
 
             foreach (var entry in entries) yield return entry;
         }

--- a/neo/Network/P2P/TaskManager.cs
+++ b/neo/Network/P2P/TaskManager.cs
@@ -118,10 +118,22 @@ namespace Neo.Network.P2P
             RequestTasks(session);
         }
 
+        private static void RemoveFirstKnownHashByValue<TKey, TValue>(Dictionary<TKey, TValue> dictionary, TValue someValue)
+        {
+            foreach (var pair in dictionary)
+            {
+                if (pair.Value.Equals(someValue))
+                {
+                    dictionary.Remove(pair.Key);
+                    break;
+                }
+            }
+        }
+
         private void OnRestartTasks(InvPayload payload)
         {
-            // TODO remove hashes by value
-            knownHashes.ExceptWith(payload.Hashes);
+            foreach (var hashToTryToRemove in payload.Hashes)
+                RemoveFirstKnownHashByValue(knownHashes, hashToTryToRemove);
 
             foreach (UInt256 hash in payload.Hashes)
                 globalTasks.Remove(hash);

--- a/neo/Network/P2P/TaskManager.cs
+++ b/neo/Network/P2P/TaskManager.cs
@@ -143,13 +143,14 @@ namespace Neo.Network.P2P
 
         private void OnTaskCompleted(UInt256 hash)
         {
-            if (knownHashes.Count >= MaxCachedHashes)
-            {
-                knownHashes.Remove(fifoKey);
-                knownHashes[fifoKey] = hash;
-                fifoKey = fifoKey == MaxConncurrentTasks ? 0 : fifoKey + 1;
-            }else
-                knownHashes[knownHashes.Count] = hash;
+            if (!knownHashes.ContainsValue(hash))
+                if (knownHashes.Count == MaxCachedHashes)
+                {
+                    knownHashes.Remove(fifoKey);
+                    knownHashes[fifoKey] = hash;
+                    fifoKey = fifoKey == MaxConncurrentTasks ? 0 : fifoKey + 1;
+                }else
+                    knownHashes[knownHashes.Count] = hash;
 
             globalTasks.Remove(hash);
             foreach (TaskSession ms in sessions.Values)

--- a/neo/Network/P2P/TaskManager.cs
+++ b/neo/Network/P2P/TaskManager.cs
@@ -121,16 +121,6 @@ namespace Neo.Network.P2P
             RequestTasks(session);
         }
 
-        private static void RemoveFirstKnownHashByValue<TKey, TValue>(Dictionary<TKey, TValue> dictionary, TValue someValue)
-        {
-            foreach (var pair in dictionary)
-                if (pair.Value.Equals(someValue))
-                {
-                    dictionary.Remove(pair.Key);
-                    break;
-                }
-        }
-
         private void OnRestartTasks(InvPayload payload)
         {
             knownHashes.Remove(payload.Hashes);

--- a/neo/Network/P2P/TaskManager.cs
+++ b/neo/Network/P2P/TaskManager.cs
@@ -123,7 +123,7 @@ namespace Neo.Network.P2P
 
         private void OnRestartTasks(InvPayload payload)
         {
-            knownHashes.Remove(payload.Hashes);
+            knownHashes.ExceptWith(payload.Hashes);
             foreach (UInt256 hash in payload.Hashes)
                 globalTasks.Remove(hash);
             foreach (InvPayload group in InvPayload.CreateGroup(payload.Type, payload.Hashes))

--- a/neo/Network/P2P/TaskManager.cs
+++ b/neo/Network/P2P/TaskManager.cs
@@ -143,13 +143,13 @@ namespace Neo.Network.P2P
 
         private void OnTaskCompleted(UInt256 hash)
         {
-            if (knownHashes.Count >= MaxConncurrentTasks)
+            if (knownHashes.Count >= MaxCachedHashes)
             {
                 knownHashes.Remove(fifoKey);
                 knownHashes[fifoKey] = hash;
                 fifoKey = fifoKey == MaxConncurrentTasks ? 0 : fifoKey + 1;
-            }
-            knownHashes[knownHashes.Count] = hash;
+            }else
+                knownHashes[knownHashes.Count] = hash;
 
             globalTasks.Remove(hash);
             foreach (TaskSession ms in sessions.Values)


### PR DESCRIPTION
This may have something related with node stopping syncing and being lost with huge sizes of `knownHashes` hashset.

This implementation is a workaround, `FIFOSet` used in `ProtocolHandler` would not be so good here.

The bad trade-off I see would be when we call `knownHashes.ExceptWith(payload.Hashes)` that we would need to iterate the dictionary and remove the first known value.

