### PR TITLE
Make Nep6Wallet changed password effective

### DIFF
--- a/src/neo/Wallets/NEP6/NEP6Wallet.cs
+++ b/src/neo/Wallets/NEP6/NEP6Wallet.cs
@@ -322,6 +322,7 @@ namespace Neo.Wallets.NEP6
                     account.ChangePasswordCommit();
                 if (password != null)
                     password = password_new;
+                Save();
             }
             else
             {


### PR DESCRIPTION
This commit is to fix the problem that Nep6Wallet's changed password won't take effect.
I tried with latest neo repo which includes changing password strategy for Nep6Wallet, but it doesn't seem to take effect as changed password is not saved to wallet file.
![image](https://user-images.githubusercontent.com/43407364/78351093-d713b480-75d8-11ea-88c3-a69a2fe808dc.png)
