### PR TITLE
Simplify and improve consensus payload serialization and deserialization

### DIFF
--- a/neo.UnitTests/IO/UT_IOHelper.cs
+++ b/neo.UnitTests/IO/UT_IOHelper.cs
@@ -24,6 +24,46 @@ namespace Neo.UnitTests.IO
         }
 
         [TestMethod]
+        public void TestNullableArray()
+        {
+            var caseArray = new UInt160[]
+            {
+                null, UInt160.Zero, new UInt160(
+                new byte[] {
+                    0xAA,0x00,0x00,0x00,0x00,
+                    0xBB,0x00,0x00,0x00,0x00,
+                    0xCC,0x00,0x00,0x00,0x00,
+                    0xDD,0x00,0x00,0x00,0x00
+                })
+            };
+
+            byte[] data;
+            using (var stream = new MemoryStream())
+            using (var writter = new BinaryWriter(stream))
+            {
+                Neo.IO.Helper.WriteNullableArray(writter, caseArray);
+                data = stream.ToArray();
+            }
+
+            // Read Error
+
+            using (var stream = new MemoryStream(data))
+            using (var reader = new BinaryReader(stream))
+            {
+                Assert.ThrowsException<FormatException>(() => Neo.IO.Helper.ReadNullableArray<UInt160>(reader, 2));
+            }
+
+            // Read 100%
+
+            using (var stream = new MemoryStream(data))
+            using (var reader = new BinaryReader(stream))
+            {
+                var read = Neo.IO.Helper.ReadNullableArray<UInt160>(reader);
+                CollectionAssert.AreEqual(caseArray, read);
+            }
+        }
+
+        [TestMethod]
         public void TestAsSerializable()
         {
             for (int i = 0; i < 2; i++)
@@ -48,7 +88,7 @@ namespace Neo.UnitTests.IO
         [TestMethod]
         public void TestAsSerializableArray()
         {
-            byte[] byteArray = Neo.IO.Helper.ToByteArray<UInt160>(new UInt160[] { UInt160.Zero });
+            byte[] byteArray = Neo.IO.Helper.ToByteArray(new UInt160[] { UInt160.Zero });
             UInt160[] result = Neo.IO.Helper.AsSerializableArray<UInt160>(byteArray);
             Assert.AreEqual(1, result.Length);
             Assert.AreEqual(UInt160.Zero, result[0]);

--- a/neo/Consensus/ConsensusContext.cs
+++ b/neo/Consensus/ConsensusContext.cs
@@ -105,11 +105,11 @@ namespace Neo.Consensus
             TransactionHashes = reader.ReadSerializableArray<UInt256>();
             Transaction[] transactions = reader.ReadSerializableArray<Transaction>(Block.MaxTransactionsPerBlock);
 
-            ReadConsensusPayloadArray(reader, out PreparationPayloads, reader.ReadVarInt(Blockchain.MaxValidators));
+            PreparationPayloads = ReadConsensusPayloadArray(reader, reader.ReadVarInt(Blockchain.MaxValidators));
             ulong emptyOrValidators = reader.ReadVarInt(Blockchain.MaxValidators);
-            ReadConsensusPayloadArray(reader, out CommitPayloads, emptyOrValidators);
-            ReadConsensusPayloadArray(reader, out ChangeViewPayloads, emptyOrValidators);
-            ReadConsensusPayloadArray(reader, out LastChangeViewPayloads, emptyOrValidators);
+            CommitPayloads = ReadConsensusPayloadArray(reader, emptyOrValidators);
+            ChangeViewPayloads = ReadConsensusPayloadArray(reader, emptyOrValidators);
+            LastChangeViewPayloads = ReadConsensusPayloadArray(reader, emptyOrValidators);
 
             if (TransactionHashes.Length == 0 && !RequestSentOrReceived)
                 TransactionHashes = null;
@@ -428,11 +428,12 @@ namespace Neo.Consensus
                 writer.Write(payload);
             }
         }
-        private void ReadConsensusPayloadArray(BinaryReader reader, out ConsensusPayload[] payloadArray, ulong payloadLenght)
+        private ConsensusPayload[] ReadConsensusPayloadArray(BinaryReader reader, ulong payloadLenght)
         {
-            payloadArray = new ConsensusPayload[payloadLenght];
+            ConsensusPayload[] payloadArray = new ConsensusPayload[payloadLenght];
             for (int i = 0; i < payloadArray.Length; i++)
                 payloadArray[i] = reader.ReadBoolean() ? reader.ReadSerializable<ConsensusPayload>() : null;
+            return payloadArray;
         }
     }
 }

--- a/neo/Consensus/ConsensusContext.cs
+++ b/neo/Consensus/ConsensusContext.cs
@@ -104,19 +104,13 @@ namespace Neo.Consensus
             ViewNumber = reader.ReadByte();
             TransactionHashes = reader.ReadSerializableArray<UInt256>();
             Transaction[] transactions = reader.ReadSerializableArray<Transaction>(Block.MaxTransactionsPerBlock);
-            PreparationPayloads = new ConsensusPayload[reader.ReadVarInt(Blockchain.MaxValidators)];
-            for (int i = 0; i < PreparationPayloads.Length; i++)
-                PreparationPayloads[i] = reader.ReadBoolean() ? reader.ReadSerializable<ConsensusPayload>() : null;
+
+            ReadConsensusPayloadArray(reader, out PreparationPayloads, reader.ReadVarInt(Blockchain.MaxValidators));
             ulong emptyOrValidators = reader.ReadVarInt(Blockchain.MaxValidators);
-            CommitPayloads = new ConsensusPayload[emptyOrValidators];
-            for (int i = 0; i < CommitPayloads.Length; i++)
-                CommitPayloads[i] = reader.ReadBoolean() ? reader.ReadSerializable<ConsensusPayload>() : null;
-            ChangeViewPayloads = new ConsensusPayload[emptyOrValidators];
-            for (int i = 0; i < ChangeViewPayloads.Length; i++)
-                ChangeViewPayloads[i] = reader.ReadBoolean() ? reader.ReadSerializable<ConsensusPayload>() : null;
-            LastChangeViewPayloads = new ConsensusPayload[emptyOrValidators];
-            for (int i = 0; i < LastChangeViewPayloads.Length; i++)
-                LastChangeViewPayloads[i] = reader.ReadBoolean() ? reader.ReadSerializable<ConsensusPayload>() : null;
+            ReadConsensusPayloadArray(reader, out CommitPayloads, emptyOrValidators);
+            ReadConsensusPayloadArray(reader, out ChangeViewPayloads, emptyOrValidators);
+            ReadConsensusPayloadArray(reader, out LastChangeViewPayloads, emptyOrValidators);
+
             if (TransactionHashes.Length == 0 && !RequestSentOrReceived)
                 TransactionHashes = null;
             Transactions = transactions.Length == 0 && !RequestSentOrReceived ? null : transactions.ToDictionary(p => p.Hash);
@@ -433,6 +427,12 @@ namespace Neo.Consensus
                 if (!hasPayload) continue;
                 writer.Write(payload);
             }
+        }
+        private void ReadConsensusPayloadArray(BinaryReader reader, out ConsensusPayload[] payloadArray, ulong payloadLenght)
+        {
+            payloadArray = new ConsensusPayload[payloadLenght];
+            for (int i = 0; i < payloadArray.Length; i++)
+                payloadArray[i] = reader.ReadBoolean() ? reader.ReadSerializable<ConsensusPayload>() : null;
         }
     }
 }


### PR DESCRIPTION
Reducing two `writer.WriteVarInt` and creating a two functions for writer and reader in order to avoid repeating the code.