### PR TITLE
Small OnPersist optimization

### DIFF
--- a/neo/Ledger/Blockchain.cs
+++ b/neo/Ledger/Blockchain.cs
@@ -455,13 +455,11 @@ namespace Neo.Ledger
                         all_application_executed.Add(application_executed);
                     }
                 }
-                snapshot.BlockHashIndex.GetAndChange().Hash = block.Hash;
-                snapshot.BlockHashIndex.GetAndChange().Index = block.Index;
+                snapshot.BlockHashIndex.GetAndChange().Set(block);
                 if (block.Index == header_index.Count)
                 {
                     header_index.Add(block.Hash);
-                    snapshot.HeaderHashIndex.GetAndChange().Hash = block.Hash;
-                    snapshot.HeaderHashIndex.GetAndChange().Index = block.Index;
+                    snapshot.HeaderHashIndex.GetAndChange().Set(block);
                 }
                 foreach (IPersistencePlugin plugin in Plugin.PersistencePlugins)
                     plugin.OnPersist(snapshot, all_application_executed);

--- a/neo/Ledger/Blockchain.cs
+++ b/neo/Ledger/Blockchain.cs
@@ -53,6 +53,7 @@ namespace Neo.Ledger
             Transactions = new[] { DeployNativeContracts() }
         };
 
+        private readonly static byte[] onPersistNativeContractScript;
         private const int MaxTxToReverifyPerIdle = 10;
         private static readonly object lockObj = new object();
         private readonly NeoSystem system;
@@ -83,6 +84,15 @@ namespace Neo.Ledger
         static Blockchain()
         {
             GenesisBlock.RebuildMerkleRoot();
+
+            NativeContract[] contracts = { NativeContract.GAS, NativeContract.NEO };
+            using (ScriptBuilder sb = new ScriptBuilder())
+            {
+                foreach (NativeContract contract in contracts)
+                    sb.EmitAppCall(contract.Hash, "onPersist");
+
+                onPersistNativeContractScript = sb.ToArray();
+            }
         }
 
         public Blockchain(NeoSystem system, Store store)
@@ -416,15 +426,9 @@ namespace Neo.Ledger
                 snapshot.PersistingBlock = block;
                 if (block.Index > 0)
                 {
-                    NativeContract[] contracts = { NativeContract.GAS, NativeContract.NEO };
                     using (ApplicationEngine engine = new ApplicationEngine(TriggerType.System, null, snapshot, 0, true))
                     {
-                        using (ScriptBuilder sb = new ScriptBuilder())
-                        {
-                            foreach (NativeContract contract in contracts)
-                                sb.EmitAppCall(contract.Hash, "onPersist");
-                            engine.LoadScript(sb.ToArray());
-                        }
+                        engine.LoadScript(onPersistNativeContractScript);
                         if (engine.Execute() != VMState.HALT) throw new InvalidOperationException();
                         ApplicationExecuted application_executed = new ApplicationExecuted(engine);
                         Context.System.EventStream.Publish(application_executed);

--- a/neo/Ledger/HashIndexState.cs
+++ b/neo/Ledger/HashIndexState.cs
@@ -1,4 +1,5 @@
 using Neo.IO;
+using Neo.Network.P2P.Payloads;
 using System.IO;
 
 namespace Neo.Ledger
@@ -35,6 +36,12 @@ namespace Neo.Ledger
         {
             writer.Write(Hash);
             writer.Write(Index);
+        }
+
+        internal void Set(BlockBase block)
+        {
+            Hash = block.Hash;
+            Index = block.Index;
         }
     }
 }


### PR DESCRIPTION
- Reduce two calls to the storage: `GetAndChange`
- Reduce the creation of onPersist script of native contracts