### PR TITLE
Remove FromJson

### DIFF
--- a/src/neo/Network/P2P/Payloads/Block.cs
+++ b/src/neo/Network/P2P/Payloads/Block.cs
@@ -113,16 +113,6 @@ namespace Neo.Network.P2P.Payloads
             return json;
         }
 
-        public new static Block FromJson(JObject json)
-        {
-            Block block = new Block();
-            BlockBase blockBase = block;
-            blockBase.FromJson(json);
-            block.ConsensusData = ConsensusData.FromJson(json["consensus_data"]);
-            block.Transactions = ((JArray)json["tx"]).Select(p => Transaction.FromJson(p)).ToArray();
-            return block;
-        }
-
         public TrimmedBlock Trim()
         {
             return new TrimmedBlock

--- a/src/neo/Network/P2P/Payloads/BlockBase.cs
+++ b/src/neo/Network/P2P/Payloads/BlockBase.cs
@@ -6,7 +6,6 @@ using Neo.SmartContract;
 using Neo.Wallets;
 using System;
 using System.IO;
-using System.Linq;
 
 namespace Neo.Network.P2P.Payloads
 {
@@ -111,17 +110,6 @@ namespace Neo.Network.P2P.Payloads
             json["nextconsensus"] = NextConsensus.ToAddress();
             json["witnesses"] = new JArray(Witness.ToJson());
             return json;
-        }
-
-        public void FromJson(JObject json)
-        {
-            Version = (uint)json["version"].AsNumber();
-            PrevHash = UInt256.Parse(json["previousblockhash"].AsString());
-            MerkleRoot = UInt256.Parse(json["merkleroot"].AsString());
-            Timestamp = (ulong)json["time"].AsNumber();
-            Index = (uint)json["index"].AsNumber();
-            NextConsensus = json["nextconsensus"].AsString().ToScriptHash();
-            Witness = ((JArray)json["witnesses"]).Select(p => Witness.FromJson(p)).FirstOrDefault();
         }
 
         public virtual bool Verify(StoreView snapshot)

--- a/src/neo/Network/P2P/Payloads/ConsensusData.cs
+++ b/src/neo/Network/P2P/Payloads/ConsensusData.cs
@@ -2,7 +2,6 @@ using Neo.Cryptography;
 using Neo.IO;
 using Neo.IO.Json;
 using Neo.Ledger;
-using System.Globalization;
 using System.IO;
 
 namespace Neo.Network.P2P.Payloads
@@ -46,14 +45,5 @@ namespace Neo.Network.P2P.Payloads
             json["nonce"] = Nonce.ToString("x16");
             return json;
         }
-
-        public static ConsensusData FromJson(JObject json)
-        {
-            ConsensusData block = new ConsensusData();
-            block.PrimaryIndex = (uint)json["primary"].AsNumber();
-            block.Nonce = ulong.Parse(json["nonce"].AsString(), NumberStyles.HexNumber);
-            return block;
-        }
-
     }
 }

--- a/src/neo/Network/P2P/Payloads/Cosigner.cs
+++ b/src/neo/Network/P2P/Payloads/Cosigner.cs
@@ -1,7 +1,6 @@
 using Neo.Cryptography.ECC;
 using Neo.IO;
 using Neo.IO.Json;
-using System;
 using System.IO;
 using System.Linq;
 
@@ -60,17 +59,6 @@ namespace Neo.Network.P2P.Payloads
             if (Scopes.HasFlag(WitnessScope.CustomGroups))
                 json["allowedGroups"] = AllowedGroups.Select(p => (JObject)p.ToString()).ToArray();
             return json;
-        }
-
-        public static Cosigner FromJson(JObject json)
-        {
-            return new Cosigner
-            {
-                Account = UInt160.Parse(json["account"].AsString()),
-                Scopes = (WitnessScope)Enum.Parse(typeof(WitnessScope), json["scopes"].AsString()),
-                AllowedContracts = ((JArray)json["allowedContracts"])?.Select(p => UInt160.Parse(p.AsString())).ToArray(),
-                AllowedGroups = ((JArray)json["allowedGroups"])?.Select(p => ECPoint.Parse(p.AsString(), ECCurve.Secp256r1)).ToArray()
-            };
         }
     }
 }

--- a/src/neo/Network/P2P/Payloads/Header.cs
+++ b/src/neo/Network/P2P/Payloads/Header.cs
@@ -1,4 +1,3 @@
-using Neo.IO.Json;
 using Neo.Ledger;
 using System;
 using System.IO;
@@ -52,14 +51,5 @@ namespace Neo.Network.P2P.Payloads
                 Hashes = new UInt256[0]
             };
         }
-
-        public new static Header FromJson(JObject json)
-        {
-            Header header = new Header();
-            BlockBase blockBase = header;
-            blockBase.FromJson(json);
-            return header;
-        }
-
     }
 }

--- a/src/neo/Network/P2P/Payloads/Transaction.cs
+++ b/src/neo/Network/P2P/Payloads/Transaction.cs
@@ -249,22 +249,6 @@ namespace Neo.Network.P2P.Payloads
             return json;
         }
 
