### PR TITLE
[neox-2.x]rm value limit

### DIFF
--- a/neo.UnitTests/UT_MPTTrie.cs
+++ b/neo.UnitTests/UT_MPTTrie.cs
@@ -158,8 +158,8 @@ namespace Neo.UnitTests.Trie.MPT
             b.Children[9] = l2;
 
             r1.Next = v1;
-            Assert.AreEqual("0xe2c39220dcd0503e89bd8865d07b905132a1ff8f6065185f46063280b7f394ce", r1.GetHash().ToString());
-            Assert.AreEqual("0x8bd128c986167bb193071111d3dd797ff87b72b3f64bbc4fae22e569be64dccd", r.GetHash().ToString());
+            Assert.AreEqual("0xdea3ab46e9461e885ed7091c1e533e0a8030b248d39cbc638962394eaca0fbb3", r1.GetHash().ToString());
+            Assert.AreEqual("0x93e8e1ffe2f83dd92fca67330e273bcc811bf64b8f8d9d1b25d5e7366b47d60d", r.GetHash().ToString());
 
             var mpt = new MPTTrie(rootHash, mptdb);
             var result = true;
@@ -169,7 +169,7 @@ namespace Neo.UnitTests.Trie.MPT
             Assert.IsTrue(result);
             result = mpt.TryDelete("acae".HexToBytes());
             Assert.IsTrue(result);
-            Assert.AreEqual("0xe2c39220dcd0503e89bd8865d07b905132a1ff8f6065185f46063280b7f394ce", mpt.GetRoot().ToString());
+            Assert.AreEqual("0xdea3ab46e9461e885ed7091c1e533e0a8030b248d39cbc638962394eaca0fbb3", mpt.GetRoot().ToString());
         }
 
         [TestMethod]

--- a/neo.UnitTests/UT_MPTTrie.cs
+++ b/neo.UnitTests/UT_MPTTrie.cs
@@ -158,8 +158,8 @@ namespace Neo.UnitTests.Trie.MPT
             b.Children[9] = l2;
 
             r1.Next = v1;
-            Assert.AreEqual("0xdea3ab46e9461e885ed7091c1e533e0a8030b248d39cbc638962394eaca0fbb3", r1.GetHash().ToString());
-            Assert.AreEqual("0x93e8e1ffe2f83dd92fca67330e273bcc811bf64b8f8d9d1b25d5e7366b47d60d", r.GetHash().ToString());
+            Assert.AreEqual("0xe2c39220dcd0503e89bd8865d07b905132a1ff8f6065185f46063280b7f394ce", r1.GetHash().ToString());
+            Assert.AreEqual("0x8bd128c986167bb193071111d3dd797ff87b72b3f64bbc4fae22e569be64dccd", r.GetHash().ToString());
 
             var mpt = new MPTTrie(rootHash, mptdb);
             var result = true;
@@ -169,7 +169,7 @@ namespace Neo.UnitTests.Trie.MPT
             Assert.IsTrue(result);
             result = mpt.TryDelete("acae".HexToBytes());
             Assert.IsTrue(result);
-            Assert.AreEqual("0xdea3ab46e9461e885ed7091c1e533e0a8030b248d39cbc638962394eaca0fbb3", mpt.GetRoot().ToString());
+            Assert.AreEqual("0xe2c39220dcd0503e89bd8865d07b905132a1ff8f6065185f46063280b7f394ce", mpt.GetRoot().ToString());
         }
 
         [TestMethod]

--- a/neo/Trie/MPT/MPTNode/LeafNode.cs
+++ b/neo/Trie/MPT/MPTNode/LeafNode.cs
@@ -22,12 +22,12 @@ namespace Neo.Trie.MPT
 
         public override void EncodeSpecific(BinaryWriter writer)
         {
-            writer.WriteVarBytes(Value);
+            writer.WriteBytesWithGrouping(Value);
         }
 
         public override void DecodeSpecific(BinaryReader reader)
         {
-            Value = reader.ReadVarBytes(ushort.MaxValue);
+            Value = reader.ReadBytesWithGrouping();
         }
 
         public override JObject ToJson()

--- a/neo/Trie/MPT/MPTNode/LeafNode.cs
+++ b/neo/Trie/MPT/MPTNode/LeafNode.cs
@@ -1,4 +1,3 @@
-using Neo.Cryptography;
 using Neo.IO;
 using Neo.IO.Json;
 using System.IO;
@@ -7,6 +6,7 @@ namespace Neo.Trie.MPT
 {
     public class LeafNode : MPTNode
     {
+        public const int MaxValueLength = 1024 * 1024;
         public byte[] Value;
 
         public LeafNode()
@@ -22,12 +22,12 @@ namespace Neo.Trie.MPT
 
         public override void EncodeSpecific(BinaryWriter writer)
         {
-            writer.WriteBytesWithGrouping(Value);
+            writer.WriteVarBytes(Value);
         }
 
         public override void DecodeSpecific(BinaryReader reader)
         {
-            Value = reader.ReadBytesWithGrouping();
+            Value = reader.ReadVarBytes(MaxValueLength);
         }
 
         public override JObject ToJson()

--- a/neo/Trie/MPT/MPTTrie.cs
+++ b/neo/Trie/MPT/MPTTrie.cs
@@ -1,5 +1,4 @@
 using Neo.IO.Json;
-using Neo;
 using System;
 using System.Collections.Generic;
 
@@ -18,7 +17,9 @@ namespace Neo.Trie.MPT
         public bool Put(byte[] key, byte[] value)
         {
             if (key.Length > ExtensionNode.MaxKeyLength)
-                throw new System.ArgumentOutOfRangeException("key out of mpt limit");
+                throw new ArgumentOutOfRangeException("key out of mpt limit");
+            if (value.Length > LeafNode.MaxValueLength)
+                throw new ArgumentOutOfRangeException("value out of mpt limit");
             var path = key.ToNibbles();
             if (value.Length == 0)
             {
@@ -32,7 +33,7 @@ namespace Neo.Trie.MPT
         {
             switch (node)
             {
-                case LeafNode leafNode:
+                case LeafNode _:
                     {
                         if (path.Length == 0 && val is LeafNode v)
                         {
@@ -93,7 +94,7 @@ namespace Neo.Trie.MPT
                     }
                 case BranchNode branchNode:
                     {
-                        var result = false;
+                        bool result;
                         if (path.Length == 0)
                         {
                             result = Put(ref branchNode.Children[BranchNode.ChildCount - 1], path, val);
@@ -143,7 +144,7 @@ namespace Neo.Trie.MPT
         {
             switch (node)
             {
-                case LeafNode leafNode:
+                case LeafNode _:
                     {
                         if (path.Length == 0)
                         {
@@ -176,7 +177,7 @@ namespace Neo.Trie.MPT
                     }
                 case BranchNode branchNode:
                     {
-                        var result = false;
+                        bool result;
                         if (path.Length == 0)
                         {
                             result = TryDelete(ref branchNode.Children[BranchNode.ChildCount - 1], path);


### PR DESCRIPTION
We should remove the `ValueNode` serialize and deserialize length limitation.
Because we have no limitation for `Storage` value.
