### PR TITLE
DeriveKey Scrypt unit test

### DIFF
--- a/neo.UnitTests/UT_Scrypt.cs
+++ b/neo.UnitTests/UT_Scrypt.cs
@@ -12,12 +12,8 @@ namespace Neo.UnitTests
         {
             int N = 16384, r = 8, p = 8;
 
-            var date = DateTime.UtcNow;
             var derivedkey = SCrypt.DeriveKey(new byte[] { 0x01, 0x02, 0x03 }, new byte[] { 0x04, 0x05, 0x06 }, N, r, p, 64).ToHexString();
-            var elapsed = (DateTime.UtcNow - date);
-
             Assert.AreEqual("2bb9c7bb9c392f0dd37821b76e42b01944902520f48d00946a51e72c960fba0a3c62a87d835c9df10a8ad66a04cdf02fbb10b9d7396c20959f28d6cb3ddfdffb", derivedkey);
-            Assert.IsTrue(elapsed.TotalSeconds > 1);
         }
     }
 }

--- a/neo.UnitTests/UT_Scrypt.cs
+++ b/neo.UnitTests/UT_Scrypt.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.Cryptography;
+using System;
+
+namespace Neo.UnitTests
+{
+    [TestClass]
+    public class UT_Scrypt
+    {
+        [TestMethod]
+        public void DeriveKeyTest()
+        {
+            int N = 16384, r = 8, p = 8;
+
+            var date = DateTime.UtcNow;
+            var derivedkey = SCrypt.DeriveKey(new byte[] { 0x01, 0x02, 0x03 }, new byte[] { 0x04, 0x05, 0x06 }, N, r, p, 64).ToHexString();
+            var elapsed = (DateTime.UtcNow - date);
+
+            Assert.AreEqual("f278f54e4a97e639c34d5f7e376d0ccd4a8c04bb8bad055d1f66a42c52c056a917ba0f4490c29209a410d9702c7e350309de8b102a617c8526a12bb16853c39a", derivedkey);
+            Assert.IsTrue(elapsed.TotalSeconds > 3);
+        }
+    }
+}

--- a/neo.UnitTests/UT_Scrypt.cs
+++ b/neo.UnitTests/UT_Scrypt.cs
@@ -16,8 +16,8 @@ namespace Neo.UnitTests
             var derivedkey = SCrypt.DeriveKey(new byte[] { 0x01, 0x02, 0x03 }, new byte[] { 0x04, 0x05, 0x06 }, N, r, p, 64).ToHexString();
             var elapsed = (DateTime.UtcNow - date);
 
-            Assert.AreEqual("f278f54e4a97e639c34d5f7e376d0ccd4a8c04bb8bad055d1f66a42c52c056a917ba0f4490c29209a410d9702c7e350309de8b102a617c8526a12bb16853c39a", derivedkey);
-            Assert.IsTrue(elapsed.TotalSeconds > 3);
+            Assert.AreEqual("2bb9c7bb9c392f0dd37821b76e42b01944902520f48d00946a51e72c960fba0a3c62a87d835c9df10a8ad66a04cdf02fbb10b9d7396c20959f28d6cb3ddfdffb", derivedkey);
+            Assert.IsTrue(elapsed.TotalSeconds > 1);
         }
     }
 }

