### PR TITLE
Rename OracleResult to OracleResponse

### DIFF
--- a/src/neo/Oracle/OracleExecutionCache.cs
+++ b/src/neo/Oracle/OracleExecutionCache.cs
@@ -4,17 +4,17 @@ using System.Collections.Generic;
 
 namespace Neo.Oracle
 {
-    public class OracleExecutionCache : IEnumerable<KeyValuePair<UInt160, OracleResult>>
+    public class OracleExecutionCache : IEnumerable<KeyValuePair<UInt160, OracleResponse>>
     {
         /// <summary>
         /// Results
         /// </summary>
-        private readonly Dictionary<UInt160, OracleResult> _cache = new Dictionary<UInt160, OracleResult>();
+        private readonly Dictionary<UInt160, OracleResponse> _cache = new Dictionary<UInt160, OracleResponse>();
 
         /// <summary>
         /// Engine
         /// </summary>
-        private readonly Func<OracleRequest, OracleResult> _oracle;
+        private readonly Func<OracleRequest, OracleResponse> _oracle;
 
         /// <summary>
         /// Count
@@ -25,7 +25,7 @@ namespace Neo.Oracle
         /// Constructor for oracles
         /// </summary>
         /// <param name="oracle">Oracle Engine</param>
-        public OracleExecutionCache(Func<OracleRequest, OracleResult> oracle = null)
+        public OracleExecutionCache(Func<OracleRequest, OracleResponse> oracle = null)
         {
             _oracle = oracle;
         }
@@ -34,7 +34,7 @@ namespace Neo.Oracle
         /// Constructor for cached results
         /// </summary>
         /// <param name="results">Results</param>
-        public OracleExecutionCache(params OracleResult[] results)
+        public OracleExecutionCache(params OracleResponse[] results)
         {
             _oracle = null;
 
@@ -50,7 +50,7 @@ namespace Neo.Oracle
         /// <param name="request">Request</param>
         /// <param name="result">Result</param>
         /// <returns></returns>
-        public bool TryGet(OracleRequest request, out OracleResult result)
+        public bool TryGet(OracleRequest request, out OracleResponse result)
         {
             if (_cache.TryGetValue(request.Hash, out result))
             {
@@ -72,7 +72,7 @@ namespace Neo.Oracle
             return false;
         }
 
-        public IEnumerator<KeyValuePair<UInt160, OracleResult>> GetEnumerator()
+        public IEnumerator<KeyValuePair<UInt160, OracleResponse>> GetEnumerator()
         {
             return _cache.GetEnumerator();
         }

--- a/tests/neo.UnitTests/Oracle/UT_OracleExecutionCache.cs
+++ b/tests/neo.UnitTests/Oracle/UT_OracleExecutionCache.cs
@@ -14,11 +14,11 @@ namespace Neo.UnitTests.Oracle
             public int Counter = 0;
         }
 
-        private OracleResult OracleLogic(OracleRequest arg)
+        private OracleResponse OracleLogic(OracleRequest arg)
         {
             var http = (CounterRequest)arg;
             http.Counter++;
-            return OracleResult.CreateResult(_txHash, arg.Hash, BitConverter.GetBytes(http.Counter));
+            return OracleResponse.CreateResult(arg.Hash, BitConverter.GetBytes(http.Counter));
         }
 
         UInt256 _txHash;
@@ -71,7 +71,6 @@ namespace Neo.UnitTests.Oracle
             var array = cache.ToArray();
             Assert.AreEqual(1, array.Length);
             Assert.AreEqual(req.Hash, array[0].Key);
-            Assert.AreEqual(_txHash, array[0].Value.TransactionHash);
             Assert.AreEqual(OracleResultError.None, array[0].Value.Error);
             CollectionAssert.AreEqual(new byte[] { 0x02, 0x00, 0x00, 0x00 }, array[0].Value.Result);
         }
@@ -86,7 +85,7 @@ namespace Neo.UnitTests.Oracle
                 Method = HttpMethod.GET
             };
 
-            var initRes = OracleResult.CreateError(_txHash, initReq.Hash, OracleResultError.ServerError);
+            var initRes = OracleResponse.CreateError(initReq.Hash, OracleResultError.ServerError);
             var cache = new OracleExecutionCache(initRes);
 
             Assert.AreEqual(1, cache.Count);
@@ -96,7 +95,6 @@ namespace Neo.UnitTests.Oracle
             var array = cache.ToArray();
             Assert.AreEqual(1, array.Length);
             Assert.AreEqual(initReq.Hash, array[0].Key);
-            Assert.AreEqual(_txHash, array[0].Value.TransactionHash);
             Assert.AreEqual(OracleResultError.ServerError, array[0].Value.Error);
             CollectionAssert.AreEqual(Array.Empty<byte>(), array[0].Value.Result);
 

--- a/tests/neo.UnitTests/Oracle/UT_OracleResponse.cs
+++ b/tests/neo.UnitTests/Oracle/UT_OracleResponse.cs
@@ -4,7 +4,7 @@ using Neo.Oracle;
 namespace Neo.UnitTests.Oracle
 {
     [TestClass]
-    public class UT_OracleResult
+    public class UT_OracleResponse
     {
         [TestMethod]
         public void TestHash()
@@ -16,10 +16,6 @@ namespace Neo.UnitTests.Oracle
             Assert.AreNotEqual(requestA.Hash, requestB.Hash);
 
             requestB = CreateDefault();
-            requestB.TransactionHash = UInt256.Parse("0xa400ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff01");
-            Assert.AreNotEqual(requestA.Hash, requestB.Hash);
-
-            requestB = CreateDefault();
             requestB.RequestHash = UInt160.Parse("0xa400ff00ff00ff00ff00ff00ff00ff00ff00ff01");
             Assert.AreNotEqual(requestA.Hash, requestB.Hash);
 
@@ -28,13 +24,12 @@ namespace Neo.UnitTests.Oracle
             Assert.AreNotEqual(requestA.Hash, requestB.Hash);
         }
 
-        private OracleResult CreateDefault()
+        private OracleResponse CreateDefault()
         {
-            return new OracleResult()
+            return new OracleResponse()
             {
                 Error = OracleResultError.None,
                 RequestHash = UInt160.Zero,
-                TransactionHash = UInt256.Zero,
                 Result = new byte[0]
             };
         }

--- a/tests/neo.UnitTests/SmartContract/UT_Syscalls.cs
+++ b/tests/neo.UnitTests/SmartContract/UT_Syscalls.cs
@@ -130,8 +130,8 @@ namespace Neo.UnitTests.SmartContract
 
                     Assert.IsTrue(engine.ResultStack.TryPop<VM.Types.Array>(out var array));
 
-                    PrimitiveType type = array[0] as PrimitiveType;
-                    ByteArray response = array[1] as ByteArray;
+                    PrimitiveType type = array[1] as PrimitiveType;
+                    ByteArray response = array[2] as ByteArray;
 
                     Assert.AreEqual((int)OracleResultError.None, type.GetBigInteger());
                     Assert.AreEqual("MyResponse", response.GetString());
@@ -155,8 +155,8 @@ namespace Neo.UnitTests.SmartContract
 
                     Assert.IsTrue(engine.ResultStack.TryPop<VM.Types.Array>(out var array));
 
-                    PrimitiveType type = array[0] as PrimitiveType;
-                    ByteArray response = array[1] as ByteArray;
+                    PrimitiveType type = array[1] as PrimitiveType;
+                    ByteArray response = array[2] as ByteArray;
 
                     Assert.AreEqual((int)OracleResultError.FilterError, type.GetBigInteger());
                     Assert.AreEqual("", response.GetString());
@@ -181,22 +181,22 @@ namespace Neo.UnitTests.SmartContract
             }
         }
 
-        private OracleResult Oracle(OracleRequest arg)
+        private OracleResponse Oracle(OracleRequest arg)
         {
             if (arg is OracleHttpsRequest https)
             {
                 if (https.Filter != "MyFilter")
                 {
-                    return OracleResult.CreateError(UInt256.Zero, UInt160.Zero, OracleResultError.FilterError);
+                    return OracleResponse.CreateError(UInt160.Zero, OracleResultError.FilterError);
                 }
 
                 if (https.URL.ToString() == "https://google.es/" && https.Method == HttpMethod.GET)
                 {
-                    return OracleResult.CreateResult(UInt256.Zero, UInt160.Zero, "MyResponse");
+                    return OracleResponse.CreateResult(UInt160.Zero, "MyResponse");
                 }
             }
 
-            return OracleResult.CreateError(UInt256.Zero, UInt160.Zero, OracleResultError.PolicyError);
+            return OracleResponse.CreateError(UInt160.Zero, OracleResultError.PolicyError);
         }
 
         [TestMethod]


### PR DESCRIPTION
- Renamed `OracleResult` to `OracleResponse`
- Removed transaction hash from the `OracleResponse`

While we discuss https://github.com/neo-project/neo/pull/1513 we can move the changes required for both options.