### PR TITLE
Fix nep-5 transferation

### DIFF
--- a/neo/Wallets/Wallet.cs
+++ b/neo/Wallets/Wallet.cs
@@ -316,9 +316,10 @@ namespace Neo.Wallets
                             }
                             ApplicationEngine engine = ApplicationEngine.Run(script);
                             if (engine.State.HasFlag(VMState.FAULT)) return null;
-                            balances.Add((account, engine.ResultStack.Pop().GetBigInteger()));
+                            var result = engine.ResultStack.Pop().GetBigInteger();
+                            if (result == 0) continue;
+                            balances.Add((account, result));
                         }
-                        balances = balances.Where(p => p.Value != 0).ToList();
                         BigInteger sum = balances.Aggregate(BigInteger.Zero, (x, y) => x + y.Value);
                         if (sum < output.Value) return null;
                         if (sum != output.Value)

--- a/neo/Wallets/Wallet.cs
+++ b/neo/Wallets/Wallet.cs
@@ -318,6 +318,7 @@ namespace Neo.Wallets
                             if (engine.State.HasFlag(VMState.FAULT)) return null;
                             balances.Add((account, engine.ResultStack.Pop().GetBigInteger()));
                         }
+                        balances = balances.Where(p => p.Value != 0).ToList();
                         BigInteger sum = balances.Aggregate(BigInteger.Zero, (x, y) => x + y.Value);
                         if (sum < output.Value) return null;
                         if (sum != output.Value)


### PR DESCRIPTION
Multi addresses in a wallet, when transfer all nep-5 from one address, if other addresses don't have this asset, it'll return "Insuffient funds". This fix is able to solve this issue.