### PR TITLE
Update neo-vm package

### DIFF
--- a/src/neo/neo.csproj
+++ b/src/neo/neo.csproj
@@ -21,12 +21,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Akka" Version="1.4.2" />
+    <PackageReference Include="Akka" Version="1.4.5" />
     <PackageReference Include="K4os.Compression.LZ4" Version="1.1.11" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.WebSockets" Version="2.2.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.3" />
     <PackageReference Include="Neo.VM" Version="3.0.0-CI00219" />
   </ItemGroup>
 

--- a/src/neo/neo.csproj
+++ b/src/neo/neo.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="Microsoft.AspNetCore.WebSockets" Version="2.2.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.0.1" />
-    <PackageReference Include="Neo.VM" Version="3.0.0-CI00218" />
+    <PackageReference Include="Neo.VM" Version="3.0.0-CI00219" />
   </ItemGroup>
 
 </Project>

--- a/tests/neo.UnitTests/neo.UnitTests.csproj
+++ b/tests/neo.UnitTests/neo.UnitTests.csproj
@@ -15,13 +15,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.9.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
-    <PackageReference Include="Moq" Version="4.13.1" />
-    <PackageReference Include="Akka.TestKit" Version="1.4.2" />
-    <PackageReference Include="Akka.TestKit.Xunit2" Version="1.4.2" />
+    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.1.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.1.1" />
+    <PackageReference Include="Moq" Version="4.14.1" />
+    <PackageReference Include="Akka.TestKit" Version="1.4.5" />
+    <PackageReference Include="Akka.TestKit.Xunit2" Version="1.4.5" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR only aim to update the neo-vm with the last patch (https://github.com/neo-project/neo-vm/pull/317).

It's required for https://github.com/neo-project/neo-devpack-dotnet/pull/262