### PR TITLE
Remove meaningless UT

### DIFF
--- a/tests/neo.UnitTests/Ledger/UT_Blockchain.cs
+++ b/tests/neo.UnitTests/Ledger/UT_Blockchain.cs
@@ -55,12 +55,6 @@ namespace Neo.UnitTests.Ledger
         }
 
         [TestMethod]
-        public void TestConstructor()
-        {
-            system.ActorSystem.ActorOf(Blockchain.Props(system, Blockchain.Singleton.Store)).Should().NotBeSameAs(system.Blockchain);
-        }
-
-        [TestMethod]
         public void TestContainsBlock()
         {
             Blockchain.Singleton.ContainsBlock(UInt256.Zero).Should().BeFalse();


### PR DESCRIPTION
This UT is meaningless. Because `ActorSystem.ActorOf()` always returns different actors. And it throws exceptions in actors and pollute the logs by the following messages:

```
[ERROR][12/02/2019 13:28:14][Thread 0021][akka://NeoSystem/user/$i] Error while creating actor instance of type Neo.Ledger.Blockchain with 2 args: (Neo.NeoSystem,Neo.Persistence.MemoryStore)
Cause: [akka://NeoSystem/user/$i#1185665970]: Akka.Actor.ActorInitializationException: Exception during creation
 ---> System.TypeLoadException: Error while creating actor instance of type Neo.Ledger.Blockchain with 2 args: (Neo.NeoSystem,Neo.Persistence.MemoryStore)
 ---> System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
 ---> System.InvalidOperationException: Operation is not valid due to the current state of the object.
   at Neo.Ledger.Blockchain..ctor(NeoSystem system, IStore store) in /home/runner/work/neo/neo/src/neo/Ledger/Blockchain.cs:line 110
   --- End of inner exception stack trace ---
   at System.RuntimeMethodHandle.InvokeMethod(Object target, Object[] arguments, Signature sig, Boolean constructor, Boolean wrapExceptions)
   at System.Reflection.RuntimeConstructorInfo.Invoke(BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
   at System.RuntimeType.CreateInstanceImpl(BindingFlags bindingAttr, Binder binder, Object[] args, CultureInfo culture)
   at Akka.Actor.Props.ActivatorProducer.Produce()
   at Akka.Actor.Props.NewActor()
   --- End of inner exception stack trace ---
   at Akka.Actor.Props.NewActor()
   at Akka.Actor.ActorCell.CreateNewActorInstance()
   at Akka.Actor.ActorCell.<>c__DisplayClass109_0.<NewActor>b__0()
   at Akka.Actor.ActorCell.UseThreadContext(Action action)
   at Akka.Actor.ActorCell.NewActor()
   at Akka.Actor.ActorCell.Create(Exception failure)
   --- End of inner exception stack trace ---
   at Akka.Actor.ActorCell.Create(Exception failure)
   at Akka.Actor.ActorCell.SysMsgInvokeAll(EarliestFirstSystemMessageList messages, Int32 currentState)
```