### PR TITLE
Enhance StorageItem.Deserialize

### DIFF
--- a/src/neo/Ledger/StorageItem.cs
+++ b/src/neo/Ledger/StorageItem.cs
@@ -69,7 +69,7 @@ namespace Neo.Ledger
             if (interoperable is null)
             {
                 interoperable = new T();
-                interoperable.FromStackItem(BinarySerializer.Deserialize(value, 128, 256));
+                interoperable.FromStackItem(BinarySerializer.Deserialize(value, 64, 128));
             }
             value = null;
             return (T)interoperable;

--- a/src/neo/Ledger/StorageItem.cs
+++ b/src/neo/Ledger/StorageItem.cs
@@ -69,7 +69,7 @@ namespace Neo.Ledger
             if (interoperable is null)
             {
                 interoperable = new T();
-                interoperable.FromStackItem(BinarySerializer.Deserialize(value, 16, 34));
+                interoperable.FromStackItem(BinarySerializer.Deserialize(value, 128, 256));
             }
             value = null;
             return (T)interoperable;


### PR DESCRIPTION
Currently, `struct`, `map`, `array` can only contain 16 elements at most, which is too small. At least, we need 21 elements.