### PR TITLE
[neox-2.x] version type

### DIFF
--- a/neo/Trie/MPT/MPTTrie.cs
+++ b/neo/Trie/MPT/MPTTrie.cs
@@ -6,7 +6,7 @@ namespace Neo.Trie.MPT
 {
     public class MPTTrie : MPTReadOnlyTrie
     {
-        public static uint Version = 0;
+        public static byte Version = 0;
         private readonly MPTDb db;
 
         public MPTTrie(UInt256 root, IKVStore store) : base(root, store)


### PR DESCRIPTION
### Improve

change version type to `byte`

@shargon I think we all agree on this.