### PR TITLE
Add ContainsTransaction Recheck when ParallelVerifiedTransaction Received

### DIFF
--- a/src/neo/Ledger/Blockchain.cs
+++ b/src/neo/Ledger/Blockchain.cs
@@ -429,7 +429,7 @@ namespace Neo.Ledger
             RelayResultReason reason = parallelVerified.VerifyResult;
             if (reason == RelayResultReason.Succeed)
             {
-                if (ContainsTransaction(parallelVerified.Transaction.Hash))
+                if (View.ContainsTransaction(parallelVerified.Transaction.Hash))
                     reason = RelayResultReason.AlreadyExists;
                 else if (!MemPool.CanTransactionFitInPool(parallelVerified.Transaction))
                     reason = RelayResultReason.OutOfMemory;

--- a/src/neo/Ledger/Blockchain.cs
+++ b/src/neo/Ledger/Blockchain.cs
@@ -429,7 +429,9 @@ namespace Neo.Ledger
             RelayResultReason reason = parallelVerified.VerifyResult;
             if (reason == RelayResultReason.Succeed)
             {
-                if (!MemPool.CanTransactionFitInPool(parallelVerified.Transaction))
+                if (ContainsTransaction(parallelVerified.Transaction.Hash))
+                    reason = RelayResultReason.AlreadyExists;
+                else if (!MemPool.CanTransactionFitInPool(parallelVerified.Transaction))
                     reason = RelayResultReason.OutOfMemory;
                 else if (!MemPool.TryAdd(parallelVerified.Transaction.Hash, parallelVerified.Transaction))
                     reason = RelayResultReason.OutOfMemory;

--- a/src/neo/Ledger/Blockchain.cs
+++ b/src/neo/Ledger/Blockchain.cs
@@ -27,7 +27,7 @@ namespace Neo.Ledger
         public class ImportCompleted { }
         public class FillMemoryPool { public IEnumerable<Transaction> Transactions; }
         public class FillCompleted { }
-        private class ParallelVerified { public Transaction Transaction; public bool ShouldRelay; public RelayResultReason VerifyResult; }
+        public class ParallelVerified { public Transaction Transaction; public bool ShouldRelay; public RelayResultReason VerifyResult; }
 
         public static readonly uint MillisecondsPerBlock = ProtocolSettings.Default.MillisecondsPerBlock;
         public const uint DecrementInterval = 2000000;

--- a/src/neo/Ledger/Blockchain.cs
+++ b/src/neo/Ledger/Blockchain.cs
@@ -27,7 +27,7 @@ namespace Neo.Ledger
         public class ImportCompleted { }
         public class FillMemoryPool { public IEnumerable<Transaction> Transactions; }
         public class FillCompleted { }
-        public class ParallelVerified { public Transaction Transaction; public bool ShouldRelay; public RelayResultReason VerifyResult; }
+        private class ParallelVerified { public Transaction Transaction; public bool ShouldRelay; public RelayResultReason VerifyResult; }
 
         public static readonly uint MillisecondsPerBlock = ProtocolSettings.Default.MillisecondsPerBlock;
         public const uint DecrementInterval = 2000000;

--- a/tests/neo.UnitTests/Ledger/UT_Blockchain.cs
+++ b/tests/neo.UnitTests/Ledger/UT_Blockchain.cs
@@ -12,7 +12,6 @@ using Neo.Wallets;
 using Neo.Wallets.NEP6;
 using System.Linq;
 using System.Reflection;
-using static Neo.Ledger.Blockchain;
 
 namespace Neo.UnitTests.Ledger
 {

--- a/tests/neo.UnitTests/Ledger/UT_Blockchain.cs
+++ b/tests/neo.UnitTests/Ledger/UT_Blockchain.cs
@@ -185,9 +185,6 @@ namespace Neo.UnitTests.Ledger
                 };
                 senderProbe.Send(system.Blockchain, parallelVerified);
                 senderProbe.ExpectMsg(RelayResultReason.Succeed);
-
-                senderProbe.Send(system.Blockchain, parallelVerified);
-                senderProbe.ExpectMsg(RelayResultReason.AlreadyExists);
             }
         }
 


### PR DESCRIPTION
There is a case that causes transactions to enter the mempool repeatedly.
1. Block synchronization of one node lags behind other nodes
2. When a Tx has just entered the `OnTransaction` method of this lagging node, at this time neither this mempool nor storage contains this Tx
3. When Tx starts an asynchronous thread to verify the signature and has not completed, the node's `Blockchain` Actor receives the block containing this Tx and persists it.
4. Tx asynchronous verification is completed, entered the `OnParallelVerified` method and is successfully added to mempool.

Because `OnParallelVerified` does not have a check of whether Tx already exists in storage, which causes repeated added to the mempool and will not be deleted in the future, it is necessary to add a `ContainsTransaction` recheck in `OnParallelVerified`.