### PR TITLE
[neox-2.x] fix empty extension node key

### DIFF
--- a/neo.UnitTests/UT_MPTTrie.cs
+++ b/neo.UnitTests/UT_MPTTrie.cs
@@ -273,5 +273,22 @@ namespace Neo.UnitTests.Trie.MPT
             result = mpt.Put(new byte[] { 0xab, 0xcd }, new byte[] { 0x02 });
             Assert.IsTrue(result);
         }
+
+        [TestMethod]
+        public void TestSplitKey()
+        {
+            var store = new MemoryStore();
+            var mpt1 = new MPTTrie(null, store);
+            Assert.IsTrue(mpt1.Put(new byte[] { 0xab, 0xcd }, new byte[] { 0x01 }));
+            Assert.IsTrue(mpt1.Put(new byte[] { 0xab }, new byte[] { 0x02 }));
+            Assert.IsTrue(mpt1.GetProof(new byte[] { 0xab, 0xcd }, out HashSet<byte[]> set1));
+            Assert.AreEqual(4, set1.Count);
+            var mpt2 = new MPTTrie(null, store);
+            Assert.IsTrue(mpt2.Put(new byte[] { 0xab }, new byte[] { 0x02 }));
+            Assert.IsTrue(mpt2.Put(new byte[] { 0xab, 0xcd }, new byte[] { 0x01 }));
+            Assert.IsTrue(mpt2.GetProof(new byte[] { 0xab, 0xcd }, out HashSet<byte[]> set2));
+            Assert.AreEqual(4, set2.Count);
+            Assert.AreEqual(mpt1.GetRoot(), mpt2.GetRoot());
+        }
     }
 }

--- a/neo/Trie/MPT/MPTTrie.cs
+++ b/neo/Trie/MPT/MPTTrie.cs
@@ -121,21 +121,29 @@ namespace Neo.Trie.MPT
                     }
                 case HashNode hashNode:
                     {
+                        MPTNode newNode;
                         if (hashNode.IsEmptyNode)
                         {
-                            var exNode = new ExtensionNode()
+                            if (path.Length == 0)
                             {
-                                Key = path,
-                                Next = val,
-                            };
-                            node = exNode;
-                            if (!(val is HashNode)) db.Put(val);
-                            db.Put(exNode);
+                                newNode = val;
+                            }
+                            else
+                            {
+                                newNode = new ExtensionNode()
+                                {
+                                    Key = path,
+                                    Next = val,
+                                };
+                                db.Put(newNode);
+                            }
+                            node = newNode;
+                            if (val is LeafNode) db.Put(val);
                             return true;
                         }
-                        var new_node = Resolve(hashNode);
-                        if (new_node is null) return false;
-                        node = new_node;
+                        newNode = Resolve(hashNode);
+                        if (newNode is null) return false;
+                        node = newNode;
                         return Put(ref node, path, val);
                     }
                 default:


### PR DESCRIPTION
Avoid `ExtensionNode` with empty key.
Didn't check `path.Length` before.

Already apply to neo3 pr #1442  https://github.com/neo-project/neo/pull/1442/commits/9a5ad98c97befaaf192cadfe210b903f35aec6cb