-        public static Transaction FromJson(JObject json)
-        {
-            Transaction tx = new Transaction();
-            tx.Version = byte.Parse(json["version"].AsString());
-            tx.Nonce = uint.Parse(json["nonce"].AsString());
-            tx.Sender = json["sender"].AsString().ToScriptHash();
-            tx.SystemFee = long.Parse(json["sys_fee"].AsString());
-            tx.NetworkFee = long.Parse(json["net_fee"].AsString());
-            tx.ValidUntilBlock = uint.Parse(json["valid_until_block"].AsString());
-            tx.Attributes = ((JArray)json["attributes"]).Select(p => TransactionAttribute.FromJson(p)).ToArray();
-            tx.Cosigners = ((JArray)json["cosigners"]).Select(p => Cosigner.FromJson(p)).ToArray();
-            tx.Script = Convert.FromBase64String(json["script"].AsString());
-            tx.Witnesses = ((JArray)json["witnesses"]).Select(p => Witness.FromJson(p)).ToArray();
-            return tx;
-        }
-
         bool IInventory.Verify(StoreView snapshot)
         {
             return Verify(snapshot, BigInteger.Zero) == VerifyResult.Succeed;

--- a/src/neo/Network/P2P/Payloads/TransactionAttribute.cs
+++ b/src/neo/Network/P2P/Payloads/TransactionAttribute.cs
@@ -33,15 +33,5 @@ namespace Neo.Network.P2P.Payloads
             json["data"] = Convert.ToBase64String(Data);
             return json;
         }
-
-        public static TransactionAttribute FromJson(JObject json)
-        {
-            TransactionAttribute transactionAttribute = new TransactionAttribute();
-            transactionAttribute.Usage = (TransactionAttributeUsage)byte.Parse(json["usage"].AsString());
-            if (!Enum.IsDefined(typeof(TransactionAttributeUsage), transactionAttribute.Usage))
-                throw new ArgumentException();
-            transactionAttribute.Data = Convert.FromBase64String(json["data"].AsString());
-            return transactionAttribute;
-        }
     }
 }

--- a/src/neo/Network/P2P/Payloads/Witness.cs
+++ b/src/neo/Network/P2P/Payloads/Witness.cs
@@ -48,13 +48,5 @@ namespace Neo.Network.P2P.Payloads
             json["verification"] = Convert.ToBase64String(VerificationScript);
             return json;
         }
-
-        public static Witness FromJson(JObject json)
-        {
-            Witness witness = new Witness();
-            witness.InvocationScript = Convert.FromBase64String(json["invocation"].AsString());
-            witness.VerificationScript = Convert.FromBase64String(json["verification"].AsString());
-            return witness;
-        }
     }
 }

--- a/tests/neo.UnitTests/Network/P2P/Payloads/UT_Cosigner.cs
+++ b/tests/neo.UnitTests/Network/P2P/Payloads/UT_Cosigner.cs
@@ -2,7 +2,6 @@ using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Neo.Cryptography.ECC;
 using Neo.IO;
-using Neo.IO.Json;
 using Neo.Network.P2P.Payloads;
 
 namespace Neo.UnitTests.Network.P2P.Payloads
@@ -97,11 +96,6 @@ namespace Neo.UnitTests.Network.P2P.Payloads
 
             var json = "{\"account\":\"0x0000000000000000000000000000000000000000\",\"scopes\":\"Global\"}";
             attr.ToJson().ToString().Should().Be(json);
-
-            var copy = Cosigner.FromJson(JObject.Parse(json));
-
-            Assert.AreEqual(attr.Scopes, copy.Scopes);
-            Assert.AreEqual(attr.Account, copy.Account);
         }
 
         [TestMethod]
@@ -115,11 +109,6 @@ namespace Neo.UnitTests.Network.P2P.Payloads
 
             var json = "{\"account\":\"0x0000000000000000000000000000000000000000\",\"scopes\":\"CalledByEntry\"}";
             attr.ToJson().ToString().Should().Be(json);
-
-            var copy = Cosigner.FromJson(JObject.Parse(json));
-
-            Assert.AreEqual(attr.Scopes, copy.Scopes);
-            Assert.AreEqual(attr.Account, copy.Account);
         }
 
         [TestMethod]
@@ -134,12 +123,6 @@ namespace Neo.UnitTests.Network.P2P.Payloads
 
             var json = "{\"account\":\"0x0000000000000000000000000000000000000000\",\"scopes\":\"CustomContracts\",\"allowedContracts\":[\"0x0000000000000000000000000000000000000000\"]}";
             attr.ToJson().ToString().Should().Be(json);
-
-            var copy = Cosigner.FromJson(JObject.Parse(json));
-
-            Assert.AreEqual(attr.Scopes, copy.Scopes);
-            CollectionAssert.AreEqual(attr.AllowedContracts, copy.AllowedContracts);
-            Assert.AreEqual(attr.Account, copy.Account);
         }
 
         [TestMethod]
@@ -154,12 +137,6 @@ namespace Neo.UnitTests.Network.P2P.Payloads
 
             var json = "{\"account\":\"0x0000000000000000000000000000000000000000\",\"scopes\":\"CustomGroups\",\"allowedGroups\":[\"03b209fd4f53a7170ea4444e0cb0a6bb6a53c2bd016926989cf85f9b0fba17a70c\"]}";
             attr.ToJson().ToString().Should().Be(json);
-
-            var copy = Cosigner.FromJson(JObject.Parse(json));
-
-            Assert.AreEqual(attr.Scopes, copy.Scopes);
-            CollectionAssert.AreEqual(attr.AllowedGroups, copy.AllowedGroups);
-            Assert.AreEqual(attr.Account, copy.Account);
         }
     }
 }


### PR DESCRIPTION
Remove `FromJson()` from the following classes:

- Block
- BlockBase
- ConsensusData
- Cosigner
- Header
- Transaction
- TransactionAttribute
- Witness

We don't need them in core. Currently they are only used in RpcClient. Maybe we should move them.