### PR TITLE
Oracle: Set the right Tx version

### DIFF
--- a/src/neo/Oracle/OracleResponse.cs
+++ b/src/neo/Oracle/OracleResponse.cs
@@ -3,16 +3,13 @@ using Neo.IO;
 using Neo.Network.P2P;
 using Neo.Network.P2P.Payloads;
 using Neo.Persistence;
-using Neo.SmartContract;
-using Neo.VM;
-using Neo.VM.Types;
 using System;
 using System.IO;
 using System.Text;
 
 namespace Neo.Oracle
 {
-    public class OracleResponse : IInteroperable, IVerifiable
+    public class OracleResponse : IVerifiable
     {
         private UInt160 _hash;
 
@@ -152,19 +149,6 @@ namespace Neo.Oracle
         public UInt160[] GetScriptHashesForVerifying(StoreView snapshot)
         {
             return new UInt160[] { new UInt160(Crypto.Hash160(this.GetHashData())) };
-        }
-
-        /// <summary>
-        /// Get Stack item for IInteroperable
-        /// </summary>
-        /// <returns>StackItem</returns>
-        public StackItem ToStackItem(ReferenceCounter referenceCounter)
-        {
-            return new VM.Types.Array(referenceCounter, new StackItem[]
-            {
-                new ByteString(RequestHash.ToArray()),
-                Result != null ? new ByteString(Result) : StackItem.Null
-            });
         }
     }
 }

--- a/src/neo/SmartContract/InteropService.Oracle.cs
+++ b/src/neo/SmartContract/InteropService.Oracle.cs
@@ -108,7 +108,7 @@ namespace Neo.SmartContract
 
                 if (engine.OracleCache.TryGet(request, out var response))
                 {
-                    engine.Push(response.ToStackItem(engine.ReferenceCounter));
+                    engine.Push(response.Result ?? StackItem.Null);
                     return true;
                 }
 

--- a/src/neo/Wallets/Wallet.cs
+++ b/src/neo/Wallets/Wallet.cs
@@ -351,48 +351,55 @@ namespace Neo.Wallets
 
                     // Change the Transaction type because it's an oracle request
 
-                    if (oracleRequests.Count > 0 && oracle == OracleWalletBehaviour.OracleWithAssert)
+                    if (oracleRequests.Count > 0)
                     {
-                        // If we want the same result for accept the response, we need to create asserts at the begining of the script
-
-                        var assertScript = new ScriptBuilder();
-
-                        foreach (var oracleRequest in oracleRequests)
+                        if (oracle == OracleWalletBehaviour.OracleWithAssert)
                         {
-                            // Do the request in order to cache the result
+                            // If we want the same result for accept the response, we need to create asserts at the begining of the script
 
-                            if (oracleRequest is OracleHttpsRequest https)
+                            var assertScript = new ScriptBuilder();
+
+                            foreach (var oracleRequest in oracleRequests)
                             {
-                                assertScript.EmitSysCall(InteropService.Oracle.Neo_Oracle_Get, https.URL.ToString(), https.Filter?.ContractHash, https.Filter?.FilterMethod);
+                                // Do the request in order to cache the result
+
+                                if (oracleRequest is OracleHttpsRequest https)
+                                {
+                                    assertScript.EmitSysCall(InteropService.Oracle.Neo_Oracle_Get, https.URL.ToString(), https.Filter?.ContractHash, https.Filter?.FilterMethod);
+                                }
+                                else
+                                {
+                                    throw new NotImplementedException();
+                                }
                             }
-                            else
-                            {
-                                throw new NotImplementedException();
-                            }
+
+                            // Clear the stack
+
+                            assertScript.Emit(OpCode.CLEAR);
+
+                            // Check that the hash of the whole responses are exactly the same
+
+                            assertScript.EmitSysCall(InteropService.Oracle.Neo_Oracle_Hash);
+                            assertScript.EmitPush(oracleCache.Hash.ToArray());
+                            assertScript.Emit(OpCode.EQUAL);
+                            assertScript.Emit(OpCode.ASSERT);
+
+                            // Concat two scripts [OracleAsserts+Script]
+
+                            script = assertScript.ToArray().Concat(script).ToArray();
+                            oracle = OracleWalletBehaviour.OracleWithoutAssert;
+
+                            // We need to remove new oracle calls (OracleService.Process)
+
+                            oracleCache = new OracleExecutionCache(oracleCache.Responses);
+
+                            // We need to compute the gas again with the right script
+                            goto Start;
                         }
-
-                        // Clear the stack
-
-                        assertScript.Emit(OpCode.CLEAR);
-
-                        // Check that the hash of the whole responses are exactly the same
-
-                        assertScript.EmitSysCall(InteropService.Oracle.Neo_Oracle_Hash);
-                        assertScript.EmitPush(oracleCache.Hash.ToArray());
-                        assertScript.Emit(OpCode.EQUAL);
-                        assertScript.Emit(OpCode.ASSERT);
-
-                        // Concat two scripts [OracleAsserts+Script]
-
-                        script = assertScript.ToArray().Concat(script).ToArray();
-                        oracle = OracleWalletBehaviour.OracleWithoutAssert;
-
-                        // We need to remove new oracle calls (OracleService.Process)
-
-                        oracleCache = new OracleExecutionCache(oracleCache.Responses);
-
-                        // We need to compute the gas again with the right script
-                        goto Start;
+                        else
+                        {
+                            tx.Version = TransactionVersion.OracleRequest;
+                        }
                     }
                 }
 

