### PR TITLE
Only 20 bytes on CheckWitness

### DIFF
--- a/neo/SmartContract/InteropService.cs
+++ b/neo/SmartContract/InteropService.cs
@@ -159,14 +159,8 @@ namespace Neo.SmartContract
         private static bool Runtime_CheckWitness(ApplicationEngine engine)
         {
             byte[] hashOrPubkey = engine.CurrentContext.EvaluationStack.Pop().GetByteArray();
-            bool result;
-            if (hashOrPubkey.Length == 20)
-                result = CheckWitness(engine, new UInt160(hashOrPubkey));
-            else if (hashOrPubkey.Length == 33)
-                result = CheckWitness(engine, ECPoint.DecodePoint(hashOrPubkey, ECCurve.Secp256r1));
-            else
-                return false;
-            engine.CurrentContext.EvaluationStack.Push(result);
+            if (hashOrPubkey.Length != 20) return false;
+            engine.CurrentContext.EvaluationStack.Push(CheckWitness(engine, new UInt160(hashOrPubkey)));
             return true;
         }
 


### PR DESCRIPTION
This allow to users to hide balances with the same account, if they use his 33 bytes format, they will have different balances comparing with the hash, because the smart contract usually store it as key.
Also, ussually we check if the address is 20 bytes in smart contracts, so i think that in neo3 we should force to use always the hash.