### PR TITLE
Ensure txs are cleared before Blockchain actor

### DIFF
--- a/neo/Ledger/MemoryPool.cs
+++ b/neo/Ledger/MemoryPool.cs
@@ -366,10 +366,17 @@ namespace Neo.Ledger
                             tx.Add(item.Tx);
 
                     if (tx.Count > 0)
-                        _system.Blockchain.Tell(tx.ToArray(), ActorRefs.NoSender);
-
-                    _unverifiedTransactions.Clear();
-                    _unverifiedSortedTransactions.Clear();
+                    {
+                        Transaction[] txsToReverify = tx.ToArray();
+                        _unverifiedTransactions.Clear();
+                        _unverifiedSortedTransactions.Clear();
+                        _system.Blockchain.Tell(txsToReverify, ActorRefs.NoSender);
+                    }
+                    else
+                    {
+                        _unverifiedTransactions.Clear();
+                        _unverifiedSortedTransactions.Clear();
+                    }
                 }
             }
             finally

--- a/neo/Ledger/MemoryPool.cs
+++ b/neo/Ledger/MemoryPool.cs
@@ -365,18 +365,11 @@ namespace Neo.Ledger
                         if (item.Tx.FeePerByte >= _feePerByte)
                             tx.Add(item.Tx);
 
+                    _unverifiedTransactions.Clear();
+                    _unverifiedSortedTransactions.Clear();
+
                     if (tx.Count > 0)
-                    {
-                        Transaction[] txsToReverify = tx.ToArray();
-                        _unverifiedTransactions.Clear();
-                        _unverifiedSortedTransactions.Clear();
-                        _system.Blockchain.Tell(txsToReverify, ActorRefs.NoSender);
-                    }
-                    else
-                    {
-                        _unverifiedTransactions.Clear();
-                        _unverifiedSortedTransactions.Clear();
-                    }
+                        _system.Blockchain.Tell(tx.ToArray(), ActorRefs.NoSender);
                 }
             }
             finally


### PR DESCRIPTION
Perhaps the mempool could be triggering `Blockchain Actor` in parallel and it could start revalidating `txs` before `unverified` arrays were cleared.

```cs
    public interface ICanTell
    {
        //
        // Summary:
        //     Asynchronously delivers a message to this Akka.Actor.IActorRef or Akka.Actor.ActorSelection
        //     in a non-blocking fashion. Uses "at most once" delivery semantics.
        //
        // Parameters:
        //   message:
        //     The message to be sent to the target.
        //
        //   sender:
        //     The sender of this message. Defaults to Akka.Actor.ActorRefs.NoSender if left
        //     to null.
        void Tell(object message, IActorRef sender);
    }
```