### PR TITLE
Renaming two variables related to Consensus Reverification of txs

### DIFF
--- a/neo.UnitTests/Network/P2P/UT_TaskManagerMailbox.cs
+++ b/neo.UnitTests/Network/P2P/UT_TaskManagerMailbox.cs
@@ -34,7 +34,7 @@ namespace Neo.UnitTests.Network.P2P
         {
             // high priority
             uut.IsHighPriority(new TaskManager.Register()).Should().Be(true);
-            uut.IsHighPriority(new TaskManager.RestartTasks()).Should().Be(true);
+            uut.IsHighPriority(new TaskManager.ConsensusTxsTask()).Should().Be(true);
 
             // low priority
             // -> NewTasks: generic InvPayload

--- a/neo/Consensus/ConsensusService.cs
+++ b/neo/Consensus/ConsensusService.cs
@@ -462,7 +462,7 @@ namespace Neo.Consensus
             if (context.Transactions.Count < context.TransactionHashes.Length)
             {
                 UInt256[] hashes = context.TransactionHashes.Where(i => !context.Transactions.ContainsKey(i)).ToArray();
-                taskManager.Tell(new TaskManager.RestartTasks
+                taskManager.Tell(new TaskManager.ConsensusTxsTask
                 {
                     Payload = InvPayload.Create(InventoryType.TX, hashes)
                 });

--- a/neo/Network/P2P/Payloads/Transaction.cs
+++ b/neo/Network/P2P/Payloads/Transaction.cs
@@ -130,7 +130,7 @@ namespace Neo.Network.P2P.Payloads
             return hashes.OrderBy(p => p).ToArray();
         }
 
-        public virtual bool Reverify(Snapshot snapshot, IEnumerable<Transaction> mempool)
+        public virtual bool Reverify(Snapshot snapshot, IEnumerable<Transaction> transactionsPool)
         {
             if (ValidUntilBlock <= snapshot.Height || ValidUntilBlock > snapshot.Height + MaxValidUntilBlockIncrement)
                 return false;
@@ -139,7 +139,7 @@ namespace Neo.Network.P2P.Payloads
             BigInteger balance = NativeContract.GAS.BalanceOf(snapshot, Sender);
             BigInteger fee = SystemFee + NetworkFee;
             if (balance < fee) return false;
-            fee += mempool.Where(p => p != this && p.Sender.Equals(Sender)).Select(p => (BigInteger)(p.SystemFee + p.NetworkFee)).Sum();
+            fee += transactionsPool.Where(p => p != this && p.Sender.Equals(Sender)).Select(p => (BigInteger)(p.SystemFee + p.NetworkFee)).Sum();
             if (balance < fee) return false;
             UInt160[] hashes = GetScriptHashesForVerifying(snapshot);
             if (hashes.Length != Witnesses.Length) return false;
@@ -209,9 +209,14 @@ namespace Neo.Network.P2P.Payloads
             return Verify(snapshot, Enumerable.Empty<Transaction>());
         }
 
-        public virtual bool Verify(Snapshot snapshot, IEnumerable<Transaction> mempool)
+        /// <summary>
+        /// Verifies the transactions against a snapshot and a set of transactions
+        /// </summary>
+        /// <param name="snapshot">A snapshot of the current </param>
+        /// <param name="transactionsPool">Usually local node memorypool or consensus node list of transactions proposed by a speaker</param>
+        public virtual bool Verify(Snapshot snapshot, IEnumerable<Transaction> transactionsPool)
         {
-            if (!Reverify(snapshot, mempool)) return false;
+            if (!Reverify(snapshot, transactionsPool)) return false;
             int size = Size;
             if (size > MaxTransactionSize) return false;
             long net_fee = NetworkFee - size * NativeContract.Policy.GetFeePerByte(snapshot);

--- a/neo/Network/P2P/TaskManager.cs
+++ b/neo/Network/P2P/TaskManager.cs
@@ -17,7 +17,7 @@ namespace Neo.Network.P2P
         public class NewTasks { public InvPayload Payload; }
         public class TaskCompleted { public UInt256 Hash; }
         public class HeaderTaskCompleted { }
-        public class RestartTasks { public InvPayload Payload; }
+        public class ConsensusTxsTask { public InvPayload Payload; }
         private class Timer { }
 
         private static readonly TimeSpan TimerInterval = TimeSpan.FromSeconds(30);
@@ -95,8 +95,8 @@ namespace Neo.Network.P2P
                 case HeaderTaskCompleted _:
                     OnHeaderTaskCompleted();
                     break;
-                case RestartTasks restart:
-                    OnRestartTasks(restart.Payload);
+                case ConsensusTxsTask consensusTask:
+                    OnConsensusTxsTask(consensusTask.Payload);
                     break;
                 case Timer _:
                     OnTimer();
@@ -115,7 +115,11 @@ namespace Neo.Network.P2P
             RequestTasks(session);
         }
 
-        private void OnRestartTasks(InvPayload payload)
+        /// <summary>
+        /// Receives the InvPayload of ConsensusService actors and cleans txs hashes in order to ensure new requests
+        /// </summary>
+        /// <param name="payload">An InvPayload payload that contains transactions that are missing in order to check a Block proposed by current Speaker </param>
+        private void OnConsensusTxsTask(InvPayload payload)
         {
             knownHashes.ExceptWith(payload.Hashes);
             foreach (UInt256 hash in payload.Hashes)
@@ -256,7 +260,7 @@ namespace Neo.Network.P2P
             switch (message)
             {
                 case TaskManager.Register _:
-                case TaskManager.RestartTasks _:
+                case TaskManager.ConsensusTxsTask _:
                     return true;
                 case TaskManager.NewTasks tasks:
                     if (tasks.Payload.Type == InventoryType.Block || tasks.Payload.Type == InventoryType.Consensus)


### PR DESCRIPTION
closes #1148 

Sometimes the `Verify` is used in another context, such as by Consensus Service, which sends a set (dictionary) of transactions that the `Speaker` is proposing.

In this sense, not always the node `mempool` is used for `Verifying`/`Reverifying`.

Thus, this renaming tries to clarify this.