### PR TITLE
Add cache to native contract executions

### DIFF
--- a/src/neo/Persistence/ClonedView.cs
+++ b/src/neo/Persistence/ClonedView.cs
@@ -15,7 +15,7 @@ namespace Neo.Persistence
         public override MetaDataCache<HashIndexState> HeaderHashIndex { get; }
         public override MetaDataCache<ContractIdState> ContractId { get; }
 
-        public ClonedView(StoreView view)
+        public ClonedView(StoreView view) : base(view.Store)
         {
             this.PersistingBlock = view.PersistingBlock;
             this.Blocks = view.Blocks.CreateSnapshot();

--- a/src/neo/Persistence/IStore.cs
+++ b/src/neo/Persistence/IStore.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace Neo.Persistence
 {
@@ -9,6 +10,7 @@ namespace Neo.Persistence
     {
         void Delete(byte table, byte[] key);
         ISnapshot GetSnapshot();
+        Dictionary<uint, object> GetCache();
         void Put(byte table, byte[] key, byte[] value);
         void PutSync(byte table, byte[] key, byte[] value)
         {

--- a/src/neo/Persistence/MemoryStore.cs
+++ b/src/neo/Persistence/MemoryStore.cs
@@ -1,6 +1,5 @@
 using Neo.IO;
 using Neo.IO.Caching;
-using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
@@ -10,9 +9,11 @@ namespace Neo.Persistence
     public class MemoryStore : IStore
     {
         private readonly ConcurrentDictionary<byte[], byte[]>[] innerData;
+        private readonly Dictionary<uint, object> cache;
 
         public MemoryStore()
         {
+            cache = new Dictionary<uint, object>();
             innerData = new ConcurrentDictionary<byte[], byte[]>[256];
             for (int i = 0; i < innerData.Length; i++)
                 innerData[i] = new ConcurrentDictionary<byte[], byte[]>(ByteArrayEqualityComparer.Default);
@@ -25,6 +26,11 @@ namespace Neo.Persistence
 
         public void Dispose()
         {
+        }
+
+        public Dictionary<uint, object> GetCache()
+        {
+            return cache;
         }
 
         public ISnapshot GetSnapshot()

--- a/src/neo/Persistence/ReadOnlyView.cs
+++ b/src/neo/Persistence/ReadOnlyView.cs
@@ -21,7 +21,7 @@ namespace Neo.Persistence
         public override MetaDataCache<HashIndexState> HeaderHashIndex => new StoreMetaDataCache<HashIndexState>(store, Prefixes.IX_CurrentHeader);
         public override MetaDataCache<ContractIdState> ContractId => new StoreMetaDataCache<ContractIdState>(store, Prefixes.IX_ContractId);
 
-        public ReadOnlyView(IReadOnlyStore store)
+        public ReadOnlyView(IReadOnlyStore store) : base(store as IStore)
         {
             this.store = store;
         }

--- a/src/neo/Persistence/SnapshotView.cs
+++ b/src/neo/Persistence/SnapshotView.cs
@@ -11,7 +11,6 @@ namespace Neo.Persistence
     public class SnapshotView : StoreView, IDisposable
     {
         private readonly ISnapshot snapshot;
-
         public override DataCache<UInt256, TrimmedBlock> Blocks { get; }
         public override DataCache<UInt256, TransactionState> Transactions { get; }
         public override DataCache<UInt160, ContractState> Contracts { get; }
@@ -21,9 +20,10 @@ namespace Neo.Persistence
         public override MetaDataCache<HashIndexState> HeaderHashIndex { get; }
         public override MetaDataCache<ContractIdState> ContractId { get; }
 
-        public SnapshotView(IStore store)
+        public SnapshotView(IStore store) : base(store)
         {
             this.snapshot = store.GetSnapshot();
+
             Blocks = new StoreDataCache<UInt256, TrimmedBlock>(snapshot, Prefixes.DATA_Block);
             Transactions = new StoreDataCache<UInt256, TransactionState>(snapshot, Prefixes.DATA_Transaction);
             Contracts = new StoreDataCache<UInt160, ContractState>(snapshot, Prefixes.ST_Contract);

--- a/src/neo/SmartContract/Native/ContractMethodAttribute.cs
+++ b/src/neo/SmartContract/Native/ContractMethodAttribute.cs
@@ -8,11 +8,15 @@ namespace Neo.SmartContract.Native
         public string Name { get; set; }
         public long Price { get; }
         public CallFlags RequiredCallFlags { get; }
+        public uint CacheKey { get; }
+        public uint[] CleanCacheKeys { get; }
 
-        public ContractMethodAttribute(long price, CallFlags requiredCallFlags)
+        public ContractMethodAttribute(long price, CallFlags requiredCallFlags, uint cacheKey = uint.MinValue, params uint[] cleanCacheKeys)
         {
             this.Price = price;
             this.RequiredCallFlags = requiredCallFlags;
+            this.CacheKey = cacheKey;
+            this.CleanCacheKeys = cleanCacheKeys;
         }
     }
 }

--- a/src/neo/SmartContract/Native/ContractMethodMetadata.cs
+++ b/src/neo/SmartContract/Native/ContractMethodMetadata.cs
@@ -14,9 +14,13 @@ namespace Neo.SmartContract.Native
         public bool NeedSnapshot { get; }
         public long Price { get; }
         public CallFlags RequiredCallFlags { get; }
+        public uint CacheKey { get; }
+        public uint[] CleanCacheKeys { get; }
 
         public ContractMethodMetadata(MemberInfo member, ContractMethodAttribute attribute)
         {
+            this.CacheKey = attribute.CacheKey;
+            this.CleanCacheKeys = attribute.CleanCacheKeys;
             this.Name = attribute.Name ?? member.Name.ToLower()[0] + member.Name[1..];
             this.Handler = member switch
             {

--- a/src/neo/SmartContract/Native/NativeContract.cs
+++ b/src/neo/SmartContract/Native/NativeContract.cs
@@ -106,15 +106,15 @@ namespace Neo.SmartContract.Native
                 throw new InvalidOperationException($"Cannot call this method with the flag {state.CallFlags}.");
             engine.AddGas(method.Price);
 
+            // Clean cache
+
+            foreach (var key in method.CleanCacheKeys)
+            {
+                engine.Snapshot.ToCache(key, null);
+            }
+
             if (method.CacheKey != uint.MinValue)
             {
-                // Clean
-
-                foreach (var key in method.CleanCacheKeys)
-                {
-                    engine.Snapshot.ToCache(key, null);
-                }
-
                 // Set
 
                 if (engine.Snapshot.TryGetFromCache(method.CacheKey, out object o))

--- a/src/neo/SmartContract/Native/Tokens/NeoToken.cs
+++ b/src/neo/SmartContract/Native/Tokens/NeoToken.cs
@@ -151,7 +151,7 @@ namespace Neo.SmartContract.Native.Tokens
             return true;
         }
 
-        [ContractMethod(5_00000000, CallFlags.AllowModifyStates)]
+        [ContractMethod(5_00000000, CallFlags.AllowModifyStates, cleanCacheKeys: new uint[] { 1, 2 })]
         private bool Vote(ApplicationEngine engine, UInt160 account, ECPoint voteTo)
         {
             if (!engine.CheckWitnessInternal(account)) return false;
@@ -202,13 +202,13 @@ namespace Neo.SmartContract.Native.Tokens
             )).Where(p => p.Item2.Registered).Select(p => (p.Item1, p.Item2.Votes));
         }
 
-        [ContractMethod(1_00000000, CallFlags.AllowStates)]
+        [ContractMethod(1_00000000, CallFlags.AllowStates, cacheKey: 2)]
         public ECPoint[] GetValidators(StoreView snapshot)
         {
             return GetCommitteeMembers(snapshot, ProtocolSettings.Default.MaxValidatorsCount).OrderBy(p => p).ToArray();
         }
 
-        [ContractMethod(1_00000000, CallFlags.AllowStates)]
+        [ContractMethod(1_00000000, CallFlags.AllowStates, cacheKey: 1)]
         public ECPoint[] GetCommittee(StoreView snapshot)
         {
             return GetCommitteeMembers(snapshot, ProtocolSettings.Default.MaxCommitteeMembersCount).OrderBy(p => p).ToArray();


### PR DESCRIPTION
If we add a memory cache to the snapshot, we can improve the access to native contracts. 

* Tests was done with memory storage.
* If you think that we can focus this cache in another way, I can change it.

Benchmarks:

```csharp
        [TestMethod]
        public void TestGetValidators1()
        {
            for (int x = 0; x < 1_000; x++)
            {
                using (ApplicationEngine engine = NativeContract.NEO.TestCall("getValidators"))
                {
                    var result = engine.ResultStack.Peek();
                    result.GetType().Should().Be(typeof(VM.Types.Array));
                    ((VM.Types.Array)result).Count.Should().Be(7);
                    ((VM.Types.Array)result)[0].GetSpan().ToHexString().Should().Be("02486fd15702c4490a26703112a5cc1d0923fd697a33406bd5a1c00e0013b09a70");
                    ((VM.Types.Array)result)[1].GetSpan().ToHexString().Should().Be("024c7b7fb6c310fccf1ba33b082519d82964ea93868d676662d4a59ad548df0e7d");
                    ((VM.Types.Array)result)[2].GetSpan().ToHexString().Should().Be("02aaec38470f6aad0042c6e877cfd8087d2676b0f516fddd362801b9bd3936399e");
                    ((VM.Types.Array)result)[3].GetSpan().ToHexString().Should().Be("03b209fd4f53a7170ea4444e0cb0a6bb6a53c2bd016926989cf85f9b0fba17a70c");
                    ((VM.Types.Array)result)[4].GetSpan().ToHexString().Should().Be("03b8d9d5771d8f513aa0869b9cc8d50986403b78c6da36890638c3d46a5adce04a");
                    ((VM.Types.Array)result)[5].GetSpan().ToHexString().Should().Be("02ca0e27697b9c248f6f16e085fd0061e26f44da85b58ee835c110caa5ec3ba554");
                    ((VM.Types.Array)result)[6].GetSpan().ToHexString().Should().Be("02df48f60e8f3e01c48ff40b9b7f1310d7a8b2a193188befe1c2e3df740e895093");
                }
            }
        }
```

Without PR: Duration: 6.6 sec

Adding this at the begining 
```csharp
using (ApplicationEngine engine = NativeContract.NEO.TestCall("getValidators"))
                engine.Snapshot.Commit();
```

With PR:    Duration: 1.1 sec

More than 500% of performance, we skip storage access, and serializations.