--- a/neo/Cryptography/SCrypt.cs
+++ b/neo/Cryptography/SCrypt.cs
@@ -5,11 +5,6 @@ namespace Neo.Cryptography
 {
     public static class SCrypt
     {
-        /// <summary>
-        /// https://pages.nist.gov/800-63-3/sp800-63b.html#sec5 Recomended 10K or more
-        /// </summary>
-        private const int PBKDF2_Iterations = 10_000;
-
         private unsafe static void BulkCopy(void* dst, void* src, int len)
         {
             var d = (byte*)dst;
@@ -265,8 +260,8 @@ namespace Neo.Cryptography
 
             var mac = new HMACSHA256(password);
 
-            /* 1: (B_0 ... B_{p-1}) <-- PBKDF2(P, S, 10_000, p * MFLen) */
-            PBKDF2_SHA256(mac, password, salt, salt.Length, PBKDF2_Iterations, Ba, p * 128 * r);
+            /* 1: (B_0 ... B_{p-1}) <-- PBKDF2(P, S, 1, p * MFLen) */
+            PBKDF2_SHA256(mac, password, salt, salt.Length, 1, Ba, p * 128 * r);
 
             fixed (byte* B = Ba)
             fixed (void* V = Va)
@@ -280,8 +275,8 @@ namespace Neo.Cryptography
                 }
             }
 
-            /* 5: DK <-- PBKDF2(P, B, 10_000, dkLen) */
-            PBKDF2_SHA256(mac, password, Ba, p * 128 * r, PBKDF2_Iterations, buf, buf.Length);
+            /* 5: DK <-- PBKDF2(P, B, 1, dkLen) */
+            PBKDF2_SHA256(mac, password, Ba, p * 128 * r, 1, buf, buf.Length);
 
             return buf;
         }

--- a/neo/Cryptography/SCrypt.cs
+++ b/neo/Cryptography/SCrypt.cs
@@ -5,6 +5,11 @@ namespace Neo.Cryptography
 {
     public static class SCrypt
     {
+        /// <summary>
+        /// https://pages.nist.gov/800-63-3/sp800-63b.html#sec5 Recomended 10K or more
+        /// </summary>
+        private const int PBKDF2_Iterations = 10_000;
+
         private unsafe static void BulkCopy(void* dst, void* src, int len)
         {
             var d = (byte*)dst;
@@ -261,7 +266,7 @@ namespace Neo.Cryptography
             var mac = new HMACSHA256(password);
 
             /* 1: (B_0 ... B_{p-1}) <-- PBKDF2(P, S, 1, p * MFLen) */
-            PBKDF2_SHA256(mac, password, salt, salt.Length, 1, Ba, p * 128 * r);
+            PBKDF2_SHA256(mac, password, salt, salt.Length, PBKDF2_Iterations, Ba, p * 128 * r);
 
             fixed (byte* B = Ba)
             fixed (void* V = Va)
@@ -276,7 +281,7 @@ namespace Neo.Cryptography
             }
 
             /* 5: DK <-- PBKDF2(P, B, 1, dkLen) */
-            PBKDF2_SHA256(mac, password, Ba, p * 128 * r, 1, buf, buf.Length);
+            PBKDF2_SHA256(mac, password, Ba, p * 128 * r, PBKDF2_Iterations, buf, buf.Length);
 
             return buf;
         }

--- a/neo/Cryptography/SCrypt.cs
+++ b/neo/Cryptography/SCrypt.cs
@@ -265,7 +265,7 @@ namespace Neo.Cryptography
 
             var mac = new HMACSHA256(password);
 
-            /* 1: (B_0 ... B_{p-1}) <-- PBKDF2(P, S, 1, p * MFLen) */
+            /* 1: (B_0 ... B_{p-1}) <-- PBKDF2(P, S, 10_000, p * MFLen) */
             PBKDF2_SHA256(mac, password, salt, salt.Length, PBKDF2_Iterations, Ba, p * 128 * r);
 
             fixed (byte* B = Ba)
@@ -280,7 +280,7 @@ namespace Neo.Cryptography
                 }
             }
 
-            /* 5: DK <-- PBKDF2(P, B, 1, dkLen) */
+            /* 5: DK <-- PBKDF2(P, B, 10_000, dkLen) */
             PBKDF2_SHA256(mac, password, Ba, p * 128 * r, PBKDF2_Iterations, buf, buf.Length);
 
             return buf;


### PR DESCRIPTION
The number of iterations is set to only to 1, last NIST recommendation (from 2016) is 10.000 (https://pages.nist.gov/800-63-3/sp800-63b.html#sec5).