### PR TITLE
Allow MultiSig contracts in Wallet.Sign method

### DIFF
--- a/src/neo/SmartContract/ContractParametersContext.cs
+++ b/src/neo/SmartContract/ContractParametersContext.cs
@@ -130,7 +130,7 @@ namespace Neo.SmartContract
 
         public bool AddSignature(Contract contract, ECPoint pubkey, byte[] signature)
         {
-            if (contract.Script.IsMultiSigContract(out _, out _, out var points))
+            if (contract.Script.IsMultiSigContract(out _, out ECPoint[] points))
             {
                 ContextItem item = CreateItem(contract);
                 if (item == null) return false;

--- a/src/neo/SmartContract/ContractParametersContext.cs
+++ b/src/neo/SmartContract/ContractParametersContext.cs
@@ -130,7 +130,7 @@ namespace Neo.SmartContract
 
         public bool AddSignature(Contract contract, ECPoint pubkey, byte[] signature)
         {
-            if (contract.Script.IsMultiSigContract(out _, out _))
+            if (contract.Script.IsMultiSigContract(out _, out _, out var points))
             {
                 ContextItem item = CreateItem(contract);
                 if (item == null) return false;
@@ -139,24 +139,6 @@ namespace Neo.SmartContract
                     item.Signatures = new Dictionary<ECPoint, byte[]>();
                 else if (item.Signatures.ContainsKey(pubkey))
                     return false;
-                List<ECPoint> points = new List<ECPoint>();
-                {
-                    int i = 0;
-                    switch (contract.Script[i++])
-                    {
-                        case (byte)OpCode.PUSHINT8:
-                            ++i;
-                            break;
-                        case (byte)OpCode.PUSHINT16:
-                            i += 2;
-                            break;
-                    }
-                    while (contract.Script[i++] == (byte)OpCode.PUSHDATA1)
-                    {
-                        points.Add(ECPoint.DecodePoint(contract.Script.AsSpan(++i, 33), ECCurve.Secp256r1));
-                        i += 33;
-                    }
-                }
                 if (!points.Contains(pubkey)) return false;
                 item.Signatures.Add(pubkey, signature);
                 if (item.Signatures.Count == contract.ParameterList.Length)

--- a/src/neo/Wallets/Wallet.cs
+++ b/src/neo/Wallets/Wallet.cs
@@ -388,7 +388,7 @@ namespace Neo.Wallets
                 {
                     // Try to sign self-contained multiSig
 
-                    Contract multiSigContract = account.Contract;
+                    Contract multiSigContract = account?.Contract;
 
                     if (multiSigContract != null &&
                         multiSigContract.Script.IsMultiSigContract(out int m, out ECPoint[] points))

--- a/src/neo/Wallets/Wallet.cs
+++ b/src/neo/Wallets/Wallet.cs
@@ -391,7 +391,7 @@ namespace Neo.Wallets
                     Contract multiSigContract = account.Contract;
 
                     if (multiSigContract != null &&
-                        SmartContract.Helper.IsMultiSigContract(multiSigContract.Script, out var m, out var n, out var points))
+                        multiSigContract.Script.IsMultiSigContract(out int m, out ECPoint[] points))
                     {
                         foreach (var point in points)
                         {

--- a/tests/neo.UnitTests/SmartContract/UT_SmartContractHelper.cs
+++ b/tests/neo.UnitTests/SmartContract/UT_SmartContractHelper.cs
@@ -4,6 +4,7 @@ using Neo.Network.P2P.Payloads;
 using Neo.SmartContract;
 using Neo.Wallets;
 using System;
+using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
 
@@ -25,7 +26,8 @@ namespace Neo.UnitTests.SmartContract
                 publicKeys1[i] = key1.PublicKey;
             }
             byte[] script1 = Contract.CreateMultiSigRedeemScript(20, publicKeys1);
-            Assert.AreEqual(true, Neo.SmartContract.Helper.IsMultiSigContract(script1, out int m1, out int n1));
+            Assert.AreEqual(true, Neo.SmartContract.Helper.IsMultiSigContract(script1, out int m1, out int n1, out var p1));
+            CollectionAssert.AreEqual(publicKeys1.OrderBy(p => p).ToArray(), p1);
 
             Neo.Cryptography.ECC.ECPoint[] publicKeys2 = new Neo.Cryptography.ECC.ECPoint[256];
             for (int i = 0; i < 256; i++)
@@ -37,7 +39,8 @@ namespace Neo.UnitTests.SmartContract
                 publicKeys2[i] = key2.PublicKey;
             }
             byte[] script2 = Contract.CreateMultiSigRedeemScript(256, publicKeys2);
-            Assert.AreEqual(true, Neo.SmartContract.Helper.IsMultiSigContract(script2, out int m2, out int n2));
+            Assert.AreEqual(true, Neo.SmartContract.Helper.IsMultiSigContract(script2, out int m2, out int n2, out var p2));
+            CollectionAssert.AreEqual(publicKeys2.OrderBy(p => p).ToArray(), p2);
 
             Neo.Cryptography.ECC.ECPoint[] publicKeys3 = new Neo.Cryptography.ECC.ECPoint[3];
             for (int i = 0; i < 3; i++)
@@ -49,7 +52,8 @@ namespace Neo.UnitTests.SmartContract
                 publicKeys3[i] = key3.PublicKey;
             }
             byte[] script3 = Contract.CreateMultiSigRedeemScript(3, publicKeys3);
-            Assert.AreEqual(true, Neo.SmartContract.Helper.IsMultiSigContract(script3, out int m3, out int n3));
+            Assert.AreEqual(true, Neo.SmartContract.Helper.IsMultiSigContract(script3, out int m3, out int n3, out var p3));
+            CollectionAssert.AreEqual(publicKeys3.OrderBy(p => p).ToArray(), p3);
 
             Neo.Cryptography.ECC.ECPoint[] publicKeys4 = new Neo.Cryptography.ECC.ECPoint[3];
             for (int i = 0; i < 3; i++)
@@ -62,8 +66,8 @@ namespace Neo.UnitTests.SmartContract
             }
             byte[] script4 = Contract.CreateMultiSigRedeemScript(3, publicKeys4);
             script4[script4.Length - 1] = 0x00;
-            Assert.AreEqual(false, Neo.SmartContract.Helper.IsMultiSigContract(script4, out int m4, out int n4));
-
+            Assert.AreEqual(false, Neo.SmartContract.Helper.IsMultiSigContract(script4, out int m4, out int n4, out var p4));
+            CollectionAssert.AreEqual(Array.Empty<ECPoint>(), p4);
         }
 
         [TestMethod]

--- a/tests/neo.UnitTests/SmartContract/UT_SmartContractHelper.cs
+++ b/tests/neo.UnitTests/SmartContract/UT_SmartContractHelper.cs
@@ -68,7 +68,7 @@ namespace Neo.UnitTests.SmartContract
             byte[] script4 = Contract.CreateMultiSigRedeemScript(3, publicKeys4);
             script4[script4.Length - 1] = 0x00;
             Assert.AreEqual(false, Neo.SmartContract.Helper.IsMultiSigContract(script4, out _, out ECPoint[] p4));
-            CollectionAssert.AreEqual(Array.Empty<ECPoint>(), p4);
+            Assert.IsNull(p4);
         }
 
         [TestMethod]

