### PR TITLE
[neox-2.x] StateHeight start from -1

### DIFF
--- a/neo.UnitTests/TestBlockchain.cs
+++ b/neo.UnitTests/TestBlockchain.cs
@@ -31,7 +31,7 @@ namespace Neo.UnitTests
                 mockSnapshot.SetupGet(p => p.ValidatorsCount).Returns(new TestMetaDataCache<ValidatorsCountState>());
                 mockSnapshot.SetupGet(p => p.BlockHashIndex).Returns(new TestMetaDataCache<HashIndexState>());
                 mockSnapshot.SetupGet(p => p.HeaderHashIndex).Returns(new TestMetaDataCache<HashIndexState>());
-                mockSnapshot.SetupGet(p => p.StateRootHashIndex).Returns(new TestMetaDataCache<HashIndexState>());
+                mockSnapshot.SetupGet(p => p.StateRootHashIndex).Returns(new TestMetaDataCache<RootHashIndex>());
 
                 var mockStore = new Mock<Store>();
 
@@ -55,7 +55,7 @@ namespace Neo.UnitTests
                 mockStore.Setup(p => p.GetValidatorsCount()).Returns(new TestMetaDataCache<ValidatorsCountState>());
                 mockStore.Setup(p => p.GetBlockHashIndex()).Returns(new TestMetaDataCache<HashIndexState>());
                 mockStore.Setup(p => p.GetHeaderHashIndex()).Returns(new TestMetaDataCache<HashIndexState>());
-                mockStore.Setup(p => p.GetStateRootHashIndex()).Returns(new TestMetaDataCache<HashIndexState>());
+                mockStore.Setup(p => p.GetStateRootHashIndex()).Returns(new TestMetaDataCache<RootHashIndex>());
                 mockStore.Setup(p => p.GetSnapshot()).Returns(mockSnapshot.Object);
                 mockStore.Setup(p => p.Get(It.IsAny<byte>(), It.IsAny<byte[]>())).Returns(UInt256.Zero.ToArray());
                 Console.WriteLine("initialize NeoSystem");

