### PR TITLE
Serialization check

### DIFF
--- a/src/neo/SmartContract/InteropService.NEO.cs
+++ b/src/neo/SmartContract/InteropService.NEO.cs
@@ -388,7 +388,6 @@ namespace Neo.SmartContract
         {
             var item = engine.CurrentContext.EvaluationStack.Pop();
             var json = JsonSerializer.Serialize(item, (int)engine.MaxItemSize).ToByteArray(false);
-            if (json.Length > engine.MaxItemSize) return false;
             engine.CurrentContext.EvaluationStack.Push(json);
             return true;
         }

--- a/src/neo/SmartContract/InteropService.NEO.cs
+++ b/src/neo/SmartContract/InteropService.NEO.cs
@@ -387,7 +387,7 @@ namespace Neo.SmartContract
         private static bool Json_Serialize(ApplicationEngine engine)
         {
             var item = engine.CurrentContext.EvaluationStack.Pop();
-            var json = JsonSerializer.Serialize(item).ToByteArray(false);
+            var json = JsonSerializer.Serialize(item, (int)engine.MaxItemSize).ToByteArray(false);
             if (json.Length > engine.MaxItemSize) return false;
             engine.CurrentContext.EvaluationStack.Push(json);
             return true;


### PR DESCRIPTION
Hi Erik,
This is less efficient because we have to do more checks, but it leaves the maxSize to the Serialize function instead of the caller and stops serialization right after the limit is reached.