### PR TITLE
[neox-2.x] fix mpt add longer key

### DIFF
--- a/neo.UnitTests/UT_MPTTrie.cs
+++ b/neo.UnitTests/UT_MPTTrie.cs
@@ -262,5 +262,16 @@ namespace Neo.UnitTests.Trie.MPT
             result = MPTTrie.VerifyProof(rootHash, "ac01".HexToBytes(), proof, out byte[] value);
             Assert.IsTrue(result);
         }
+
+        [TestMethod]
+        public void TestAddLongerKey()
+        {
+            var store = new MemoryStore();
+            var mpt = new MPTTrie(null, store);
+            var result = mpt.Put(new byte[] { 0xab }, new byte[] { 0x01 });
+            Assert.IsTrue(result);
+            result = mpt.Put(new byte[] { 0xab, 0xcd }, new byte[] { 0x02 });
+            Assert.IsTrue(result);
+        }
     }
 }

--- a/neo/Trie/MPT/MPTNode/HashNode.cs
+++ b/neo/Trie/MPT/MPTNode/HashNode.cs
@@ -56,7 +56,10 @@ namespace Neo.Trie.MPT
         public override JObject ToJson()
         {
             var json = new JObject();
-            json["hash"] = Hash.ToString();
+            if (!this.IsEmptyNode)
+            {
+                json["hash"] = Hash.ToString();
+            }
             return json;
         }
     }

--- a/neo/Trie/MPT/MPTTrie.cs
+++ b/neo/Trie/MPT/MPTTrie.cs
@@ -33,12 +33,21 @@ namespace Neo.Trie.MPT
         {
             switch (node)
             {
-                case LeafNode _:
+                case LeafNode leafNode:
                     {
-                        if (path.Length == 0 && val is LeafNode v)
+                        if (val is LeafNode v)
                         {
-                            node = v;
-                            db.Put(node);
+                            if (path.Length == 0)
+                            {
+                                node = v;
+                                db.Put(node);
+                                return true;
+                            }
+                            var branch = new BranchNode();
+                            branch.Children[BranchNode.ChildCount - 1] = leafNode;
+                            Put(ref branch.Children[path[0]], path.Skip(1), v);
+                            db.Put(branch);
+                            node = branch;
                             return true;
                         }
                         return false;


### PR DESCRIPTION
  scenario is this:
1. if we had saved `path:0a0b` `value:v1` like this;
![image](https://user-images.githubusercontent.com/22324403/80186594-d0f57e80-8640-11ea-872b-36a62f480bb6.png)
2. Then if we  want to save a longer key with prefix `0a0b`, like `path:0a0b050a` `value: v2`.
![image](https://user-images.githubusercontent.com/22324403/80186785-22057280-8641-11ea-80ed-9aba66948514.png)
 
Before this fix, it will return false.