### PR TITLE
Optimize mempool message

### DIFF
--- a/neo/Ledger/Blockchain.cs
+++ b/neo/Ledger/Blockchain.cs
@@ -364,7 +364,7 @@ namespace Neo.Ledger
             system.TaskManager.Tell(new TaskManager.HeaderTaskCompleted(), Sender);
         }
 
-        private RelayResultReason OnNewTransaction(Transaction transaction)
+        private RelayResultReason OnNewTransaction(Transaction transaction, bool relay)
         {
             if (ContainsTransaction(transaction.Hash))
                 return RelayResultReason.AlreadyExists;
@@ -377,8 +377,8 @@ namespace Neo.Ledger
 
             if (!MemPool.TryAdd(transaction.Hash, transaction))
                 return RelayResultReason.OutOfMemory;
-
-            system.LocalNode.Tell(new LocalNode.RelayDirectly { Inventory = transaction });
+            if (relay)
+                system.LocalNode.Tell(new LocalNode.RelayDirectly { Inventory = transaction });
             return RelayResultReason.Succeed;
         }
 
@@ -407,12 +407,13 @@ namespace Neo.Ledger
                     break;
                 case Transaction[] transactions:
                     {
+                        // This message comes from a revalidation of the mempool, already relayed
                         foreach (var tx in transactions)
-                            Sender.Tell(OnNewTransaction(tx));
+                            Sender.Tell(OnNewTransaction(tx, false));
                         break;
                     }
                 case Transaction transaction:
-                    Sender.Tell(OnNewTransaction(transaction));
+                    Sender.Tell(OnNewTransaction(transaction, true));
                     break;
                 case ConsensusPayload payload:
                     Sender.Tell(OnNewConsensus(payload));

--- a/neo/Ledger/Blockchain.cs
+++ b/neo/Ledger/Blockchain.cs
@@ -407,7 +407,7 @@ namespace Neo.Ledger
                     break;
                 case Transaction[] transactions:
                     {
-                        // This message comes from a revalidation of the mempool, already relayed
+                        // This message comes from a mempool's revalidation, already relayed
                         foreach (var tx in transactions)
                             Sender.Tell(OnNewTransaction(tx, false));
                         break;

--- a/neo/Ledger/Blockchain.cs
+++ b/neo/Ledger/Blockchain.cs
@@ -405,6 +405,12 @@ namespace Neo.Ledger
                 case Block block:
                     Sender.Tell(OnNewBlock(block));
                     break;
+                case Transaction[] transactions:
+                    {
+                        foreach (var tx in transactions)
+                            Sender.Tell(OnNewTransaction(tx));
+                        break;
+                    }
                 case Transaction transaction:
                     Sender.Tell(OnNewTransaction(transaction));
                     break;

--- a/neo/Ledger/Blockchain.cs
+++ b/neo/Ledger/Blockchain.cs
@@ -408,8 +408,7 @@ namespace Neo.Ledger
                 case Transaction[] transactions:
                     {
                         // This message comes from a mempool's revalidation, already relayed
-                        foreach (var tx in transactions)
-                            Sender.Tell(OnNewTransaction(tx, false));
+                        foreach (var tx in transactions) OnNewTransaction(tx, false);
                         break;
                     }
                 case Transaction transaction:

--- a/neo/Ledger/MemoryPool.cs
+++ b/neo/Ledger/MemoryPool.cs
@@ -360,9 +360,12 @@ namespace Neo.Ledger
 
                 if (policyChanged)
                 {
+                    var tx = new List<Transaction>();
                     foreach (PoolItem item in _unverifiedSortedTransactions.Reverse())
                         if (item.Tx.FeePerByte >= _feePerByte)
-                            _system.Blockchain.Tell(item.Tx, ActorRefs.NoSender);
+                            tx.Add(item.Tx);
+
+                    _system.Blockchain.Tell(tx.ToArray(), ActorRefs.NoSender);
                     _unverifiedTransactions.Clear();
                     _unverifiedSortedTransactions.Clear();
                 }

--- a/neo/Ledger/MemoryPool.cs
+++ b/neo/Ledger/MemoryPool.cs
@@ -365,7 +365,9 @@ namespace Neo.Ledger
                         if (item.Tx.FeePerByte >= _feePerByte)
                             tx.Add(item.Tx);
 
-                    _system.Blockchain.Tell(tx.ToArray(), ActorRefs.NoSender);
+                    if (tx.Count > 0)
+                        _system.Blockchain.Tell(tx.ToArray(), ActorRefs.NoSender);
+
                     _unverifiedTransactions.Clear();
                     _unverifiedSortedTransactions.Clear();
                 }


### PR DESCRIPTION
When the mempool need to reverify the transactions, it send all the valid transactions to the `blockchain` one by one, and Blockchain when a transaction is received send it to the localnode for relay. 

Think in a 40k valid transactions. This prevent 40k messages from the mempool to Blockchain and 40k relays more, because is not needed to relay the transactions at this moment.