--- a/neo/Ledger/BlockChain.State.cs
+++ b/neo/Ledger/BlockChain.State.cs
@@ -13,7 +13,7 @@ namespace Neo.Ledger
     public sealed partial class Blockchain : UntypedActor
     {
         public class ImportRoots { public IEnumerable<StateRoot> Roots; }
-        public long StateHeight => currentSnapshot.StateHeight == uint.MaxValue ? -1 : (long)currentSnapshot.StateHeight;
+        public long StateHeight => currentSnapshot.StateHeight;
         private static uint StateRootEnableIndex => ProtocolSettings.Default.StateRootEnableIndex;
         private readonly Dictionary<uint, StateRoot> stateRootCache = new Dictionary<uint, StateRoot>();
 
@@ -103,9 +103,9 @@ namespace Neo.Ledger
                 var localState = snapshot.StateRoots.GetAndChange(stateRoot.Index);
                 if (localState.StateRoot.Root == stateRoot.Root && localState.StateRoot.PreHash == stateRoot.PreHash)
                 {
-                    HashIndexState hashIndexState = snapshot.StateRootHashIndex.GetAndChange();
-                    hashIndexState.Index = stateRoot.Index;
-                    hashIndexState.Hash = stateRoot.Hash;
+                    RootHashIndex rootHashIndex = snapshot.StateRootHashIndex.GetAndChange();
+                    rootHashIndex.Index = stateRoot.Index;
+                    rootHashIndex.Hash = stateRoot.Hash;
                     localState.StateRoot = stateRoot;
                     localState.Flag = StateRootVerifyFlag.Verified;
                 }

--- a/neo/Ledger/BlockChain.State.cs
+++ b/neo/Ledger/BlockChain.State.cs
@@ -13,7 +13,7 @@ namespace Neo.Ledger
     public sealed partial class Blockchain : UntypedActor
     {
         public class ImportRoots { public IEnumerable<StateRoot> Roots; }
-        public uint StateHeight => currentSnapshot.StateHeight;
+        public long StateHeight => currentSnapshot.StateHeight == uint.MaxValue ? -1 : (long)currentSnapshot.StateHeight;
         private static uint StateRootEnableIndex => ProtocolSettings.Default.StateRootEnableIndex;
         private readonly Dictionary<uint, StateRoot> stateRootCache = new Dictionary<uint, StateRoot>();
 
@@ -152,7 +152,7 @@ namespace Neo.Ledger
 
         private void CheckRootOnBlockPersistCompleted()
         {
-            var index = Math.Max(StateHeight + 1, StateRootEnableIndex);
+            var index = (uint)Math.Max(StateHeight + 1, StateRootEnableIndex);
             if (GetStateRoot(index)?.Flag == StateRootVerifyFlag.Unverified && stateRootCache.TryGetValue(index, out StateRoot state_root))
             {
                 stateRootCache.Remove(index);

--- a/neo/Ledger/RootHashIndex.cs
+++ b/neo/Ledger/RootHashIndex.cs
@@ -1,0 +1,51 @@
+﻿using Neo.IO;
+using Neo.IO.Json;
+using System.IO;
+
+namespace Neo.Ledger
+{
+    public class RootHashIndex : StateBase, ICloneable<RootHashIndex>
+    {
+        public UInt256 Hash = UInt256.Zero;
+        public long Index = -1;
+
+        public override int Size => base.Size + Hash.Size + sizeof(long);
+
+        RootHashIndex ICloneable<RootHashIndex>.Clone()
+        {
+            return new RootHashIndex
+            {
+                Hash = Hash,
+                Index = Index
+            };
+        }
+
+        public override void Deserialize(BinaryReader reader)
+        {
+            base.Deserialize(reader);
+            Hash = reader.ReadSerializable<UInt256>();
+            Index = reader.ReadInt64();
+        }
+
+        void ICloneable<RootHashIndex>.FromReplica(RootHashIndex replica)
+        {
+            Hash = replica.Hash;
+            Index = replica.Index;
+        }
+
+        public override void Serialize(BinaryWriter writer)
+        {
+            base.Serialize(writer);
+            writer.Write(Hash);
+            writer.Write(Index);
+        }
+
+        public override JObject ToJson()
+        {
+            JObject json = base.ToJson();
+            json["hash"] = Hash.ToString();
+            json["index"] = Index;
+            return json;
+        }
+    }
+}

--- a/neo/Network/P2P/TaskManager.cs
+++ b/neo/Network/P2P/TaskManager.cs
@@ -275,14 +275,14 @@ namespace Neo.Network.P2P
             }
             if (!HasStateRootTask)
             {
-                var state_height = Math.Max(Blockchain.Singleton.StateHeight, ProtocolSettings.Default.StateRootEnableIndex - 1);
+                var state_height = Math.Max(Blockchain.Singleton.StateHeight, (long)ProtocolSettings.Default.StateRootEnableIndex - 1);
                 var height = Blockchain.Singleton.Height;
                 if (state_height + 1 < height)
                 {
-                    var state = Blockchain.Singleton.GetStateRoot(state_height + 1);
+                    var state = Blockchain.Singleton.GetStateRoot((uint)(state_height + 1));
                     if (state is null || state.Flag == StateRootVerifyFlag.Unverified)
                     {
-                        var start_index = state_height + 1;
+                        var start_index = (uint)(state_height + 1);
                         var count = Math.Min(height - start_index, StateRootsPayload.MaxStateRootsCount);
                         session.Tasks[StateRootTaskHash] = DateTime.UtcNow;
                         IncrementGlobalTask(StateRootTaskHash);

--- a/neo/Persistence/CloneSnapshot.cs
+++ b/neo/Persistence/CloneSnapshot.cs
@@ -21,7 +21,7 @@ namespace Neo.Persistence
         public override MetaDataCache<ValidatorsCountState> ValidatorsCount { get; }
         public override MetaDataCache<HashIndexState> BlockHashIndex { get; }
         public override MetaDataCache<HashIndexState> HeaderHashIndex { get; }
-        public override MetaDataCache<HashIndexState> StateRootHashIndex { get; }
+        public override MetaDataCache<RootHashIndex> StateRootHashIndex { get; }
 
         public CloneSnapshot(Snapshot snapshot)
         {

--- a/neo/Persistence/IPersistence.cs
+++ b/neo/Persistence/IPersistence.cs
@@ -21,6 +21,6 @@ namespace Neo.Persistence
         MetaDataCache<ValidatorsCountState> ValidatorsCount { get; }
         MetaDataCache<HashIndexState> BlockHashIndex { get; }
         MetaDataCache<HashIndexState> HeaderHashIndex { get; }
-        MetaDataCache<HashIndexState> StateRootHashIndex { get; }
+        MetaDataCache<RootHashIndex> StateRootHashIndex { get; }
     }
 }

--- a/neo/Persistence/LevelDB/DbSnapshot.cs
+++ b/neo/Persistence/LevelDB/DbSnapshot.cs
@@ -48,15 +48,7 @@ namespace Neo.Persistence.LevelDB
             ValidatorsCount = new DbMetaDataCache<ValidatorsCountState>(db, options, batch, Prefixes.IX_ValidatorsCount);
             BlockHashIndex = new DbMetaDataCache<HashIndexState>(db, options, batch, Prefixes.IX_CurrentBlock);
             HeaderHashIndex = new DbMetaDataCache<HashIndexState>(db, options, batch, Prefixes.IX_CurrentHeader);
-            StateRootHashIndex = new DbMetaDataCache<HashIndexState>(db, options, batch, Prefixes.IX_CurrentStateRoot,
-            () =>
-            {
-                return new HashIndexState
-                {
-                    Index = 0,
-                    Hash = UInt256.Zero,
-                };
-            });
+            StateRootHashIndex = new DbMetaDataCache<HashIndexState>(db, options, batch, Prefixes.IX_CurrentStateRoot);
         }
 
         public override void Commit()

--- a/neo/Persistence/LevelDB/DbSnapshot.cs
+++ b/neo/Persistence/LevelDB/DbSnapshot.cs
@@ -26,7 +26,7 @@ namespace Neo.Persistence.LevelDB
         public override MetaDataCache<ValidatorsCountState> ValidatorsCount { get; }
         public override MetaDataCache<HashIndexState> BlockHashIndex { get; }
         public override MetaDataCache<HashIndexState> HeaderHashIndex { get; }
-        public override MetaDataCache<HashIndexState> StateRootHashIndex { get; }
+        public override MetaDataCache<RootHashIndex> StateRootHashIndex { get; }
 
         public DbSnapshot(DB db)
         {
@@ -48,7 +48,7 @@ namespace Neo.Persistence.LevelDB
             ValidatorsCount = new DbMetaDataCache<ValidatorsCountState>(db, options, batch, Prefixes.IX_ValidatorsCount);
             BlockHashIndex = new DbMetaDataCache<HashIndexState>(db, options, batch, Prefixes.IX_CurrentBlock);
             HeaderHashIndex = new DbMetaDataCache<HashIndexState>(db, options, batch, Prefixes.IX_CurrentHeader);
-            StateRootHashIndex = new DbMetaDataCache<HashIndexState>(db, options, batch, Prefixes.IX_CurrentStateRoot);
+            StateRootHashIndex = new DbMetaDataCache<RootHashIndex>(db, options, batch, Prefixes.IX_CurrentStateRoot);
         }
 
         public override void Commit()

--- a/neo/Persistence/LevelDB/LevelDBStore.cs
+++ b/neo/Persistence/LevelDB/LevelDBStore.cs
@@ -117,9 +117,9 @@ namespace Neo.Persistence.LevelDB
             return new DbMetaDataCache<HashIndexState>(db, null, null, Prefixes.IX_CurrentHeader);
         }
 
-        public override MetaDataCache<HashIndexState> GetStateRootHashIndex()
+        public override MetaDataCache<RootHashIndex> GetStateRootHashIndex()
         {
-            return new DbMetaDataCache<HashIndexState>(db, null, null, Prefixes.IX_CurrentStateRoot);
+            return new DbMetaDataCache<RootHashIndex>(db, null, null, Prefixes.IX_CurrentStateRoot);
         }
 
         public override void Put(byte prefix, byte[] key, byte[] value)

--- a/neo/Persistence/Snapshot.cs
+++ b/neo/Persistence/Snapshot.cs
@@ -27,11 +27,11 @@ namespace Neo.Persistence
         public abstract MetaDataCache<ValidatorsCountState> ValidatorsCount { get; }
         public abstract MetaDataCache<HashIndexState> BlockHashIndex { get; }
         public abstract MetaDataCache<HashIndexState> HeaderHashIndex { get; }
-        public abstract MetaDataCache<HashIndexState> StateRootHashIndex { get; }
+        public abstract MetaDataCache<RootHashIndex> StateRootHashIndex { get; }
 
         public uint Height => BlockHashIndex.Get().Index;
         public uint HeaderHeight => HeaderHashIndex.Get().Index;
-        public uint StateHeight => StateRootHashIndex.Get().Index;
+        public long StateHeight => StateRootHashIndex.Get().Index;
         public UInt256 CurrentBlockHash => BlockHashIndex.Get().Hash;
         public UInt256 CurrentHeaderHash => HeaderHashIndex.Get().Hash;
 

--- a/neo/Persistence/Store.cs
+++ b/neo/Persistence/Store.cs
@@ -21,7 +21,7 @@ namespace Neo.Persistence
         MetaDataCache<ValidatorsCountState> IPersistence.ValidatorsCount => GetValidatorsCount();
         MetaDataCache<HashIndexState> IPersistence.BlockHashIndex => GetBlockHashIndex();
         MetaDataCache<HashIndexState> IPersistence.HeaderHashIndex => GetHeaderHashIndex();
-        MetaDataCache<HashIndexState> IPersistence.StateRootHashIndex => GetStateRootHashIndex();
+        MetaDataCache<RootHashIndex> IPersistence.StateRootHashIndex => GetStateRootHashIndex();
         public abstract byte[] Get(byte prefix, byte[] key);
         public abstract DataCache<UInt256, BlockState> GetBlocks();
         public abstract DataCache<UInt256, TransactionState> GetTransactions();
@@ -37,7 +37,7 @@ namespace Neo.Persistence
         public abstract MetaDataCache<ValidatorsCountState> GetValidatorsCount();
         public abstract MetaDataCache<HashIndexState> GetBlockHashIndex();
         public abstract MetaDataCache<HashIndexState> GetHeaderHashIndex();
-        public abstract MetaDataCache<HashIndexState> GetStateRootHashIndex();
+        public abstract MetaDataCache<RootHashIndex> GetStateRootHashIndex();
         public abstract void Put(byte prefix, byte[] key, byte[] value);
         public abstract void PutSync(byte prefix, byte[] key, byte[] value);
 


### PR DESCRIPTION
Since we need cn to confirm `StateRoot` of genesis block, `StateHeight` can't start at 0 as default.
This will stop node sync `StateRoot` with 0 index.
@shargon 