### PR TITLE
Fix possible memory leak (2x)

### DIFF
--- a/neo/Persistence/LevelDB/DbSnapshot.cs
+++ b/neo/Persistence/LevelDB/DbSnapshot.cs
@@ -57,6 +57,7 @@ namespace Neo.Persistence.LevelDB
         public override void Dispose()
         {
             snapshot.Dispose();
+            batch.Dispose();
         }
     }
 }


### PR DESCRIPTION
Like with `snapshot`, `batch` use native pointers that it's needed to be disposed