--- a/tests/neo.UnitTests/SmartContract/UT_SmartContractHelper.cs
+++ b/tests/neo.UnitTests/SmartContract/UT_SmartContractHelper.cs
@@ -7,6 +7,7 @@ using System;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
+using ECPoint = Neo.Cryptography.ECC.ECPoint;
 
 namespace Neo.UnitTests.SmartContract
 {
@@ -26,7 +27,7 @@ namespace Neo.UnitTests.SmartContract
                 publicKeys1[i] = key1.PublicKey;
             }
             byte[] script1 = Contract.CreateMultiSigRedeemScript(20, publicKeys1);
-            Assert.AreEqual(true, Neo.SmartContract.Helper.IsMultiSigContract(script1, out int m1, out int n1, out var p1));
+            Assert.AreEqual(true, Neo.SmartContract.Helper.IsMultiSigContract(script1, out _, out ECPoint[] p1));
             CollectionAssert.AreEqual(publicKeys1.OrderBy(p => p).ToArray(), p1);
 
             Neo.Cryptography.ECC.ECPoint[] publicKeys2 = new Neo.Cryptography.ECC.ECPoint[256];
@@ -39,7 +40,7 @@ namespace Neo.UnitTests.SmartContract
                 publicKeys2[i] = key2.PublicKey;
             }
             byte[] script2 = Contract.CreateMultiSigRedeemScript(256, publicKeys2);
-            Assert.AreEqual(true, Neo.SmartContract.Helper.IsMultiSigContract(script2, out int m2, out int n2, out var p2));
+            Assert.AreEqual(true, Neo.SmartContract.Helper.IsMultiSigContract(script2, out _, out ECPoint[] p2));
             CollectionAssert.AreEqual(publicKeys2.OrderBy(p => p).ToArray(), p2);
 
             Neo.Cryptography.ECC.ECPoint[] publicKeys3 = new Neo.Cryptography.ECC.ECPoint[3];
@@ -52,7 +53,7 @@ namespace Neo.UnitTests.SmartContract
                 publicKeys3[i] = key3.PublicKey;
             }
             byte[] script3 = Contract.CreateMultiSigRedeemScript(3, publicKeys3);
-            Assert.AreEqual(true, Neo.SmartContract.Helper.IsMultiSigContract(script3, out int m3, out int n3, out var p3));
+            Assert.AreEqual(true, Neo.SmartContract.Helper.IsMultiSigContract(script3, out _, out ECPoint[] p3));
             CollectionAssert.AreEqual(publicKeys3.OrderBy(p => p).ToArray(), p3);
 
             Neo.Cryptography.ECC.ECPoint[] publicKeys4 = new Neo.Cryptography.ECC.ECPoint[3];
@@ -66,7 +67,7 @@ namespace Neo.UnitTests.SmartContract
             }
             byte[] script4 = Contract.CreateMultiSigRedeemScript(3, publicKeys4);
             script4[script4.Length - 1] = 0x00;
-            Assert.AreEqual(false, Neo.SmartContract.Helper.IsMultiSigContract(script4, out int m4, out int n4, out var p4));
+            Assert.AreEqual(false, Neo.SmartContract.Helper.IsMultiSigContract(script4, out _, out ECPoint[] p4));
             CollectionAssert.AreEqual(Array.Empty<ECPoint>(), p4);
         }
 


### PR DESCRIPTION
Currently if you want to sign a multisg transfer, you can't use the `Sign` method. You should do that like this:

```
var CNContract = Contract.CreateMultiSigContract(m, Blockchain.StandbyValidators);

// Sign with all required CN

            foreach (var cnWallet in cnWallets)
            {
                var key = cnWallet.GetKey();
                var signature = context.Verifiable.Sign(key);

                context.AddSignature(CNContract, key.PublicKey, signature);
                if (context.Completed) break;
            }
``` 

This PR allow to use normal `Sign` method, also **for development purpose** if you have in the same wallet all the accounts for this multi signature, it will be fully signed.