### PR TITLE
Add InvalidOperationException exception

### DIFF
--- a/src/neo/IO/Json/JObject.cs
+++ b/src/neo/IO/Json/JObject.cs
@@ -63,10 +63,6 @@ namespace Neo.IO.Json
             {
                 throw new FormatException(ex.Message, ex);
             }
-            catch (InvalidOperationException ex)
-            {
-                throw new FormatException(ex.Message, ex);
-            }
         }
 
         public static JObject Parse(string value, int max_nest = 100)
@@ -117,7 +113,15 @@ namespace Neo.IO.Json
                     case JsonTokenType.EndObject:
                         return obj;
                     case JsonTokenType.PropertyName:
-                        string name = reader.GetString();
+                        string name;
+                        try
+                        {
+                            name = reader.GetString();
+                        }
+                        catch (InvalidOperationException ex)
+                        {
+                            throw new FormatException(ex.Message, ex);
+                        }
                         if (obj.Properties.ContainsKey(name)) throw new FormatException();
                         JObject value = Read(ref reader);
                         obj.Properties.Add(name, value);

--- a/src/neo/IO/Json/JObject.cs
+++ b/src/neo/IO/Json/JObject.cs
@@ -63,6 +63,10 @@ namespace Neo.IO.Json
             {
                 throw new FormatException(ex.Message, ex);
             }
+            catch (Exception)
+            {
+                throw new FormatException();
+            }
         }
 
         public static JObject Parse(string value, int max_nest = 100)

--- a/src/neo/IO/Json/JObject.cs
+++ b/src/neo/IO/Json/JObject.cs
@@ -63,7 +63,7 @@ namespace Neo.IO.Json
             {
                 throw new FormatException(ex.Message, ex);
             }
-            catch (InvalidOperationException)
+            catch (InvalidOperationException ex)
             {
                 throw new FormatException(ex.Message, ex);
             }

--- a/src/neo/IO/Json/JObject.cs
+++ b/src/neo/IO/Json/JObject.cs
@@ -63,9 +63,9 @@ namespace Neo.IO.Json
             {
                 throw new FormatException(ex.Message, ex);
             }
-            catch (Exception)
+            catch (InvalidOperationException)
             {
-                throw new FormatException();
+                throw new FormatException(ex.Message, ex);
             }
         }
 

--- a/tests/neo.UnitTests/IO/Json/UT_JObject.cs
+++ b/tests/neo.UnitTests/IO/Json/UT_JObject.cs
@@ -63,7 +63,8 @@ namespace Neo.UnitTests.IO.Json
             Assert.ThrowsException<FormatException>(() => JObject.Parse("{\"k1\",\"k1\"}"));
             Assert.ThrowsException<FormatException>(() => JObject.Parse("{\"k1\":\"v1\""));
             Assert.ThrowsException<FormatException>(() => JObject.Parse(new byte[] { 0x22, 0x01, 0x22 }));
-
+            Assert.ThrowsException<FormatException>(() => JObject.Parse("{\"color\":\"red\",\"\\uDBFF\\u0DFFF\":\"#f00\"}"));
+            
             JObject.Parse("null").Should().BeNull();
             JObject.Parse("true").AsBoolean().Should().BeTrue();
             JObject.Parse("false").AsBoolean().Should().BeFalse();

--- a/tests/neo.UnitTests/IO/Json/UT_JObject.cs
+++ b/tests/neo.UnitTests/IO/Json/UT_JObject.cs
@@ -64,7 +64,7 @@ namespace Neo.UnitTests.IO.Json
             Assert.ThrowsException<FormatException>(() => JObject.Parse("{\"k1\":\"v1\""));
             Assert.ThrowsException<FormatException>(() => JObject.Parse(new byte[] { 0x22, 0x01, 0x22 }));
             Assert.ThrowsException<FormatException>(() => JObject.Parse("{\"color\":\"red\",\"\\uDBFF\\u0DFFF\":\"#f00\"}"));
-            
+
             JObject.Parse("null").Should().BeNull();
             JObject.Parse("true").AsBoolean().Should().BeTrue();
             JObject.Parse("false").AsBoolean().Should().BeFalse();


### PR DESCRIPTION
According to our fuzzing process we need to cover generic exceptions

![image](https://user-images.githubusercontent.com/3167973/70159345-0b25aa00-16b9-11ea-9be9-9a2209671866.png)

We can get errors like this:
```
System.InvalidOperationException: Cannot read invalid UTF-16 JSON text as string. Invalid surrogate value: '0xDBFF'.
   at TuringMachine.Core.Fuzzers.FuzzerClient.Execute(Action`1 action, FuzzingStream stream)
ExtraInformation: TaskId: 2
```

With entries like

```json
[
	[100, 500, 300, 200],
	123,
	true,
	false,
	null,
	{
		"color": "red",
		"value": "#f\uDBFF\uDBFF\uDFFF\uDFFFdata": [1, 2]
	}
]
```