### PR TITLE
fix null values while checking ChangeViewReason

### DIFF
--- a/neo/Consensus/ConsensusService.cs
+++ b/neo/Consensus/ConsensusService.cs
@@ -551,7 +551,7 @@ namespace Neo.Consensus
                 {
                     var reason = ChangeViewReason.Timeout;
 
-                    if (context.Block != null && context.TransactionHashes.Count() > context.Transactions.Count)
+                    if (context.Block != null && context.TransactionHashes?.Count() > context.Transactions?.Count)
                     {
                         reason = ChangeViewReason.TxNotFound;
                     }


### PR DESCRIPTION
Consensus is crashing here because **TransactionHashes** and **Transactions** are not yet initialized in the first timeout/changeview.
https://github.com/neo-project/neo/blob/2bbcb1448dc01345dfd102cdfccb8f216a72f648/neo/Consensus/ConsensusService.cs#L554 

```
[17:54:11.093] OnStart
[17:54:11.126] initialize: height=1 view=0 index=0 role=Backup
[17:54:14.140] timeout: height=1 view=0
[17:54:14.160] OnStop
[ERROR][08/09/2019 17:54:14][Thread 0008][akka://NeoSystem/user/$d] Value cannot be null.
Parameter name: source
Cause: System.ArgumentNullException: Value cannot be null.
Parameter name: source
   at System.Linq.Enumerable.Count[TSource](IEnumerable`1 source)
   at Neo.Consensus.ConsensusService.OnTimer(Timer timer) in /src/neo/neo/Consensus/ConsensusService.cs:line 554
   at Akka.Actor.UntypedActor.Receive(Object message)
   at Akka.Actor.ActorBase.AroundReceive(Receive receive, Object message)
   at Akka.Actor.ActorCell.ReceiveMessage(Object message)
   at Akka.Actor.ActorCell.Invoke(Envelope envelope)
```