### PR TITLE
New plugin interface: IStoragePlugin

### DIFF
--- a/src/neo/Plugins/IStoragePlugin.cs
+++ b/src/neo/Plugins/IStoragePlugin.cs
@@ -1,0 +1,9 @@
+using Neo.Persistence;
+
+namespace Neo.Plugins
+{
+    public interface IStoragePlugin
+    {
+        IStore GetStore();
+    }
+}

--- a/src/neo/Plugins/Plugin.cs
+++ b/src/neo/Plugins/Plugin.cs
@@ -12,6 +12,7 @@ namespace Neo.Plugins
     {
         public static readonly List<Plugin> Plugins = new List<Plugin>();
         private static readonly List<ILogPlugin> Loggers = new List<ILogPlugin>();
+        internal static readonly Dictionary<string, IStoragePlugin> Storages = new Dictionary<string, IStoragePlugin>();
         internal static readonly List<IRpcPlugin> RpcPlugins = new List<IRpcPlugin>();
         internal static readonly List<IPersistencePlugin> PersistencePlugins = new List<IPersistencePlugin>();
         internal static readonly List<IP2PPlugin> P2PPlugins = new List<IP2PPlugin>();
@@ -48,6 +49,7 @@ namespace Neo.Plugins
             Plugins.Add(this);
 
             if (this is ILogPlugin logger) Loggers.Add(logger);
+            if (this is IStoragePlugin storage) Storages.Add(Name, storage);
             if (this is IP2PPlugin p2p) P2PPlugins.Add(p2p);
             if (this is IRpcPlugin rpc) RpcPlugins.Add(rpc);
             if (this is IPersistencePlugin persistence) PersistencePlugins.Add(persistence);

--- a/tests/neo.UnitTests/Consensus/UT_Consensus.cs
+++ b/tests/neo.UnitTests/Consensus/UT_Consensus.cs
@@ -41,7 +41,7 @@ namespace Neo.UnitTests.Consensus
             TestProbe subscriber = CreateTestProbe();
             var mockWallet = new Mock<Wallet>();
             mockWallet.Setup(p => p.GetAccount(It.IsAny<UInt160>())).Returns<UInt160>(p => new TestWalletAccount(p));
-            ConsensusContext context = new ConsensusContext(mockWallet.Object, TestBlockchain.Store);
+            ConsensusContext context = new ConsensusContext(mockWallet.Object, Blockchain.Singleton.Store);
 
             int timeIndex = 0;
             var timeValues = new[] {

--- a/tests/neo.UnitTests/Consensus/UT_ConsensusContext.cs
+++ b/tests/neo.UnitTests/Consensus/UT_ConsensusContext.cs
@@ -3,6 +3,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Neo.Consensus;
 using Neo.IO;
+using Neo.Ledger;
 using Neo.Network.P2P.Payloads;
 using Neo.SmartContract.Native;
 using Neo.Wallets;
@@ -38,7 +39,7 @@ namespace Neo.UnitTests.Consensus
                 _validatorKeys[x] = new KeyPair(pk);
             }
 
-            _context = new ConsensusContext(mockWallet.Object, TestBlockchain.Store)
+            _context = new ConsensusContext(mockWallet.Object, Blockchain.Singleton.Store)
             {
                 Validators = _validatorKeys.Select(u => u.PublicKey).ToArray()
             };

--- a/tests/neo.UnitTests/Ledger/UT_Blockchain.cs
+++ b/tests/neo.UnitTests/Ledger/UT_Blockchain.cs
@@ -37,21 +37,19 @@ namespace Neo.UnitTests.Ledger
     public class UT_Blockchain
     {
         private NeoSystem system;
-        private IStore store;
         Transaction txSample = Blockchain.GenesisBlock.Transactions[0];
 
         [TestInitialize]
         public void Initialize()
         {
             system = TestBlockchain.TheNeoSystem;
-            store = TestBlockchain.Store;
             Blockchain.Singleton.MemPool.TryAdd(txSample.Hash, txSample);
         }
 
         [TestMethod]
         public void TestConstructor()
         {
-            system.ActorSystem.ActorOf(Blockchain.Props(system, store)).Should().NotBeSameAs(system.Blockchain);
+            system.ActorSystem.ActorOf(Blockchain.Props(system, Blockchain.Singleton.Store)).Should().NotBeSameAs(system.Blockchain);
         }
 
         [TestMethod]

--- a/tests/neo.UnitTests/TestBlockchain.cs
+++ b/tests/neo.UnitTests/TestBlockchain.cs
@@ -1,21 +1,16 @@
 using Neo.Ledger;
-using Neo.Persistence;
 using System;
-using MemoryStore = Neo.Persistence.Memory.Store;
 
 namespace Neo.UnitTests
 {
     public static class TestBlockchain
     {
-        public static readonly IStore Store;
         public static readonly NeoSystem TheNeoSystem;
 
         static TestBlockchain()
         {
-            Store = new MemoryStore();
-
             Console.WriteLine("initialize NeoSystem");
-            TheNeoSystem = new NeoSystem(Store);
+            TheNeoSystem = new NeoSystem();
 
             // Ensure that blockchain is loaded
 


### PR DESCRIPTION
Currently we only have one storage, and that is LevelDb. In the future, we may have a variety of storage, such as RocksDb, FASTER, memory, and so on.

This PR allows new storage to be created in the plugin and integrated into the NEO client without modifying the core.

I think that in the future the core should contain only one default storage (perhaps memory), and the rest are provided through plugins.