### PR TITLE
Add `description` field in CandidateState

### DIFF
--- a/src/neo/SmartContract/Native/Tokens/NeoToken.cs
+++ b/src/neo/SmartContract/Native/Tokens/NeoToken.cs
@@ -95,7 +95,7 @@ namespace Neo.SmartContract.Native.Tokens
             for (int i = 0; i < Blockchain.CommitteeMembersCount; i++)
             {
                 ECPoint pubkey = Blockchain.StandbyCommittee[i];
-                RegisterCandidate(engine.Snapshot, pubkey, "Backup candidate");
+                RegisterCandidate(engine.Snapshot, pubkey, "Genesis candidate");
                 BigInteger balance = TotalAmount / 2 / (Blockchain.ValidatorsCount * 2 + (Blockchain.CommitteeMembersCount - Blockchain.ValidatorsCount));
                 if (i < Blockchain.ValidatorsCount) balance *= 2;
                 UInt160 account = Contract.CreateSignatureRedeemScript(pubkey).ToScriptHash();

--- a/src/neo/SmartContract/Native/Tokens/NeoToken.cs
+++ b/src/neo/SmartContract/Native/Tokens/NeoToken.cs
@@ -299,7 +299,7 @@ namespace Neo.SmartContract.Native.Tokens
                 Struct @struct = (Struct)stackItem;
                 Registered = @struct[0].ToBoolean();
                 Votes = @struct[1].GetBigInteger();
-                Description = @struct[1].GetString();
+                Description = @struct[2].GetString();
             }
 
             public StackItem ToStackItem(ReferenceCounter referenceCounter)


### PR DESCRIPTION
Since neo3 governance need to vote the committees and have a new economic model, more exchanges, wallets, mining pool will participate, they may need to know  the information about the candidates.

**Where in the software does this update applies to?**
- neo-cli
- sdk