### PR TITLE
[neox-2.x] must use StateRootBase

### DIFF
--- a/neo/Consensus/ConsensusContext.cs
+++ b/neo/Consensus/ConsensusContext.cs
@@ -437,7 +437,7 @@ namespace Neo.Consensus
             Transactions = transactions.ToDictionary(p => p.Hash);
             NextConsensus = Blockchain.GetConsensusAddress(Snapshot.GetValidators(transactions).ToArray());
             Timestamp = Math.Max(TimeProvider.Current.UtcNow.ToTimestamp(), this.PrevHeader().Timestamp + 1);
-            ProposalStateRoot = Blockchain.Singleton.GetStateRoot(Snapshot.Height).StateRoot;
+            ProposalStateRoot = Blockchain.Singleton.GetStateRoot(Snapshot.Height).StateRoot.ToArray().AsSerializable<StateRootBase>();
         }
 
         private static ulong GetNonce()


### PR DESCRIPTION
We should use `StateRootBase` here.
Otherwise, `RecoveryMessage` by `Primary` will use `StateRoot` `Serialize` function, here:
https://github.com/neo-project/neo/blob/cab07c13ff359c44e57e741ed1004f1cd3ae90e3/neo/Consensus/ConsensusContext.cs#L274
which will make `RecoveryMessage` deserialize fail.
@shargon @erikzhang 