### PR TITLE
Fix the way to get the directory path of assembly

### DIFF
--- a/src/neo/Utility.cs
+++ b/src/neo/Utility.cs
@@ -34,11 +34,11 @@ namespace Neo
             if (!File.Exists(file))
             {
                 // EntryPoint folder
-                file = Path.Combine(Assembly.GetEntryAssembly().Location, configFile);
+                file = Path.Combine(Path.GetDirectoryName(Assembly.GetEntryAssembly().Location), configFile);
                 if (!File.Exists(file))
                 {
                     // neo.dll folder
-                    file = Path.Combine(Assembly.GetExecutingAssembly().Location, configFile);
+                    file = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), configFile);
                     if (!File.Exists(file))
                     {
                         // default config


### PR DESCRIPTION
Fixes bug in https://github.com/neo-project/neo-node/pull/587

Github action use the `dotnet out/neo-cli.dll` command to start neo node, it will output the directory path:

```cs
Assembly.GetEntryAssembly().Location
// output:  /home/runner/work/neo-node/neo-node/out/neo-cli.dll
Path.Combine(Assembly.GetExecutingAssembly().Location, configFile)
// output:  /home/runner/work/neo-node/neo-node/out/neo-cli.dll/config.json

Assembly.GetExecutingAssembly().Location
// output:  /home/runner/work/neo-node/neo-node/out/neo.dll
Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), configFile);
// output: /home/runner/work/neo-node/neo-node/out/neo.dll/config.json
```

**Where in the software does this update applies to?**
- neo-cli https://github.com/neo-project/neo-node/pull/587
