### PR TITLE
Storage payback

### DIFF
--- a/src/neo/IO/Caching/DataCache.cs
+++ b/src/neo/IO/Caching/DataCache.cs
@@ -260,7 +260,7 @@ namespace Neo.IO.Caching
             }
         }
 
-        public TValue TryGet(TKey key)
+        public virtual TValue TryGet(TKey key)
         {
             lock (dictionary)
             {

--- a/src/neo/SmartContract/InteropDescriptor.cs
+++ b/src/neo/SmartContract/InteropDescriptor.cs
@@ -10,6 +10,8 @@ namespace Neo.SmartContract
         internal Func<ApplicationEngine, bool> Handler { get; }
         public long Price { get; }
         public Func<EvaluationStack, long> PriceCalculator { get; }
+        public Func<ApplicationEngine, long> StoragePriceCalculator { get; }
+        public bool IsStateful { get; }
         public TriggerType AllowedTriggers { get; }
 
         internal InteropDescriptor(string method, Func<ApplicationEngine, bool> handler, long price, TriggerType allowedTriggers)
@@ -24,6 +26,13 @@ namespace Neo.SmartContract
             this.PriceCalculator = priceCalculator;
         }
 
+        public InteropDescriptor(string method, Func<ApplicationEngine, bool> handler, Func<ApplicationEngine, long> priceCalculator, TriggerType allowedTriggers)
+            : this(method, handler, allowedTriggers)
+        {
+            this.StoragePriceCalculator = priceCalculator;
+            this.IsStateful = true;
+        }
+
         private InteropDescriptor(string method, Func<ApplicationEngine, bool> handler, TriggerType allowedTriggers)
         {
             this.Method = method;
@@ -32,8 +41,24 @@ namespace Neo.SmartContract
             this.AllowedTriggers = allowedTriggers;
         }
 
+        public long GetPrice()
+        {
+            return Price;
+        }
+
+        public long GetPrice(ApplicationEngine applicationEngine)
+        {
+            return StoragePriceCalculator is null ? Price : StoragePriceCalculator(applicationEngine);
+        }
+
         public long GetPrice(EvaluationStack stack)
         {
+#if DEBUG
+            if (IsStateful)
+            {
+                throw new InvalidOperationException();
+            }
+#endif
             return PriceCalculator is null ? Price : PriceCalculator(stack);
         }
 

--- a/tests/neo.UnitTests/SmartContract/UT_ApplicationEngine.cs
+++ b/tests/neo.UnitTests/SmartContract/UT_ApplicationEngine.cs
@@ -7,6 +7,8 @@ using Neo.Ledger;
 using Neo.Network.P2P.Payloads;
 using Neo.Persistence;
 using Neo.SmartContract;
+using Neo.SmartContract.Native;
+using Neo.VM;
 using Neo.VM.Types;
 using System;
 


### PR DESCRIPTION
Extending VM Gas when user reuses or releases storage. Related to #278 .

Another option would be evaluating previously the amount of data that would be released, allowing this GAS to be used before in any part of the transaction, however, this has a greater performance impact and this would be required to occur during the verification and would require us to run the application trigger twice.


@shargon when possible, could you please contact me on Discord to help me improve the tests? Thanks.
