### PR TITLE
Ensure the hash length (3x)

### DIFF
--- a/neo/Cryptography/ECC/ECPoint.cs
+++ b/neo/Cryptography/ECC/ECPoint.cs
@@ -112,11 +112,21 @@ namespace Neo.Cryptography.ECC
             {
                 case 0x02:
                 case 0x03:
-                    reader.Read(buffer, 1, expectedLength);
-                    return DecodePoint(buffer.Take(1 + expectedLength).ToArray(), curve);
+                    {
+                        if (reader.Read(buffer, 1, expectedLength) != expectedLength)
+                        {
+                            throw new FormatException();
+                        }
+                        return DecodePoint(buffer.Take(1 + expectedLength).ToArray(), curve);
+                    }
                 case 0x04:
-                    reader.Read(buffer, 1, expectedLength * 2);
-                    return DecodePoint(buffer, curve);
+                    {
+                        if (reader.Read(buffer, 1, expectedLength * 2) != expectedLength * 2)
+                        {
+                            throw new FormatException();
+                        }
+                        return DecodePoint(buffer, curve);
+                    }
                 default:
                     throw new FormatException("Invalid point encoding " + buffer[0]);
             }

--- a/neo/UIntBase.cs
+++ b/neo/UIntBase.cs
@@ -44,7 +44,10 @@ namespace Neo
         /// </summary>
         void ISerializable.Deserialize(BinaryReader reader)
         {
-            reader.Read(data_bytes, 0, data_bytes.Length);
+            if (reader.Read(data_bytes, 0, data_bytes.Length) != data_bytes.Length)
+            {
+                throw new FormatException();
+            }
         }
 
         /// <summary>
@@ -53,7 +56,7 @@ namespace Neo
         /// </summary>
         public bool Equals(UIntBase other)
         {
-            if (ReferenceEquals(other, null))
+            if (other is null)
                 return false;
             if (ReferenceEquals(this, other))
                 return true;
@@ -68,7 +71,7 @@ namespace Neo
         /// </summary>
         public override bool Equals(object obj)
         {
-            if (ReferenceEquals(obj, null))
+            if (obj is null)
                 return false;
             if (!(obj is UIntBase))
                 return false;

--- a/neo/UIntBase.cs
+++ b/neo/UIntBase.cs
@@ -5,7 +5,6 @@ using System.Linq;
 
 namespace Neo
 {
-
     /// <summary>
     /// Base class for little-endian unsigned integers. Two classes inherit from this: UInt160 and UInt256.
     /// Only basic comparison/serialization are proposed for these classes. For arithmetic purposes, use BigInteger class.
@@ -15,7 +14,7 @@ namespace Neo
         /// <summary>
         /// Storing unsigned int in a little-endian byte array.
         /// </summary>
-        private byte[] data_bytes;
+        private readonly byte[] data_bytes;
 
         /// <summary>
         /// Number of bytes of the unsigned int.


### PR DESCRIPTION
Before this patch, was possible to parse an array of hashes only with the length of the array, so is easier to produce undesired results.