### PR TITLE
Add ITraceDebugPlugin

### DIFF
--- a/neo/Ledger/Blockchain.cs
+++ b/neo/Ledger/Blockchain.cs
@@ -580,7 +580,7 @@ namespace Neo.Ledger
                             break;
 #pragma warning restore CS0612
                         case InvocationTransaction tx_invocation:
-                            using (ApplicationEngine engine = new ApplicationEngine(TriggerType.Application, tx_invocation, snapshot.Clone(), tx_invocation.Gas))
+                            using (ApplicationEngine engine = new ApplicationEngine(TriggerType.Application, tx_invocation, snapshot.Clone(), tx_invocation.Gas, traceMode: true))
                             {
                                 engine.LoadScript(tx_invocation.Script);
                                 engine.Execute();

--- a/neo/Ledger/Blockchain.cs
+++ b/neo/Ledger/Blockchain.cs
@@ -581,7 +581,8 @@ namespace Neo.Ledger
 #pragma warning restore CS0612
                         case InvocationTransaction tx_invocation:
                             {
-                                // For now, only support a first trace debug plugin that returns true to ShouldTrace
+                                // only use first trace debug plugin that returns true to ShouldTrace
+
                                 var plugin = Plugin.TraceDebugPlugins
                                     .Where(p => p.ShouldTrace(block.Header, tx_invocation))
                                     .FirstOrDefault();

--- a/neo/Ledger/Blockchain.cs
+++ b/neo/Ledger/Blockchain.cs
@@ -590,12 +590,19 @@ namespace Neo.Ledger
  
                                 using (ApplicationEngine engine = new ApplicationEngine(TriggerType.Application, tx_invocation, snapshot.Clone(), tx_invocation.Gas, traceDebugSink: sink.Trace))
                                 {
+                                    if (sink != null)
+                                    {
+                                        engine.Service.LocalNotify += (_, args) => sink.Notify(args);
+                                        engine.Service.LocalLog += (_, args) => sink.Log(args);
+                                    }
+
                                     engine.LoadScript(tx_invocation.Script);
                                     engine.Execute();
                                     if (!engine.State.HasFlag(VMState.FAULT))
                                     {
                                         engine.Service.Commit();
                                     }
+                                    sink?.Results(engine.State, engine.GasConsumed, engine.ResultStack);
                                     execution_results.Add(new ApplicationExecutionResult
                                     {
                                         Trigger = TriggerType.Application,

--- a/neo/Ledger/Blockchain.cs
+++ b/neo/Ledger/Blockchain.cs
@@ -589,7 +589,7 @@ namespace Neo.Ledger
 
                                 using var sink = plugin != null ? plugin.GetSink(block.Header, tx_invocation) : null;
  
-                                using (ApplicationEngine engine = new ApplicationEngine(TriggerType.Application, tx_invocation, snapshot.Clone(), tx_invocation.Gas, traceDebugSink: sink.Trace))
+                                using (ApplicationEngine engine = new ApplicationEngine(TriggerType.Application, tx_invocation, snapshot.Clone(), tx_invocation.Gas, traceDebugSink: sink))
                                 {
                                     if (sink != null)
                                     {

--- a/neo/Plugins/ITraceDebugPlugin.cs
+++ b/neo/Plugins/ITraceDebugPlugin.cs
@@ -1,0 +1,11 @@
+using Neo.Network.P2P.Payloads;
+
+namespace Neo.Plugins
+{
+    public interface ITraceDebugPlugin
+    {
+        bool ShouldTrace(Header header, InvocationTransaction tx);
+        
+        ITraceDebugSink GetSink(Header header, InvocationTransaction tx);
+    }
+}

--- a/neo/Plugins/ITraceDebugSink.cs
+++ b/neo/Plugins/ITraceDebugSink.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using Neo.Ledger;
 using Neo.Network.P2P.Payloads;
+using Neo.SmartContract;
 using Neo.VM;
 
 namespace Neo.Plugins
@@ -27,6 +28,9 @@ namespace Neo.Plugins
         }
 
         void Trace(VMState vmState, IList<StackFrame> stackFrames);
+        void Log(LogEventArgs args);
+        void Notify(NotifyEventArgs args);
+        void Results(VMState vmState, Fixed8 gasConsumed, RandomAccessStack<StackItem> results);
     }
 
     public interface ITraceDebugPlugin

--- a/neo/Plugins/ITraceDebugSink.cs
+++ b/neo/Plugins/ITraceDebugSink.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+using Neo.Ledger;
+using Neo.Network.P2P.Payloads;
+using Neo.VM;
+
+namespace Neo.Plugins
+{
+    public interface ITraceDebugSink : IDisposable
+    {
+        public readonly struct StackFrame
+        {
+            public readonly int StackFrameIndex;
+            public readonly UInt160 ScriptHash;
+            public readonly int InstructionPointer;
+            public readonly Neo.VM.Types.Array Variables;
+            public readonly IEnumerable<KeyValuePair<StorageKey, StorageItem>> Storages;
+
+            public StackFrame(int stackFrameIndex, UInt160 scriptHash, int instructionPointer, VM.Types.Array variables, IEnumerable<KeyValuePair<StorageKey, StorageItem>> storages)
+            {
+                StackFrameIndex = stackFrameIndex;
+                ScriptHash = scriptHash;
+                InstructionPointer = instructionPointer;
+                Variables = variables;
+                Storages = storages;
+            }
+        }
+
+        void Trace(VMState vmState, IList<StackFrame> stackFrames);
+    }
+
+    public interface ITraceDebugPlugin
+    {
+        bool ShouldTrace(Header header, InvocationTransaction tx);
+        
+        ITraceDebugSink GetSink(Header header, InvocationTransaction tx);
+    }
+}

--- a/neo/Plugins/ITraceDebugSink.cs
+++ b/neo/Plugins/ITraceDebugSink.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using Neo.Ledger;
-using Neo.Network.P2P.Payloads;
 using Neo.SmartContract;
 using Neo.VM;
 
@@ -9,34 +8,10 @@ namespace Neo.Plugins
 {
     public interface ITraceDebugSink : IDisposable
     {
-        public readonly struct StackFrame
-        {
-            public readonly int StackFrameIndex;
-            public readonly UInt160 ScriptHash;
-            public readonly int InstructionPointer;
-            public readonly Neo.VM.Types.Array Variables;
-            public readonly IEnumerable<KeyValuePair<StorageKey, StorageItem>> Storages;
-
-            public StackFrame(int stackFrameIndex, UInt160 scriptHash, int instructionPointer, VM.Types.Array variables, IEnumerable<KeyValuePair<StorageKey, StorageItem>> storages)
-            {
-                StackFrameIndex = stackFrameIndex;
-                ScriptHash = scriptHash;
-                InstructionPointer = instructionPointer;
-                Variables = variables;
-                Storages = storages;
-            }
-        }
-
-        void Trace(VMState vmState, IList<StackFrame> stackFrames);
+        void Trace(VMState vmState, IReadOnlyCollection<ExecutionContext> contexts, 
+            Func<byte[], IEnumerable<KeyValuePair<StorageKey, StorageItem>>> getStorage);
         void Log(LogEventArgs args);
         void Notify(NotifyEventArgs args);
         void Results(VMState vmState, Fixed8 gasConsumed, RandomAccessStack<StackItem> results);
-    }
-
-    public interface ITraceDebugPlugin
-    {
-        bool ShouldTrace(Header header, InvocationTransaction tx);
-        
-        ITraceDebugSink GetSink(Header header, InvocationTransaction tx);
     }
 }

--- a/neo/Plugins/ITraceDebugSink.cs
+++ b/neo/Plugins/ITraceDebugSink.cs
@@ -8,8 +8,8 @@ namespace Neo.Plugins
 {
     public interface ITraceDebugSink : IDisposable
     {
-        void Trace(VMState vmState, IReadOnlyCollection<ExecutionContext> contexts, 
-            Func<byte[], IEnumerable<KeyValuePair<StorageKey, StorageItem>>> getStorage);
+        void Trace(VMState vmState, RandomAccessStack<ExecutionContext> contexts, 
+            Func<UInt160, IEnumerable<KeyValuePair<StorageKey, StorageItem>>> getStorage);
         void Log(LogEventArgs args);
         void Notify(NotifyEventArgs args);
         void Results(VMState vmState, Fixed8 gasConsumed, RandomAccessStack<StackItem> results);

--- a/neo/Plugins/Plugin.cs
+++ b/neo/Plugins/Plugin.cs
@@ -18,7 +18,8 @@ namespace Neo.Plugins
         internal static readonly List<IPersistencePlugin> PersistencePlugins = new List<IPersistencePlugin>();
         internal static readonly List<IP2PPlugin> P2PPlugins = new List<IP2PPlugin>();
         internal static readonly List<IMemoryPoolTxObserverPlugin> TxObserverPlugins = new List<IMemoryPoolTxObserverPlugin>();
-
+        internal static readonly List<ITraceDebugPlugin> TraceDebugPlugins = new List<ITraceDebugPlugin>();
+        
         private static readonly string pluginsPath = Path.Combine(Path.GetDirectoryName(Assembly.GetEntryAssembly().Location), "Plugins");
         private static readonly FileSystemWatcher configWatcher;
 
@@ -55,6 +56,7 @@ namespace Neo.Plugins
             if (this is IRpcPlugin rpc) RpcPlugins.Add(rpc);
             if (this is IPersistencePlugin persistence) PersistencePlugins.Add(persistence);
             if (this is IMemoryPoolTxObserverPlugin txObserver) TxObserverPlugins.Add(txObserver);
+            if (this is ITraceDebugPlugin traceDebugPlugin) TraceDebugPlugins.Add(traceDebugPlugin);
 
             Configure();
         }

--- a/neo/SmartContract/ApplicationEngine.cs
+++ b/neo/SmartContract/ApplicationEngine.cs
@@ -13,17 +13,27 @@ namespace Neo.SmartContract
         private readonly long gas_amount;
         private long gas_consumed = 0;
         private readonly bool testMode;
+        private readonly bool traceMode;
         private readonly Snapshot snapshot;
 
         public Fixed8 GasConsumed => new Fixed8(gas_consumed);
         public new NeoService Service => (NeoService)base.Service;
 
-        public ApplicationEngine(TriggerType trigger, IScriptContainer container, Snapshot snapshot, Fixed8 gas, bool testMode = false)
+        public ApplicationEngine(TriggerType trigger, IScriptContainer container, Snapshot snapshot, Fixed8 gas, bool testMode = false, bool traceMode = false)
             : base(container, Cryptography.Crypto.Default, snapshot, new NeoService(trigger, snapshot))
         {
             this.gas_amount = gas_free + gas.GetData();
             this.testMode = testMode;
+            this.traceMode = traceMode;
             this.snapshot = snapshot;
+        }
+
+        protected override void Trace()
+        {
+            if (traceMode)
+            {
+                ;   
+            }
         }
 
         private bool CheckDynamicInvoke()

--- a/neo/SmartContract/ApplicationEngine.cs
+++ b/neo/SmartContract/ApplicationEngine.cs
@@ -9,7 +9,7 @@ using Neo.VM.Types;
 
 namespace Neo.SmartContract
 {
-    using TraceSink = System.Action<VMState, IReadOnlyCollection<ExecutionContext>, System.Func<byte[], IEnumerable<KeyValuePair<StorageKey, StorageItem>>>>;
+    using TraceSink = System.Action<VMState, RandomAccessStack<ExecutionContext>, System.Func<UInt160, IEnumerable<KeyValuePair<StorageKey, StorageItem>>>>;
 
     public class ApplicationEngine : ExecutionEngine
     {
@@ -41,10 +41,9 @@ namespace Neo.SmartContract
             }
         }
 
-        private IEnumerable<KeyValuePair<StorageKey, StorageItem>> GetStorage(byte[] scriptHash)
+        private IEnumerable<KeyValuePair<StorageKey, StorageItem>> GetStorage(UInt160 scriptHash)
         {
-            var _scriptHash = new UInt160(scriptHash);
-            return snapshot.Storages.Find().Where(s => s.Key.ScriptHash == _scriptHash);
+            return snapshot.Storages.Find().Where(s => s.Key.ScriptHash == scriptHash);
         }
 
         private bool CheckDynamicInvoke()

--- a/neo/SmartContract/ApplicationEngine.cs
+++ b/neo/SmartContract/ApplicationEngine.cs
@@ -18,18 +18,21 @@ namespace Neo.SmartContract
         private readonly long gas_amount;
         private long gas_consumed = 0;
         private readonly bool testMode;
-        private readonly TraceSink traceDebugSink;
+        private readonly TraceSink traceDebugSink = null;
         private readonly Snapshot snapshot;
 
         public Fixed8 GasConsumed => new Fixed8(gas_consumed);
         public new NeoService Service => (NeoService)base.Service;
 
-        public ApplicationEngine(TriggerType trigger, IScriptContainer container, Snapshot snapshot, Fixed8 gas, bool testMode = false, TraceSink traceDebugSink = null)
+        public ApplicationEngine(TriggerType trigger, IScriptContainer container, Snapshot snapshot, Fixed8 gas, bool testMode = false, ITraceDebugSink traceDebugSink = null)
             : base(container, Cryptography.Crypto.Default, snapshot, new NeoService(trigger, snapshot))
         {
             this.gas_amount = gas_free + gas.GetData();
             this.testMode = testMode;
-            this.traceDebugSink = traceDebugSink;
+            if (traceDebugSink != null) 
+            {
+                this.traceDebugSink = traceDebugSink.Trace;
+            }
             this.snapshot = snapshot;
         }
 

--- a/neo/SmartContract/StandardService.cs
+++ b/neo/SmartContract/StandardService.cs
@@ -21,6 +21,9 @@ namespace Neo.SmartContract
         public static event EventHandler<NotifyEventArgs> Notify;
         public static event EventHandler<LogEventArgs> Log;
 
+        internal event EventHandler<NotifyEventArgs> LocalNotify;
+        internal event EventHandler<LogEventArgs> LocalLog;
+
         protected readonly TriggerType Trigger;
         protected readonly Snapshot Snapshot;
         protected readonly List<IDisposable> Disposables = new List<IDisposable>();
@@ -185,6 +188,7 @@ namespace Neo.SmartContract
             StackItem state = engine.CurrentContext.EvaluationStack.Pop();
             NotifyEventArgs notification = new NotifyEventArgs(engine.ScriptContainer, new UInt160(engine.CurrentContext.ScriptHash), state);
             Notify?.Invoke(this, notification);
+            LocalNotify?.Invoke(this, notification);
             notifications.Add(notification);
             return true;
         }
@@ -192,7 +196,9 @@ namespace Neo.SmartContract
         protected bool Runtime_Log(ExecutionEngine engine)
         {
             string message = Encoding.UTF8.GetString(engine.CurrentContext.EvaluationStack.Pop().GetByteArray());
-            Log?.Invoke(this, new LogEventArgs(engine.ScriptContainer, new UInt160(engine.CurrentContext.ScriptHash), message));
+            var eventArgs = new LogEventArgs(engine.ScriptContainer, new UInt160(engine.CurrentContext.ScriptHash), message);
+            Log?.Invoke(this, eventArgs);
+            LocalLog?.Invoke(this, eventArgs);
             return true;
         }
 

--- a/neo/neo.csproj
+++ b/neo/neo.csproj
@@ -28,12 +28,15 @@
     <PackageReference Include="Microsoft.AspNetCore.WebSockets" Version="2.2.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.1.4" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
-    <PackageReference Include="Neo.VM" Version="2.4.3" />
     <PackageReference Include="System.Text.Encodings.Web" Version="4.5.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net47'">
     <PackageReference Include="Replicon.Cryptography.SCrypt" Version="1.1.6.13" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\vm\src\neo-vm\neo-vm.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This PR adds the infrastructure needed in Neo core to enable trace debugging. This is part of the Time Travel Debugging work announced at Consensus 2020 and was the [first neo-debugger bug filed](https://github.com/neo-project/neo-debugger/issues/1) by @lightszero. 

The central piece of the trace debug work is the new ITraceDebugPlugin and ITraceDebugSink types. ITraceDebugPlugin is a new plugin type that leverages the existing Neo plugin architecture. ITraceDebugSink represents a single debug trace session. ApplicationEngine has been updated to accept an ITraceDebugSink instance and invoke methods on the sink in the newly-introduced ExecutionEngine.Trace method override. Blockchain.Persist has been updated to discover and create an ITraceDebugSink instance when persisting an InvocationTransaction. 

Additional work that will be coming as part of the Time Travel Debugging workstream:
* NGD Seattle will publish a trace file format and corresponding ITraceDebugPlugin implementation. This format and implementation is expected to be widely used as it will interoperate with other parts of the [Neo Blockchain Toolkit](https://marketplace.visualstudio.com/items?itemName=ngd-seattle.neo-blockchain-toolkit). However, other projects (such as [NeoRay](https://neoray.nel.group/)) will be able to leverage the ITraceDebugPlugin infrastructure with a format and/or implementation of their choosing. 
* The [Neo Smart Contract Debugger](https://github.com/neo-project/neo-debugger) will be updated to provide a full-featured debug experience for trace files conforming to the above mentioned format.
* [neo-express](https://github.com/neo-project/neo-express) will be updated to include the above-mentioned ITraceDebugPlugin implementation to support generating debug traces  

This PR is currently in draft as it depends on a [NeoVM change](https://github.com/neo-project/neo-vm/pull/319) that adds the core Trace method to ExecutionEngine. A similar PR will be opened for the master branch / Neo 3 core in the near future. 