### PR TITLE
Improving the use of `RelayCache` on `ProtocolHandler`

### DIFF
--- a/neo/Ledger/Blockchain.cs
+++ b/neo/Ledger/Blockchain.cs
@@ -60,7 +60,7 @@ namespace Neo.Ledger
         private uint stored_header_count = 0;
         private readonly Dictionary<UInt256, Block> block_cache = new Dictionary<UInt256, Block>();
         private readonly Dictionary<uint, LinkedList<Block>> block_cache_unverified = new Dictionary<uint, LinkedList<Block>>();
-        internal readonly RelayCache RelayCache = new RelayCache(100);
+        internal readonly RelayCache ConsensusRelayCache = new RelayCache(100);
         private Snapshot currentSnapshot;
 
         public Store Store { get; }
@@ -327,7 +327,7 @@ namespace Neo.Ledger
         {
             if (!payload.Verify(currentSnapshot)) return RelayResultReason.Invalid;
             system.Consensus?.Tell(payload);
-            RelayCache.Add(payload);
+            ConsensusRelayCache.Add(payload);
             system.LocalNode.Tell(new LocalNode.RelayDirectly { Inventory = payload });
             return RelayResultReason.Succeed;
         }

--- a/neo/Network/P2P/ProtocolHandler.cs
+++ b/neo/Network/P2P/ProtocolHandler.cs
@@ -203,9 +203,9 @@ namespace Neo.Network.P2P
                         }
                         break;
                     case InventoryType.Consensus:
-                        Blockchain.Singleton.ConsensusRelayCache.TryGet(hash, out IInventory consensusInventory);
-                        if (consensusInventory != null)
-                            Context.Parent.Tell(Message.Create(MessageCommand.Consensus, consensusInventory));
+                        Blockchain.Singleton.ConsensusRelayCache.TryGet(hash, out IInventory inventoryConsensus);
+                        if (inventoryConsensus != null)
+                            Context.Parent.Tell(Message.Create(MessageCommand.Consensus, inventoryConsensus));
                         break;
                 }
             }

--- a/neo/Network/P2P/ProtocolHandler.cs
+++ b/neo/Network/P2P/ProtocolHandler.cs
@@ -183,17 +183,17 @@ namespace Neo.Network.P2P
                 switch (payload.Type)
                 {
                     case InventoryType.TX:
-                        IInventory inventoryTx = Blockchain.Singleton.GetTransaction(hash);
-                        if (inventoryTx is Transaction)
-                            Context.Parent.Tell(Message.Create(MessageCommand.Transaction, inventoryTx));
+                        Transaction tx = Blockchain.Singleton.GetTransaction(hash);
+                        if (tx != null)
+                            Context.Parent.Tell(Message.Create(MessageCommand.Transaction, tx));
                         break;
                     case InventoryType.Block:
-                        IInventory inventoryBlock = Blockchain.Singleton.GetBlock(hash);
-                        if (inventoryBlock is Block block)
+                        Block block = Blockchain.Singleton.GetBlock(hash);
+                        if (block != null)
                         {
                             if (bloom_filter == null)
                             {
-                                Context.Parent.Tell(Message.Create(MessageCommand.Block, inventoryBlock));
+                                Context.Parent.Tell(Message.Create(MessageCommand.Block, block));
                             }
                             else
                             {
@@ -203,8 +203,7 @@ namespace Neo.Network.P2P
                         }
                         break;
                     case InventoryType.Consensus:
-                        Blockchain.Singleton.ConsensusRelayCache.TryGet(hash, out IInventory inventoryConsensus);
-                        if (inventoryConsensus != null)
+                        if (Blockchain.Singleton.ConsensusRelayCache.TryGet(hash, out IInventory inventoryConsensus))
                             Context.Parent.Tell(Message.Create(MessageCommand.Consensus, inventoryConsensus));
                         break;
                 }


### PR DESCRIPTION
Refactoring `RelayCache` to `ConsensusRelayCache`, it was used just for `OnNewConsensus` event, right @erikzhang?

In addition, optimized `ProtocolHandle` search by avoiding the `tryget`.