--- a/src/neo/Wallets/Wallet.cs
+++ b/src/neo/Wallets/Wallet.cs
@@ -324,8 +324,7 @@ namespace Neo.Wallets
             {
                 Transaction tx = new Transaction
                 {
-                    Version = 0,
-                    //TODO: x.Version = TransactionType.Oracle; <- if oracleQueries.Count != 0
+                    Version = oracleCache?.Count > 0 ? TransactionVersion.OracleRequest : TransactionVersion.Transaction,
                     Nonce = (uint)rand.Next(),
                     Script = script,
                     Sender = account,

--- a/tests/neo.UnitTests/Oracle/UT_OracleExecutionCache.cs
+++ b/tests/neo.UnitTests/Oracle/UT_OracleExecutionCache.cs
@@ -78,7 +78,7 @@ namespace Neo.UnitTests.Oracle
 
             Assert.AreEqual(2, req.Counter);
             Assert.AreEqual(1, cache.Count);
-            Assert.AreEqual(OracleResultError.None, ret.Error);
+            Assert.IsFalse(ret.Error);
             CollectionAssert.AreEqual(new byte[] { 0x02, 0x00, 0x00, 0x00 }, ret.Result);
 
             // Test cached
@@ -87,7 +87,7 @@ namespace Neo.UnitTests.Oracle
 
             Assert.AreEqual(2, req.Counter);
             Assert.AreEqual(1, cache.Count);
-            Assert.AreEqual(OracleResultError.None, ret.Error);
+            Assert.IsFalse(ret.Error);
             CollectionAssert.AreEqual(new byte[] { 0x02, 0x00, 0x00, 0x00 }, ret.Result);
 
             // Check collection
@@ -95,7 +95,7 @@ namespace Neo.UnitTests.Oracle
             var array = cache.ToArray();
             Assert.AreEqual(1, array.Length);
             Assert.AreEqual(req.Hash, array[0].Key);
-            Assert.AreEqual(OracleResultError.None, array[0].Value.Error);
+            Assert.IsFalse(array[0].Value.Error);
             CollectionAssert.AreEqual(new byte[] { 0x02, 0x00, 0x00, 0x00 }, array[0].Value.Result);
         }
 
@@ -118,8 +118,8 @@ namespace Neo.UnitTests.Oracle
             var array = cache.ToArray();
             Assert.AreEqual(1, array.Length);
             Assert.AreEqual(initReq.Hash, array[0].Key);
-            Assert.AreEqual(OracleResultError.ServerError, array[0].Value.Error);
-            CollectionAssert.AreEqual(Array.Empty<byte>(), array[0].Value.Result);
+            Assert.IsTrue(array[0].Value.Error);
+            Assert.AreEqual(null, array[0].Value.Result);
 
             // Test without cache
 

--- a/tests/neo.UnitTests/Oracle/UT_OracleResponse.cs
+++ b/tests/neo.UnitTests/Oracle/UT_OracleResponse.cs
@@ -21,7 +21,7 @@ namespace Neo.UnitTests.Oracle
             Assert.AreNotEqual(requestA.Hash, requestB.Hash);
 
             requestB = CreateDefault();
-            requestB.Error = OracleResultError.FilterError;
+            requestB.Result = null;
             Assert.AreNotEqual(requestA.Hash, requestB.Hash);
         }
 
