### PR TITLE
empty scripthash, all notifications

### DIFF
--- a/neo.UnitTests/SmartContract/UT_InteropService.cs
+++ b/neo.UnitTests/SmartContract/UT_InteropService.cs
@@ -85,7 +85,7 @@ namespace Neo.UnitTests.SmartContract
 
                 // Receive all notifications
 
-                script.EmitPush(UInt160.Zero.ToArray());
+                script.EmitPush(new byte[0]);
                 script.EmitSysCall(InteropService.System_Runtime_GetNotifications);
 
                 // Execute

--- a/neo/SmartContract/InteropService.cs
+++ b/neo/SmartContract/InteropService.cs
@@ -236,14 +236,16 @@ namespace Neo.SmartContract
 
         private static bool Runtime_GetNotifications(ApplicationEngine engine)
         {
-            var data = engine.CurrentContext.EvaluationStack.Pop().GetByteArray();
-            if (data.Length != UInt160.Length) return false;
+            byte[] data = engine.CurrentContext.EvaluationStack.Pop().GetByteArray();
+            if ((data.Length != 0) || (data.Length != UInt160.Length)) return false;
             if (!engine.CheckArraySize(engine.Notifications.Count)) return false;
 
-            var hash = new UInt160(data);
             IEnumerable<NotifyEventArgs> notifications = engine.Notifications;
-            if (!hash.Equals(UInt160.Zero))
+            if (data.Length == UInt160.Length) // must filter by scriptHash
+            {
+                var hash = new UInt160(data);
                 notifications = notifications.Where(p => p.ScriptHash == hash);
+            }
 
             engine.CurrentContext.EvaluationStack.Push(notifications.Select(u => new VM.Types.Array(new StackItem[] { u.ScriptHash.ToArray(), u.State })).ToArray());
             return true;

--- a/neo/SmartContract/InteropService.cs
+++ b/neo/SmartContract/InteropService.cs
@@ -237,7 +237,7 @@ namespace Neo.SmartContract
         private static bool Runtime_GetNotifications(ApplicationEngine engine)
         {
             byte[] data = engine.CurrentContext.EvaluationStack.Pop().GetByteArray();
-            if ((data.Length != 0) || (data.Length != UInt160.Length)) return false;
+            if ((data.Length != 0) && (data.Length != UInt160.Length)) return false;
             if (!engine.CheckArraySize(engine.Notifications.Count)) return false;
 
             IEnumerable<NotifyEventArgs> notifications = engine.Notifications;


### PR DESCRIPTION
Looks like much easier for GetNotifications to pass an empty byte array, instead of an array of 20 zeroes (to get all notifications).