### PR TITLE
Downgrade Sqlite to 2.1.4

### DIFF
--- a/neo/neo.csproj
+++ b/neo/neo.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Https" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.WebSockets" Version="2.2.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.2.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.1.4" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
     <PackageReference Include="Neo.VM" Version="3.0.0-CI00035" />
     <PackageReference Include="System.Text.Encodings.Web" Version="4.5.0" />

--- a/neo/neo.csproj
+++ b/neo/neo.csproj
@@ -27,6 +27,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Https" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.WebSockets" Version="2.2.1" />
+    <!-- Check https://github.com/neo-project/neo/pull/535 before upgrade this package -->
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.1.4" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
     <PackageReference Include="Neo.VM" Version="3.0.0-CI00035" />


### PR DESCRIPTION
```cs
  Restoring packages for /root/Github/neo-cli/neo-cli/neo-cli.csproj...
  Restoring packages for /root/Github/neo/neo/neo.csproj...
/root/Github/neo/neo/neo.csproj : error NU1605: Detected package downgrade: System.IO.FileSystem.Primitives from 4.3.0 to 4.0.1. Reference the package directly from the project to select a different version.  [/root/Github/neo-cli/neo-cli.sln]
/root/Github/neo/neo/neo.csproj : error NU1605:  Neo -> Microsoft.EntityFrameworkCore.Sqlite 2.2.6 -> Microsoft.EntityFrameworkCore.Sqlite.Core 2.2.6 -> Microsoft.Extensions.DependencyModel 2.1.0 -> Microsoft.DotNet.PlatformAbstractions 2.1.0 -> System.IO.FileSystem 4.0.1 -> runtime.unix.System.IO.FileSystem 4.3.0 -> System.IO.FileSystem.Primitives (>= 4.3.0)  [/root/Github/neo-cli/neo-cli.sln]
/root/Github/neo/neo/neo.csproj : error NU1605:  Neo -> Microsoft.EntityFrameworkCore.Sqlite 2.2.6 -> Microsoft.EntityFrameworkCore.Sqlite.Core 2.2.6 -> Microsoft.Extensions.DependencyModel 2.1.0 -> Microsoft.DotNet.PlatformAbstractions 2.1.0 -> System.IO.FileSystem 4.0.1 -> System.IO.FileSystem.Primitives (>= 4.0.1) [/root/Github/neo-cli/neo-cli.sln]
  Generating MSBuild file /root/Github/neo-cli/neo-cli/obj/neo-cli.csproj.nuget.g.props.
  Generating MSBuild file /root/Github/neo-cli/neo-cli/obj/neo-cli.csproj.nuget.g.targets.
  Restore failed in 623.08 ms for /root/Github/neo/neo/neo.csproj.
  Restore completed in 623.01 ms for /root/Github/neo-cli/neo-cli/neo-cli.csproj.
```

Downgrading package as done before in https://github.com/neo-project/neo/pull/535

It a workaround using an old version.
If we need the most recent version let's search for a permanent fix.