@@ -45,7 +45,6 @@ namespace Neo.UnitTests.Oracle
         {
             return new OracleResponse()
             {
-                Error = OracleResultError.None,
                 RequestHash = UInt160.Parse("0xff00ff00ff00ff00ff00ff00ff00ff00ff00ff01"),
                 Result = new byte[] { 0x01, 0x02, 0x03 }
             };

--- a/tests/neo.UnitTests/Oracle/UT_OracleService.cs
+++ b/tests/neo.UnitTests/Oracle/UT_OracleService.cs
@@ -255,10 +255,7 @@ namespace Neo.UnitTests.Oracle
                 byte[] script;
                 using (ScriptBuilder sb = new ScriptBuilder())
                 {
-                    // self-transfer of 1e-8 GAS
-                    System.Numerics.BigInteger value = (new BigDecimal(1, 8)).Value;
                     sb.EmitSysCall(InteropService.Oracle.Neo_Oracle_Get, $"https://127.0.0.1:{port}/ping", null, null);
-                    sb.Emit(OpCode.UNPACK);
                     script = sb.ToArray();
                 }
 

--- a/tests/neo.UnitTests/Oracle/UT_OracleService.cs
+++ b/tests/neo.UnitTests/Oracle/UT_OracleService.cs
@@ -276,6 +276,7 @@ namespace Neo.UnitTests.Oracle
 
                 Assert.IsNotNull(txWithout);
                 Assert.IsNull(txWithout.Witnesses);
+                Assert.AreEqual(TransactionVersion.OracleRequest, txWithout.Version);
 
                 // OracleWithoutAssert
 
@@ -283,6 +284,7 @@ namespace Neo.UnitTests.Oracle
 
                 Assert.IsNotNull(txWith);
                 Assert.IsNull(txWith.Witnesses);
+                Assert.AreEqual(TransactionVersion.OracleRequest, txWith.Version);
 
                 // Check that has more fee and the script is longer
 

--- a/tests/neo.UnitTests/Oracle/UT_OracleService.cs
+++ b/tests/neo.UnitTests/Oracle/UT_OracleService.cs
@@ -1,6 +1,5 @@
 using Akka.TestKit;
 using Akka.TestKit.Xunit2;
-using FluentAssertions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
@@ -195,7 +194,7 @@ namespace Neo.UnitTests.Oracle
             Assert.AreEqual(1, response.ExecutionResult.Count);
 
             var entry = response.ExecutionResult.First();
-            Assert.AreEqual(OracleResultError.None, entry.Value.Error);
+            Assert.IsFalse(entry.Value.Error);
             Assert.AreEqual("pong", Encoding.UTF8.GetString(entry.Value.Result));
             Assert.AreEqual(tx.Hash, response.UserTxHash);
 
@@ -317,8 +316,8 @@ namespace Neo.UnitTests.Oracle
 
             OracleService.HTTPSProtocol.TimeOut = TimeSpan.FromSeconds(5);
 
-            Assert.AreEqual(OracleResultError.Timeout, response.Error);
-            Assert.IsTrue(response.Result.Length == 0);
+            Assert.IsTrue(response.Error);
+            Assert.IsTrue(response.Result == null);
             Assert.AreEqual(request.Hash, response.RequestHash);
             Assert.AreNotEqual(UInt160.Zero, response.Hash);
 
@@ -332,7 +331,7 @@ namespace Neo.UnitTests.Oracle
 
             response = OracleService.Process(request);
 
-            Assert.AreEqual(OracleResultError.None, response.Error);
+            Assert.IsFalse(response.Error);
             Assert.AreEqual("pong", Encoding.UTF8.GetString(response.Result));
             Assert.AreEqual(request.Hash, response.RequestHash);
             Assert.AreNotEqual(UInt160.Zero, response.Hash);
@@ -347,8 +346,8 @@ namespace Neo.UnitTests.Oracle
 
             response = OracleService.Process(request);
 
-            Assert.AreEqual(OracleResultError.ResponseError, response.Error);
-            Assert.IsTrue(response.Result.Length == 0);
+            Assert.IsTrue(response.Error);
+            Assert.IsTrue(response.Result == null);
             Assert.AreEqual(request.Hash, response.RequestHash);
             Assert.AreNotEqual(UInt160.Zero, response.Hash);
 
@@ -357,8 +356,8 @@ namespace Neo.UnitTests.Oracle
             OracleService.HTTPSProtocol.AllowPrivateHost = false;
             response = OracleService.Process(request);
 
-            Assert.AreEqual(OracleResultError.PolicyError, response.Error);
-            Assert.IsTrue(response.Result.Length == 0);
+            Assert.IsTrue(response.Error);
+            Assert.IsTrue(response.Result == null);
             Assert.AreEqual(request.Hash, response.RequestHash);
             Assert.AreNotEqual(UInt160.Zero, response.Hash);
         }
