### PR TITLE
Remove Debug.Assert

### DIFF
--- a/neo/Cryptography/ECC/ECFieldElement.cs
+++ b/neo/Cryptography/ECC/ECFieldElement.cs
@@ -47,7 +47,9 @@ namespace Neo.Cryptography.ECC
             int n = k.GetBitLength();
             int s = k.GetLowestSetBit();
 
+#if DEBUG
             Debug.Assert(k.TestBit(s));
+#endif
 
             BigInteger Uh = 1;
             BigInteger Vl = 2;
@@ -131,7 +133,9 @@ namespace Neo.Cryptography.ECC
                         V += curve.Q;
                     }
                     V >>= 1;
+#if DEBUG
                     Debug.Assert((V * V).Mod(curve.Q) == Value);
+#endif
                     return new ECFieldElement(V, curve);
                 }
             }

--- a/neo/Cryptography/ECC/ECFieldElement.cs
+++ b/neo/Cryptography/ECC/ECFieldElement.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics;
 using System.Linq;
 using System.Numerics;
 
@@ -46,10 +45,6 @@ namespace Neo.Cryptography.ECC
         {
             int n = k.GetBitLength();
             int s = k.GetLowestSetBit();
-
-#if DEBUG
-            Debug.Assert(k.TestBit(s));
-#endif
 
             BigInteger Uh = 1;
             BigInteger Vl = 2;
@@ -133,9 +128,6 @@ namespace Neo.Cryptography.ECC
                         V += curve.Q;
                     }
                     V >>= 1;
-#if DEBUG
-                    Debug.Assert((V * V).Mod(curve.Q) == Value);
-#endif
                     return new ECFieldElement(V, curve);
                 }
             }

--- a/neo/Cryptography/ECC/ECPoint.cs
+++ b/neo/Cryptography/ECC/ECPoint.cs
@@ -386,7 +386,9 @@ namespace Neo.Cryptography.ECC
             {
                 if (x.Y.Equals(y.Y))
                     return x.Twice();
+#if DEBUG
                 Debug.Assert(x.Y.Equals(-y.Y));
+#endif
                 return x.Curve.Infinity;
             }
             ECFieldElement gamma = (y.Y - x.Y) / (y.X - x.X);

--- a/neo/Cryptography/ECC/ECPoint.cs
+++ b/neo/Cryptography/ECC/ECPoint.cs
@@ -1,6 +1,5 @@
 ﻿using Neo.IO;
 using System;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Numerics;
@@ -386,9 +385,6 @@ namespace Neo.Cryptography.ECC
             {
                 if (x.Y.Equals(y.Y))
                     return x.Twice();
-#if DEBUG
-                Debug.Assert(x.Y.Equals(-y.Y));
-#endif
                 return x.Curve.Infinity;
             }
             ECFieldElement gamma = (y.Y - x.Y) / (y.X - x.X);


### PR DESCRIPTION
Acording to https://www.google.com/search?q=debug.assert&oq=Debug.Assert&aqs=chrome.0.0l6.2038j0j7&sourceid=chrome&ie=UTF-8 

`By default, the Debug.Assert method works only in debug builds. Use the Trace.Assert method if you want to do assertions in release builds. For more information, see Assertions in Managed Code.`

So we don't need to execute it in release mode.