### PR TITLE
Add Data Size Non-negative Check in DecompressLz4

### DIFF
--- a/src/neo/IO/Helper.cs
+++ b/src/neo/IO/Helper.cs
@@ -79,7 +79,8 @@ namespace Neo.IO
 
         public static byte[] DecompressLz4(this byte[] data, int maxOutput)
         {
-            maxOutput = Math.Min(maxOutput, data.Length * 255);
+            var maxDecompressDataLength = data.Length * 255;
+            if (maxDecompressDataLength > 0) maxOutput = Math.Min(maxOutput, maxDecompressDataLength);
             using var buffer = MemoryPool<byte>.Shared.Rent(maxOutput);
             int length = LZ4Codec.Decode(data, buffer.Memory.Span);
             if (length < 0 || length > maxOutput) throw new FormatException();


### PR DESCRIPTION
When the length of data is quite large (but it does not exceed the max value of int), `data.length * 255 
` may go out of bounds and become negative. This happened to me during the performance test, when message size reach almost `Message.PayloadMaxSize = 0x02000000`, `data.length * 255 
` becomes negative. Therefore, it is recommended to add a non-negative check here.