@@ -375,10 +374,10 @@ namespace Neo.UnitTests.Oracle
             var request = new ErrorRequest();
             var response = OracleService.Process(request);
 
-            Assert.AreEqual(OracleResultError.ProtocolError, response.Error);
-            CollectionAssert.AreEqual(new byte[0], response.Result);
+            Assert.IsTrue(response.Error);
+            Assert.AreEqual(null, response.Result);
             Assert.AreEqual(request.Hash, response.RequestHash);
-            Assert.AreEqual("0x6d53b08489400de6e2d3bf0edfd1385e14dbde68", response.Hash.ToString());
+            Assert.AreEqual("0xe62b56e4b43b01411403058ba53fc5e6dbdf8fba", response.Hash.ToString());
         }
     }
 }

--- a/tests/neo.UnitTests/SmartContract/UT_Syscalls.cs
+++ b/tests/neo.UnitTests/SmartContract/UT_Syscalls.cs
@@ -131,10 +131,8 @@ namespace Neo.UnitTests.SmartContract
 
                     Assert.IsTrue(engine.ResultStack.TryPop<VM.Types.Array>(out var array));
 
-                    var type = array[1] as PrimitiveType;
-                    var response = array[2] as ByteString;
-
-                    Assert.AreEqual((int)OracleResultError.None, type.GetBigInteger());
+                    Assert.IsTrue(array[1] is ByteString);
+                    var response = array[1] as ByteString;
                     Assert.AreEqual("MyResponse", response.GetString());
                 }
             }
@@ -156,12 +154,7 @@ namespace Neo.UnitTests.SmartContract
                     Assert.AreEqual(1, engine.ResultStack.Count);
 
                     Assert.IsTrue(engine.ResultStack.TryPop<VM.Types.Array>(out var array));
-
-                    var type = array[1] as PrimitiveType;
-                    var response = array[2] as ByteString;
-
-                    Assert.AreEqual((int)OracleResultError.FilterError, type.GetBigInteger());
-                    Assert.AreEqual("", response.GetString());
+                    Assert.IsTrue(array[1] is Null);
                 }
             }
 

--- a/tests/neo.UnitTests/SmartContract/UT_Syscalls.cs
+++ b/tests/neo.UnitTests/SmartContract/UT_Syscalls.cs
@@ -129,10 +129,7 @@ namespace Neo.UnitTests.SmartContract
                     Assert.AreEqual(engine.Execute(), VMState.HALT);
                     Assert.AreEqual(1, engine.ResultStack.Count);
 
-                    Assert.IsTrue(engine.ResultStack.TryPop<VM.Types.Array>(out var array));
-
-                    Assert.IsTrue(array[1] is ByteString);
-                    var response = array[1] as ByteString;
+                    Assert.IsTrue(engine.ResultStack.TryPop<ByteString>(out var response));
                     Assert.AreEqual("MyResponse", response.GetString());
                 }
             }
@@ -153,8 +150,7 @@ namespace Neo.UnitTests.SmartContract
                     Assert.AreEqual(engine.Execute(), VMState.HALT);
                     Assert.AreEqual(1, engine.ResultStack.Count);
 
-                    Assert.IsTrue(engine.ResultStack.TryPop<VM.Types.Array>(out var array));
-                    Assert.IsTrue(array[1] is Null);
+                    Assert.IsTrue(engine.ResultStack.TryPop<Null>(out var isNull));
                 }
             }
 


### PR DESCRIPTION
- Assign the right version when we create a new TX
- The type of error in the response was also eliminated, we should log it, but not hash or retransmit it to reduce indeterminism