### PR TITLE
Add new SYSCALL: System.Runtime.GetCounter

### DIFF
--- a/src/neo/IO/SerializableWrapper.cs
+++ b/src/neo/IO/SerializableWrapper.cs
@@ -3,11 +3,11 @@ using System.IO;
 
 namespace Neo.IO
 {
-    public class SerializableWrapper<T> : IEquatable<T>, IEquatable<SerializableWrapper<T>>, ISerializable
+    public class SerializableWrapper<T> : ICloneable<SerializableWrapper<T>>, IEquatable<T>, IEquatable<SerializableWrapper<T>>, ISerializable
         where T : unmanaged
     {
         private static unsafe readonly int ValueSize = sizeof(T);
-        private T value;
+        internal T Value;
 
         public SerializableWrapper()
         {
@@ -15,14 +15,19 @@ namespace Neo.IO
 
         private SerializableWrapper(T value)
         {
-            this.value = value;
+            this.Value = value;
         }
 
         public int Size => ValueSize;
 
+        public SerializableWrapper<T> Clone()
+        {
+            return Value;
+        }
+
         public unsafe void Deserialize(BinaryReader reader)
         {
-            fixed (T* p = &value)
+            fixed (T* p = &Value)
             {
                 Span<byte> buffer = new Span<byte>(p, ValueSize);
                 int i = 0;
@@ -37,17 +42,22 @@ namespace Neo.IO
 
         public bool Equals(T other)
         {
-            return value.Equals(other);
+            return Value.Equals(other);
         }
 
         public bool Equals(SerializableWrapper<T> other)
         {
-            return value.Equals(other.value);
+            return Value.Equals(other.Value);
+        }
+
+        public void FromReplica(SerializableWrapper<T> replica)
+        {
+            Value = replica.Value;
         }
 
         public unsafe void Serialize(BinaryWriter writer)
         {
-            fixed (T* p = &value)
+            fixed (T* p = &Value)
             {
                 ReadOnlySpan<byte> buffer = new ReadOnlySpan<byte>(p, ValueSize);
                 writer.Write(buffer);
@@ -61,7 +71,7 @@ namespace Neo.IO
 
         public static implicit operator T(SerializableWrapper<T> wrapper)
         {
-            return wrapper.value;
+            return wrapper.Value;
         }
     }
 }

--- a/src/neo/Persistence/ClonedView.cs
+++ b/src/neo/Persistence/ClonedView.cs
@@ -9,6 +9,7 @@ namespace Neo.Persistence
         public override DataCache<UInt256, TrimmedBlock> Blocks { get; }
         public override DataCache<UInt256, TransactionState> Transactions { get; }
         public override DataCache<UInt160, ContractState> Contracts { get; }
+        public override DataCache<UInt160, SerializableWrapper<ulong>> ContractCounter { get; }
         public override DataCache<StorageKey, StorageItem> Storages { get; }
         public override DataCache<SerializableWrapper<uint>, HeaderHashList> HeaderHashList { get; }
         public override MetaDataCache<HashIndexState> BlockHashIndex { get; }
@@ -21,6 +22,7 @@ namespace Neo.Persistence
             this.Blocks = view.Blocks.CreateSnapshot();
             this.Transactions = view.Transactions.CreateSnapshot();
             this.Contracts = view.Contracts.CreateSnapshot();
+            this.ContractCounter = view.ContractCounter.CreateSnapshot();
             this.Storages = view.Storages.CreateSnapshot();
             this.HeaderHashList = view.HeaderHashList.CreateSnapshot();
             this.BlockHashIndex = view.BlockHashIndex.CreateSnapshot();

--- a/src/neo/Persistence/Prefixes.cs
+++ b/src/neo/Persistence/Prefixes.cs
@@ -6,6 +6,7 @@ namespace Neo.Persistence
         public const byte DATA_Transaction = 0x02;
 
         public const byte ST_Contract = 0x50;
+        public const byte ST_ContractCounter = 0x58;
         public const byte ST_Storage = 0x70;
 
         public const byte IX_HeaderHashList = 0x80;

--- a/src/neo/Persistence/ReadOnlyView.cs
+++ b/src/neo/Persistence/ReadOnlyView.cs
@@ -15,6 +15,7 @@ namespace Neo.Persistence
         public override DataCache<UInt256, TrimmedBlock> Blocks => new StoreDataCache<UInt256, TrimmedBlock>(store, Prefixes.DATA_Block);
         public override DataCache<UInt256, TransactionState> Transactions => new StoreDataCache<UInt256, TransactionState>(store, Prefixes.DATA_Transaction);
         public override DataCache<UInt160, ContractState> Contracts => new StoreDataCache<UInt160, ContractState>(store, Prefixes.ST_Contract);
+        public override DataCache<UInt160, SerializableWrapper<ulong>> ContractCounter => new StoreDataCache<UInt160, SerializableWrapper<ulong>>(store, Prefixes.ST_ContractCounter);
         public override DataCache<StorageKey, StorageItem> Storages => new StoreDataCache<StorageKey, StorageItem>(store, Prefixes.ST_Storage);
         public override DataCache<SerializableWrapper<uint>, HeaderHashList> HeaderHashList => new StoreDataCache<SerializableWrapper<uint>, HeaderHashList>(store, Prefixes.IX_HeaderHashList);
         public override MetaDataCache<HashIndexState> BlockHashIndex => new StoreMetaDataCache<HashIndexState>(store, Prefixes.IX_CurrentBlock);

--- a/src/neo/Persistence/SnapshotView.cs
+++ b/src/neo/Persistence/SnapshotView.cs
@@ -15,6 +15,7 @@ namespace Neo.Persistence
         public override DataCache<UInt256, TrimmedBlock> Blocks { get; }
         public override DataCache<UInt256, TransactionState> Transactions { get; }
         public override DataCache<UInt160, ContractState> Contracts { get; }
+        public override DataCache<UInt160, SerializableWrapper<ulong>> ContractCounter { get; }
         public override DataCache<StorageKey, StorageItem> Storages { get; }
         public override DataCache<SerializableWrapper<uint>, HeaderHashList> HeaderHashList { get; }
         public override MetaDataCache<HashIndexState> BlockHashIndex { get; }
@@ -27,6 +28,7 @@ namespace Neo.Persistence
             Blocks = new StoreDataCache<UInt256, TrimmedBlock>(snapshot, Prefixes.DATA_Block);
             Transactions = new StoreDataCache<UInt256, TransactionState>(snapshot, Prefixes.DATA_Transaction);
             Contracts = new StoreDataCache<UInt160, ContractState>(snapshot, Prefixes.ST_Contract);
+            ContractCounter = new StoreDataCache<UInt160, SerializableWrapper<ulong>>(snapshot, Prefixes.ST_ContractCounter);
             Storages = new StoreDataCache<StorageKey, StorageItem>(snapshot, Prefixes.ST_Storage);
             HeaderHashList = new StoreDataCache<SerializableWrapper<uint>, HeaderHashList>(snapshot, Prefixes.IX_HeaderHashList);
             BlockHashIndex = new StoreMetaDataCache<HashIndexState>(snapshot, Prefixes.IX_CurrentBlock);

--- a/src/neo/Persistence/StoreView.cs
+++ b/src/neo/Persistence/StoreView.cs
@@ -14,6 +14,7 @@ namespace Neo.Persistence
         public abstract DataCache<UInt256, TrimmedBlock> Blocks { get; }
         public abstract DataCache<UInt256, TransactionState> Transactions { get; }
         public abstract DataCache<UInt160, ContractState> Contracts { get; }
+        public abstract DataCache<UInt160, SerializableWrapper<ulong>> ContractCounter { get; }
         public abstract DataCache<StorageKey, StorageItem> Storages { get; }
         public abstract DataCache<SerializableWrapper<uint>, HeaderHashList> HeaderHashList { get; }
         public abstract MetaDataCache<HashIndexState> BlockHashIndex { get; }

--- a/src/neo/SmartContract/CounterScope.cs
+++ b/src/neo/SmartContract/CounterScope.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace Neo.SmartContract
+{
+    [Flags]
+    public enum CounterScope : byte
+    {
+        //Flags
+
+        Shared = 0b00000001,
+        Persistent = 0b00000010,
+
+        //Combinations
+
+        Temporary = 0,
+        TemporaryShared = Shared,
+        Contract = Persistent,
+        Global = Shared | Persistent
+    }
+}


### PR DESCRIPTION
This PR provides a new SYSCALL: `System.Runtime.GetCounter`. Some contracts, such as NFT, may require counters.