### PR TITLE
Small fix for ConsensusContext

### DIFF
--- a/src/neo/Consensus/ConsensusContext.cs
+++ b/src/neo/Consensus/ConsensusContext.cs
@@ -88,8 +88,8 @@ namespace Neo.Consensus
             for (int i = 0, j = 0; i < Validators.Length && j < M; i++)
             {
                 if (CommitPayloads[i]?.ConsensusMessage.ViewNumber != ViewNumber) continue;
-                sc.AddSignature(contract, Validators[i], CommitPayloads[i].GetDeserializedMessage<Commit>().Signature);
-                j++;
+                if (sc.AddSignature(contract, Validators[i], CommitPayloads[i].GetDeserializedMessage<Commit>().Signature))
+                    j++;
             }
             Block.Witness = sc.GetWitnesses()[0];
             Block.Transactions = TransactionHashes.Select(p => Transactions[p]).ToArray();


### PR DESCRIPTION
`j` must be only increased if the `AddSignature` was true