### PR TITLE
Change consensus timespan strategy

### DIFF
--- a/src/neo/Consensus/ConsensusService.cs
+++ b/src/neo/Consensus/ConsensusService.cs
@@ -177,10 +177,11 @@ namespace Neo.Consensus
                 }
                 else
                 {
-                    //Too long (if changeview happens during consensus) or too short (which will occur during synchronization) consensus period will be filtered. Only normal consensus should be taken into account.
+                    // Too long (if changeview happens during consensus) or too short (which will occur during synchronization)
+                    // consensus period will be filtered. Only normal consensus should be taken into account.
                     if (block_received_gap > Blockchain.TimePerBlock / 3 && block_received_gap < Blockchain.TimePerBlock * 2)
                     {
-                        //Renew time per block by last consensus period
+                        // Renew time per block by last consensus period.
                         block_span = (8 * block_span + 3 * (2 * Blockchain.TimePerBlock - block_received_gap)) / 11.0;
                     }
                     TimeSpan span = TimeProvider.Current.UtcNow - block_received_time;

--- a/src/neo/Consensus/ConsensusService.cs
+++ b/src/neo/Consensus/ConsensusService.cs
@@ -319,11 +319,11 @@ namespace Neo.Consensus
         private void OnPersistCompleted(Block block)
         {
             Log($"persist block: height={block.Index} hash={block.Hash} tx={block.Transactions.Length}");
+            knownHashes.Clear();
+            InitializeConsensus(0);
             DateTime now = TimeProvider.Current.UtcNow;
             block_received_gap = now - block_received_time;
             block_received_time = now;
-            knownHashes.Clear();
-            InitializeConsensus(0);
         }
 
         private void OnRecoveryMessageReceived(ConsensusPayload payload, RecoveryMessage message)

--- a/src/neo/Consensus/ConsensusService.cs
+++ b/src/neo/Consensus/ConsensusService.cs
@@ -177,7 +177,7 @@ namespace Neo.Consensus
                 }
                 else
                 {
-                    // Too long (if changeview happens during consensus) or too short (which will occur during synchronization)
+                    // Too long (if changeview happens during consensus) or too short (which will occur during synchronization) 
                     // consensus period will be filtered. Only normal consensus should be taken into account.
                     if (block_received_gap > Blockchain.TimePerBlock / 3 && block_received_gap < Blockchain.TimePerBlock * 2)
                     {

--- a/src/neo/Consensus/ConsensusService.cs
+++ b/src/neo/Consensus/ConsensusService.cs
@@ -182,7 +182,8 @@ namespace Neo.Consensus
                     if (block_received_gap > Blockchain.TimePerBlock / 3 && block_received_gap < Blockchain.TimePerBlock * 2)
                     {
                         // Renew time per block by last consensus period.
-                        block_span = (8 * block_span + 3 * (2 * Blockchain.TimePerBlock - block_received_gap)) / 11.0;
+                        block_span = block_span + 3 * (Blockchain.TimePerBlock - block_received_gap) / 11.0;
+                        if (block_span < TimeSpan.Zero) block_span = TimeSpan.Zero;
                     }
                     TimeSpan span = TimeProvider.Current.UtcNow - block_received_time;
                     if (span >= block_span)

--- a/src/neo/Consensus/ConsensusService.cs
+++ b/src/neo/Consensus/ConsensusService.cs
@@ -319,11 +319,9 @@ namespace Neo.Consensus
         private void OnPersistCompleted(Block block)
         {
             Log($"persist block: height={block.Index} hash={block.Hash} tx={block.Transactions.Length}");
+            block_received_time = TimeProvider.Current.UtcNow;
             knownHashes.Clear();
             InitializeConsensus(0);
-            DateTime now = TimeProvider.Current.UtcNow;
-            block_received_gap = now - block_received_time;
-            block_received_time = now;
         }
 
         private void OnRecoveryMessageReceived(ConsensusPayload payload, RecoveryMessage message)

--- a/src/neo/Consensus/ConsensusService.cs
+++ b/src/neo/Consensus/ConsensusService.cs
@@ -177,8 +177,10 @@ namespace Neo.Consensus
                 }
                 else
                 {
+                    //Too long (if changeview happens during consensus) or too short (which will occur during synchronization) consensus period will be filtered. Only normal consensus should be taken into account.
                     if (block_received_gap > Blockchain.TimePerBlock / 3 && block_received_gap < Blockchain.TimePerBlock * 2)
                     {
+                        //Renew time per block by last consensus period
                         block_span = (8 * block_span + 3 * (2 * Blockchain.TimePerBlock - block_received_gap)) / 11.0;
                     }
                     TimeSpan span = TimeProvider.Current.UtcNow - block_received_time;

--- a/src/neo/Consensus/ConsensusService.cs
+++ b/src/neo/Consensus/ConsensusService.cs
@@ -319,7 +319,9 @@ namespace Neo.Consensus
         private void OnPersistCompleted(Block block)
         {
             Log($"persist block: height={block.Index} hash={block.Hash} tx={block.Transactions.Length}");
-            block_received_time = TimeProvider.Current.UtcNow;
+            DateTime now = TimeProvider.Current.UtcNow;
+            block_received_gap = now - block_received_time;
+            block_received_time = now;
             knownHashes.Clear();
             InitializeConsensus(0);
         }


### PR DESCRIPTION
This PR aims to provide agiler as well as smooth block time span strategy.
Block time span will be adjusted automatically according to the time consumed in last consensus.