### PR TITLE
StorageKey optimization

### DIFF
--- a/neo.UnitTests/UT_StorageKey.cs
+++ b/neo.UnitTests/UT_StorageKey.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.IO;
 using Neo.Ledger;
 
 namespace Neo.UnitTests
@@ -19,6 +20,19 @@ namespace Neo.UnitTests
         public void ScriptHash_Get()
         {
             uut.ScriptHash.Should().BeNull();
+        }
+
+        [TestMethod]
+        public void Size()
+        {
+            var ut = new StorageKey() { Key = new byte[17], ScriptHash = UInt160.Zero };
+            ut.ToArray().Length.Should().Be(((ISerializable)ut).Size);
+
+            ut = new StorageKey() { Key = new byte[0], ScriptHash = UInt160.Zero };
+            ut.ToArray().Length.Should().Be(((ISerializable)ut).Size);
+
+            ut = new StorageKey() { Key = new byte[16], ScriptHash = UInt160.Zero };
+            ut.ToArray().Length.Should().Be(((ISerializable)ut).Size);
         }
 
         [TestMethod]
@@ -113,6 +127,5 @@ namespace Neo.UnitTests
             uut.Key = TestUtils.GetByteArray(10, 0x42);
             uut.GetHashCode().Should().Be(806209853);
         }
-
     }
 }

--- a/neo/Ledger/StorageKey.cs
+++ b/neo/Ledger/StorageKey.cs
@@ -30,9 +30,8 @@ namespace Neo.Ledger
 
         public override bool Equals(object obj)
         {
-            if (obj is null) return false;
-            if (!(obj is StorageKey)) return false;
-            return Equals((StorageKey)obj);
+            if (!(obj is StorageKey other)) return false;
+            return Equals(other);
         }
 
         public override int GetHashCode()


### PR DESCRIPTION
Also, i don't like the `WriteBytesWithGrouping` i understand the problem, but i think that we can (only on this class) read until the end of the stream, because always comes from a fixed buffer, so we don't need to write the length prefix.