### PR TITLE
[neox-2.x] Snapshot in plugin

### DIFF
--- a/neo/Ledger/Blockchain.cs
+++ b/neo/Ledger/Blockchain.cs
@@ -631,7 +631,7 @@ namespace Neo.Ledger
                     snapshot.HeaderHashIndex.GetAndChange().Index = block.Index;
                 }
                 foreach (IPersistencePlugin plugin in Plugin.PersistencePlugins)
-                    plugin.OnPersist(snapshot, all_application_executed);
+                    plugin.OnPersist(snapshot.Clone(), all_application_executed);
                 snapshot.Commit();
                 List<Exception> commitExceptions = null;
                 foreach (IPersistencePlugin plugin in Plugin.PersistencePlugins)


### PR DESCRIPTION
To fix 
* #1683 
* [neo-modules #258](https://github.com/neo-project/neo-modules/issues/258)

We shouldn't use `snapshot` directly in plugin, instead, we can use a snapshot clone.
Currently `IPersistencePlugin` has no choice but commit their changes, intentionally or not. 
We should let plugin to choose `commit` the changes they make.