### PR TITLE
Remove Manifest Clone in ContractState

### DIFF
--- a/src/neo/Ledger/ContractState.cs
+++ b/src/neo/Ledger/ContractState.cs
@@ -38,7 +38,7 @@ namespace Neo.Ledger
             return new ContractState
             {
                 Script = Script,
-                Manifest = Manifest.Clone()
+                Manifest = Manifest
             };
         }
 


### PR DESCRIPTION
After performance testing, we found that when the NEO / GAS transfer transaction was executed in the block `Persist`, the average time was 0.3ms, and about 0.1-0.2ms of it was spent on the `Clone()` of the ContractState Manifest. The Clone() is invoked by `engine.Snapshot.Contracts.TryGet()` of InteropService `Contract_Call`

https://github.com/neo-project/neo/blob/afec99a7207e3651f5022acbb853b0fed3163f02/src/neo/SmartContract/InteropService.cs#L478

Since Contracts is a CloneCache, when calling TryGetInternal(), the ContractState will clone another copy including the `Manifest` as well.

Considering that `Manifest` will not be modified if the snapshot is not committed, and the transaction is executed sequentially, so if the Manifest is used in the transaction execution process, it will not interfere with each other. So consider removing `Clone()` to improve speed.