### PR TITLE
Renaming RestartTasks to ConsensusTxsTask

### DIFF
--- a/neo.UnitTests/Network/P2P/UT_TaskManagerMailbox.cs
+++ b/neo.UnitTests/Network/P2P/UT_TaskManagerMailbox.cs
@@ -34,7 +34,7 @@ namespace Neo.UnitTests.Network.P2P
         {
             // high priority
             uut.IsHighPriority(new TaskManager.Register()).Should().Be(true);
-            uut.IsHighPriority(new TaskManager.RestartTasks()).Should().Be(true);
+            uut.IsHighPriority(new TaskManager.ConsensusTxsTask()).Should().Be(true);
 
             // low priority
             // -> NewTasks: generic InvPayload

--- a/neo/Consensus/ConsensusService.cs
+++ b/neo/Consensus/ConsensusService.cs
@@ -462,7 +462,7 @@ namespace Neo.Consensus
             if (context.Transactions.Count < context.TransactionHashes.Length)
             {
                 UInt256[] hashes = context.TransactionHashes.Where(i => !context.Transactions.ContainsKey(i)).ToArray();
-                taskManager.Tell(new TaskManager.RestartTasks
+                taskManager.Tell(new TaskManager.ConsensusTxsTask
                 {
                     Payload = InvPayload.Create(InventoryType.TX, hashes)
                 });

--- a/neo/Network/P2P/ProtocolHandler.cs
+++ b/neo/Network/P2P/ProtocolHandler.cs
@@ -27,8 +27,6 @@ namespace Neo.Network.P2P
         private bool verack = false;
         private BloomFilter bloom_filter;
 
-        private static readonly Random random = new Random();
-
         public ProtocolHandler(NeoSystem system)
         {
             this.system = system;
@@ -180,8 +178,7 @@ namespace Neo.Network.P2P
         private void OnGetDataMessageReceived(InvPayload payload)
         {
             UInt256[] hashes = payload.Hashes.Where(p => sentHashes.Add(p)).ToArray();
-            var randomHashes = hashes.OrderBy(x => random.Next()).ToArray();
-            foreach (UInt256 hash in randomHashes)
+            foreach (UInt256 hash in hashes)
             {
                 switch (payload.Type)
                 {

--- a/neo/Network/P2P/ProtocolHandler.cs
+++ b/neo/Network/P2P/ProtocolHandler.cs
@@ -28,7 +28,7 @@ namespace Neo.Network.P2P
         private BloomFilter bloom_filter;
 
         private static readonly Random random = new Random();
-        
+
         public ProtocolHandler(NeoSystem system)
         {
             this.system = system;

--- a/neo/Network/P2P/ProtocolHandler.cs
+++ b/neo/Network/P2P/ProtocolHandler.cs
@@ -27,6 +27,8 @@ namespace Neo.Network.P2P
         private bool verack = false;
         private BloomFilter bloom_filter;
 
+        private static readonly Random random = new Random();
+        
         public ProtocolHandler(NeoSystem system)
         {
             this.system = system;

--- a/neo/Network/P2P/ProtocolHandler.cs
+++ b/neo/Network/P2P/ProtocolHandler.cs
@@ -178,7 +178,8 @@ namespace Neo.Network.P2P
         private void OnGetDataMessageReceived(InvPayload payload)
         {
             UInt256[] hashes = payload.Hashes.Where(p => sentHashes.Add(p)).ToArray();
-            foreach (UInt256 hash in hashes)
+            var randomHashes = hashes.OrderBy(x => random.Next()).ToArray();
+            foreach (UInt256 hash in randomHashes)
             {
                 switch (payload.Type)
                 {

--- a/neo/Network/P2P/TaskManager.cs
+++ b/neo/Network/P2P/TaskManager.cs
@@ -95,8 +95,8 @@ namespace Neo.Network.P2P
                 case HeaderTaskCompleted _:
                     OnHeaderTaskCompleted();
                     break;
-                case ConsensusTxsTask restart:
-                    OnConsensusTxsTask(restart.Payload);
+                case ConsensusTxsTask consensusTask:
+                    OnConsensusTxsTask(consensusTask.Payload);
                     break;
                 case Timer _:
                     OnTimer();

--- a/neo/Network/P2P/TaskManager.cs
+++ b/neo/Network/P2P/TaskManager.cs
@@ -96,7 +96,7 @@ namespace Neo.Network.P2P
                     OnHeaderTaskCompleted();
                     break;
                 case ConsensusTxsTask restart:
-                    OnConsensusTxsTasks(restart.Payload);
+                    OnConsensusTxsTask(restart.Payload);
                     break;
                 case Timer _:
                     OnTimer();
@@ -115,7 +115,7 @@ namespace Neo.Network.P2P
             RequestTasks(session);
         }
 
-        private void OnConsensusTxsTasks(InvPayload payload)
+        private void OnConsensusTxsTask(InvPayload payload)
         {
             knownHashes.ExceptWith(payload.Hashes);
             foreach (UInt256 hash in payload.Hashes)

--- a/neo/Network/P2P/TaskManager.cs
+++ b/neo/Network/P2P/TaskManager.cs
@@ -17,7 +17,7 @@ namespace Neo.Network.P2P
         public class NewTasks { public InvPayload Payload; }
         public class TaskCompleted { public UInt256 Hash; }
         public class HeaderTaskCompleted { }
-        public class RestartTasks { public InvPayload Payload; }
+        public class ConsensusTxsTask { public InvPayload Payload; }
         private class Timer { }
 
         private static readonly TimeSpan TimerInterval = TimeSpan.FromSeconds(30);
@@ -95,8 +95,8 @@ namespace Neo.Network.P2P
                 case HeaderTaskCompleted _:
                     OnHeaderTaskCompleted();
                     break;
-                case RestartTasks restart:
-                    OnRestartTasks(restart.Payload);
+                case ConsensusTxsTask restart:
+                    OnConsensusTxsTasks(restart.Payload);
                     break;
                 case Timer _:
                     OnTimer();
@@ -115,7 +115,7 @@ namespace Neo.Network.P2P
             RequestTasks(session);
         }
 
-        private void OnRestartTasks(InvPayload payload)
+        private void OnConsensusTxsTasks(InvPayload payload)
         {
             knownHashes.ExceptWith(payload.Hashes);
             foreach (UInt256 hash in payload.Hashes)
@@ -256,7 +256,7 @@ namespace Neo.Network.P2P
             switch (message)
             {
                 case TaskManager.Register _:
-                case TaskManager.RestartTasks _:
+                case TaskManager.ConsensusTxsTask _:
                     return true;
                 case TaskManager.NewTasks tasks:
                     if (tasks.Payload.Type == InventoryType.Block || tasks.Payload.Type == InventoryType.Consensus)

--- a/neo/Network/P2P/TaskManager.cs
+++ b/neo/Network/P2P/TaskManager.cs
@@ -115,6 +115,10 @@ namespace Neo.Network.P2P
             RequestTasks(session);
         }
 
+        /// <summary>
+        /// Receives the InvPayload of ConsensusService actors and cleans txs hashes in order to ensure new requests
+        /// </summary>
+        /// <param name="payload">An InvPayload payload that contains transactions that are missing in order to check a Block proposed by current Speaker </param>
         private void OnConsensusTxsTask(InvPayload payload)
         {
             knownHashes.ExceptWith(payload.Hashes);


### PR DESCRIPTION
This also helps for understanding #1148 

@erikzhang, please consider this renaming. `RestartTasks` was a name hard to understand.
In fact, that class was just used at `ConsensusService`, which forces a restart of `global` and `knowhashes`

I believe that comprehension will improve with this.