### PR TITLE
Add cache to native contract executions V2

### DIFF
--- a/src/neo/Ledger/StorageItem.cs
+++ b/src/neo/Ledger/StorageItem.cs
@@ -1,7 +1,9 @@
 using Neo.IO;
 using Neo.SmartContract;
+using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Numerics;
 
 namespace Neo.Ledger
@@ -10,7 +12,8 @@ namespace Neo.Ledger
     {
         private byte[] value;
         public bool IsConstant;
-        private object cached;
+        private object cache;
+        private Func<byte[]> serializer;
 
         public int Size => Value.GetVarSize() + sizeof(bool);
 
@@ -18,13 +21,14 @@ namespace Neo.Ledger
         {
             get
             {
-                if (value is null && cached is IInteroperable interoperable)
-                    value = BinarySerializer.Serialize(interoperable.ToStackItem(null), 4096);
+                if (value is null && serializer != null)
+                    value = serializer();
                 return value;
             }
             set
             {
-                cached = null;
+                cache = null;
+                serializer = null;
                 this.value = value;
             }
         }
@@ -33,21 +37,25 @@ namespace Neo.Ledger
 
         public StorageItem(byte[] value, bool isConstant = false)
         {
-            this.value = value;
             this.IsConstant = isConstant;
+            this.value = value;
+            this.cache = null;
+            this.serializer = null;
         }
 
         public StorageItem(BigInteger value, bool isConstant = false)
         {
-            this.value = value.ToByteArrayStandard();
-            this.cached = value;
             this.IsConstant = isConstant;
+            this.value = value.ToByteArrayStandard();
+            this.cache = value;
         }
 
         public StorageItem(IInteroperable interoperable, bool isConstant = false)
         {
-            this.cached = interoperable;
             this.IsConstant = isConstant;
+            this.value = null;
+            this.cache = interoperable;
+            this.serializer = () => BinarySerializer.Serialize(interoperable.ToStackItem(null), 4096);
         }
 
         StorageItem ICloneable<StorageItem>.Clone()
@@ -65,43 +73,17 @@ namespace Neo.Ledger
             IsConstant = reader.ReadBoolean();
         }
 
-        public T[] GetSerializableArray<T>(int max = 0x1000000) where T : ISerializable, new()
-        {
-            if (cached is T[] value) return value;
-
-            var ret = Value.AsSerializableArray<T>(max);
-            cached = ret;
-            return ret;
-        }
-
-        public T GetSerializable<T>() where T : ISerializable, new()
-        {
-            if (cached is T value) return value;
-
-            var ret = Value.AsSerializable<T>();
-            cached = ret;
-            return ret;
-        }
-
-        public BigInteger GetBigInteger()
-        {
-            if (cached is BigInteger value) return value;
-
-            var ret = new BigInteger(Value);
-            cached = ret;
-            return ret;
-        }
-
         public void Set(BigInteger value)
         {
             this.value = value.ToByteArrayStandard();
-            this.cached = value;
+            this.cache = value;
         }
 
         public void Set<T>(IReadOnlyCollection<T> value) where T : ISerializable
         {
-            this.value = value.ToByteArray();
-            this.cached = value;
+            this.value = null;
+            this.cache = value;
+            this.serializer = () => value.ToByteArray();
         }
 
         void ICloneable<StorageItem>.FromReplica(StorageItem replica)
@@ -112,14 +94,39 @@ namespace Neo.Ledger
 
         public T GetInteroperable<T>() where T : IInteroperable, new()
         {
-            if (cached is null)
+            if (cache is null)
             {
                 var interoperable = new T();
                 interoperable.FromStackItem(BinarySerializer.Deserialize(value, 16, 34));
-                cached = interoperable;
+                this.serializer = () => BinarySerializer.Serialize(interoperable.ToStackItem(null), 4096);
+                cache = interoperable;
             }
             value = null;
-            return (T)cached;
+            return (T)cache;
+        }
+
+        public T[] GetSerializableArray<T>(int max = 0x1000000) where T : ISerializable, new()
+        {
+            if (cache is null)
+            {
+                var ret = Value.AsSerializableArray<T>(max);
+                this.serializer = () => ret.ToByteArray();
+                cache = ret;
+            }
+            value = null;
+            return ((IReadOnlyCollection<T>)cache).ToArray();
+        }
+
+        public BigInteger GetBigInteger()
+        {
+            if (cache is null)
+            {
+                var ret = new BigInteger(Value);
+                this.serializer = () => ret.ToByteArrayStandard();
+                cache = ret;
+            }
+            value = null;
+            return (BigInteger)cache;
         }
 
         public void Serialize(BinaryWriter writer)

--- a/src/neo/Ledger/StorageItem.cs
+++ b/src/neo/Ledger/StorageItem.cs
@@ -1,5 +1,6 @@
 using Neo.IO;
 using Neo.SmartContract;
+using System.Collections.Generic;
 using System.IO;
 using System.Numerics;
 
@@ -33,6 +34,13 @@ namespace Neo.Ledger
         public StorageItem(byte[] value, bool isConstant = false)
         {
             this.value = value;
+            this.IsConstant = isConstant;
+        }
+
+        public StorageItem(BigInteger value, bool isConstant = false)
+        {
+            this.value = value.ToByteArrayStandard();
+            this.cached = value;
             this.IsConstant = isConstant;
         }
 
@@ -82,6 +90,18 @@ namespace Neo.Ledger
             var ret = new BigInteger(Value);
             cached = ret;
             return ret;
+        }
+
+        public void Set(BigInteger value)
+        {
+            this.value = value.ToByteArrayStandard();
+            this.cached = value;
+        }
+
+        public void Set<T>(IReadOnlyCollection<T> value) where T : ISerializable
+        {
+            this.value = value.ToByteArray();
+            this.cached = value;
         }
 
         void ICloneable<StorageItem>.FromReplica(StorageItem replica)

--- a/src/neo/Ledger/StorageItem.cs
+++ b/src/neo/Ledger/StorageItem.cs
@@ -1,6 +1,5 @@
 using Neo.IO;
 using Neo.SmartContract;
-using System;
 using System.IO;
 using System.Numerics;
 

--- a/src/neo/SmartContract/Native/PolicyContract.cs
+++ b/src/neo/SmartContract/Native/PolicyContract.cs
@@ -6,6 +6,7 @@ using Neo.Persistence;
 using Neo.SmartContract.Manifest;
 using System;
 using System.Collections.Generic;
+using System.Numerics;
 
 namespace Neo.SmartContract.Native
 {
@@ -58,31 +59,31 @@ namespace Neo.SmartContract.Native
         [ContractMethod(0_01000000, CallFlags.AllowStates)]
         public uint GetMaxTransactionsPerBlock(StoreView snapshot)
         {
-            return BitConverter.ToUInt32(snapshot.Storages[CreateStorageKey(Prefix_MaxTransactionsPerBlock)].Value, 0);
+            return (uint)(BigInteger)snapshot.Storages[CreateStorageKey(Prefix_MaxTransactionsPerBlock)];
         }
 
         [ContractMethod(0_01000000, CallFlags.AllowStates)]
         public uint GetMaxBlockSize(StoreView snapshot)
         {
-            return BitConverter.ToUInt32(snapshot.Storages[CreateStorageKey(Prefix_MaxBlockSize)].Value, 0);
+            return (uint)(BigInteger)snapshot.Storages[CreateStorageKey(Prefix_MaxBlockSize)];
         }
 
         [ContractMethod(0_01000000, CallFlags.AllowStates)]
         public long GetMaxBlockSystemFee(StoreView snapshot)
         {
-            return BitConverter.ToInt64(snapshot.Storages[CreateStorageKey(Prefix_MaxBlockSystemFee)].Value, 0);
+            return (long)(BigInteger)snapshot.Storages[CreateStorageKey(Prefix_MaxBlockSystemFee)];
         }
 
         [ContractMethod(0_01000000, CallFlags.AllowStates)]
         public long GetFeePerByte(StoreView snapshot)
         {
-            return BitConverter.ToInt64(snapshot.Storages[CreateStorageKey(Prefix_FeePerByte)].Value, 0);
+            return (long)(BigInteger)snapshot.Storages[CreateStorageKey(Prefix_FeePerByte)];
         }
 
         [ContractMethod(0_01000000, CallFlags.AllowStates)]
         public UInt160[] GetBlockedAccounts(StoreView snapshot)
         {
-            return snapshot.Storages[CreateStorageKey(Prefix_BlockedAccounts)].GetSerializableArray<UInt160>();
+            return snapshot.Storages[CreateStorageKey(Prefix_BlockedAccounts)].GetSerializableList<UInt160>().ToArray();
         }
 
         [ContractMethod(0_03000000, CallFlags.AllowModifyStates)]
@@ -91,7 +92,7 @@ namespace Neo.SmartContract.Native
             if (!CheckCommittees(engine)) return false;
             if (Network.P2P.Message.PayloadMaxSize <= value) return false;
             StorageItem storage = engine.Snapshot.Storages.GetAndChange(CreateStorageKey(Prefix_MaxBlockSize));
-            storage.Value = BitConverter.GetBytes(value);
+            storage.Set(value);
             return true;
         }
 
@@ -100,7 +101,7 @@ namespace Neo.SmartContract.Native
         {
             if (!CheckCommittees(engine)) return false;
             StorageItem storage = engine.Snapshot.Storages.GetAndChange(CreateStorageKey(Prefix_MaxTransactionsPerBlock));
-            storage.Value = BitConverter.GetBytes(value);
+            storage.Set(value);
             return true;
         }
 
@@ -110,7 +111,7 @@ namespace Neo.SmartContract.Native
             if (!CheckCommittees(engine)) return false;
             if (value <= 4007600) return false;
             StorageItem storage = engine.Snapshot.Storages.GetAndChange(CreateStorageKey(Prefix_MaxBlockSystemFee));
-            storage.Value = BitConverter.GetBytes(value);
+            storage.Set(value);
             return true;
         }
 
@@ -119,7 +120,7 @@ namespace Neo.SmartContract.Native
         {
             if (!CheckCommittees(engine)) return false;
             StorageItem storage = engine.Snapshot.Storages.GetAndChange(CreateStorageKey(Prefix_FeePerByte));
-            storage.Value = BitConverter.GetBytes(value);
+            storage.Set(value);
             return true;
         }
 
@@ -129,10 +130,10 @@ namespace Neo.SmartContract.Native
             if (!CheckCommittees(engine)) return false;
             StorageKey key = CreateStorageKey(Prefix_BlockedAccounts);
             StorageItem storage = engine.Snapshot.Storages[key];
-            SortedSet<UInt160> accounts = new SortedSet<UInt160>(storage.GetSerializableArray<UInt160>());
-            if (!accounts.Add(account)) return false;
-            storage = engine.Snapshot.Storages.GetAndChange(key);
-            storage.Set(accounts);
+            List<UInt160> accounts = storage.GetSerializableList<UInt160>();
+            if (accounts.Contains(account)) return false;
+            engine.Snapshot.Storages.GetAndChange(key);
+            accounts.Add(account);
             return true;
         }
 
@@ -142,10 +143,11 @@ namespace Neo.SmartContract.Native
             if (!CheckCommittees(engine)) return false;
             StorageKey key = CreateStorageKey(Prefix_BlockedAccounts);
             StorageItem storage = engine.Snapshot.Storages[key];
-            SortedSet<UInt160> accounts = new SortedSet<UInt160>(storage.GetSerializableArray<UInt160>());
-            if (!accounts.Remove(account)) return false;
-            storage = engine.Snapshot.Storages.GetAndChange(key);
-            storage.Set(accounts);
+            List<UInt160> accounts = storage.GetSerializableList<UInt160>();
+            int index = accounts.IndexOf(account);
+            if (index < 0) return false;
+            engine.Snapshot.Storages.GetAndChange(key);
+            accounts.RemoveAt(index);
             return true;
         }
     }

--- a/src/neo/SmartContract/Native/PolicyContract.cs
+++ b/src/neo/SmartContract/Native/PolicyContract.cs
@@ -82,7 +82,7 @@ namespace Neo.SmartContract.Native
         [ContractMethod(0_01000000, CallFlags.AllowStates)]
         public UInt160[] GetBlockedAccounts(StoreView snapshot)
         {
-            return snapshot.Storages[CreateStorageKey(Prefix_BlockedAccounts)].Value.AsSerializableArray<UInt160>();
+            return snapshot.Storages[CreateStorageKey(Prefix_BlockedAccounts)].GetSerializableArray<UInt160>();
         }
 
         [ContractMethod(0_03000000, CallFlags.AllowModifyStates)]
@@ -129,7 +129,7 @@ namespace Neo.SmartContract.Native
             if (!CheckCommittees(engine)) return false;
             StorageKey key = CreateStorageKey(Prefix_BlockedAccounts);
             StorageItem storage = engine.Snapshot.Storages[key];
-            SortedSet<UInt160> accounts = new SortedSet<UInt160>(storage.Value.AsSerializableArray<UInt160>());
+            SortedSet<UInt160> accounts = new SortedSet<UInt160>(storage.GetSerializableArray<UInt160>());
             if (!accounts.Add(account)) return false;
             storage = engine.Snapshot.Storages.GetAndChange(key);
             storage.Value = accounts.ToByteArray();
@@ -142,7 +142,7 @@ namespace Neo.SmartContract.Native
             if (!CheckCommittees(engine)) return false;
             StorageKey key = CreateStorageKey(Prefix_BlockedAccounts);
             StorageItem storage = engine.Snapshot.Storages[key];
-            SortedSet<UInt160> accounts = new SortedSet<UInt160>(storage.Value.AsSerializableArray<UInt160>());
+            SortedSet<UInt160> accounts = new SortedSet<UInt160>(storage.GetSerializableArray<UInt160>());
             if (!accounts.Remove(account)) return false;
             storage = engine.Snapshot.Storages.GetAndChange(key);
             storage.Value = accounts.ToByteArray();

--- a/src/neo/SmartContract/Native/PolicyContract.cs
+++ b/src/neo/SmartContract/Native/PolicyContract.cs
@@ -132,7 +132,7 @@ namespace Neo.SmartContract.Native
             SortedSet<UInt160> accounts = new SortedSet<UInt160>(storage.GetSerializableArray<UInt160>());
             if (!accounts.Add(account)) return false;
             storage = engine.Snapshot.Storages.GetAndChange(key);
-            storage.Value = accounts.ToByteArray();
+            storage.Set(accounts);
             return true;
         }
 
@@ -145,7 +145,7 @@ namespace Neo.SmartContract.Native
             SortedSet<UInt160> accounts = new SortedSet<UInt160>(storage.GetSerializableArray<UInt160>());
             if (!accounts.Remove(account)) return false;
             storage = engine.Snapshot.Storages.GetAndChange(key);
-            storage.Value = accounts.ToByteArray();
+            storage.Set(accounts);
             return true;
         }
     }

--- a/src/neo/SmartContract/Native/Tokens/NeoToken.cs
+++ b/src/neo/SmartContract/Native/Tokens/NeoToken.cs
@@ -46,7 +46,7 @@ namespace Neo.SmartContract.Native.Tokens
                 engine.Snapshot.Storages.GetAndChange(CreateStorageKey(Prefix_Candidate).Add(state.VoteTo)).GetInteroperable<CandidateState>().Votes += amount;
                 StorageItem item = engine.Snapshot.Storages.GetAndChange(CreateStorageKey(Prefix_VotersCount));
                 BigInteger votersCount = item.GetBigInteger() + amount;
-                item.Value = votersCount.ToByteArray();
+                item.Set(votersCount);
             }
         }
 
@@ -99,7 +99,7 @@ namespace Neo.SmartContract.Native.Tokens
         {
             base.OnPersist(engine);
             StorageItem storage = engine.Snapshot.Storages.GetAndChange(CreateStorageKey(Prefix_NextValidators), () => new StorageItem());
-            storage.Value = GetValidators(engine.Snapshot).ToByteArray();
+            storage.Set(GetValidators(engine.Snapshot));
         }
 
         [ContractMethod(0_03000000, CallFlags.AllowStates)]
@@ -155,7 +155,7 @@ namespace Neo.SmartContract.Native.Tokens
                     votersCount += state_account.Balance;
                 else
                     votersCount -= state_account.Balance;
-                item.Value = votersCount.ToByteArray();
+                item.Set(votersCount);
             }
             if (state_account.VoteTo != null)
             {

--- a/src/neo/SmartContract/Native/Tokens/NeoToken.cs
+++ b/src/neo/SmartContract/Native/Tokens/NeoToken.cs
@@ -210,7 +210,7 @@ namespace Neo.SmartContract.Native.Tokens
 
         private IEnumerable<ECPoint> GetCommitteeMembers(StoreView snapshot)
         {
-            decimal votersCount = (decimal)new BigInteger(snapshot.Storages[CreateStorageKey(Prefix_VotersCount)].Value);
+            decimal votersCount = (decimal)snapshot.Storages[CreateStorageKey(Prefix_VotersCount)].GetBigInteger();
             decimal VoterTurnout = votersCount / (decimal)TotalAmount;
             if (VoterTurnout < EffectiveVoterTurnout)
                 return Blockchain.StandbyCommittee;
@@ -225,7 +225,7 @@ namespace Neo.SmartContract.Native.Tokens
         {
             StorageItem storage = snapshot.Storages.TryGet(CreateStorageKey(Prefix_NextValidators));
             if (storage is null) return Blockchain.StandbyValidators;
-            return storage.Value.AsSerializableArray<ECPoint>();
+            return storage.GetSerializableArray<ECPoint>();
         }
 
         public class NeoAccountState : AccountState

--- a/src/neo/SmartContract/Native/Tokens/NeoToken.cs
+++ b/src/neo/SmartContract/Native/Tokens/NeoToken.cs
@@ -45,7 +45,7 @@ namespace Neo.SmartContract.Native.Tokens
             {
                 engine.Snapshot.Storages.GetAndChange(CreateStorageKey(Prefix_Candidate).Add(state.VoteTo)).GetInteroperable<CandidateState>().Votes += amount;
                 StorageItem item = engine.Snapshot.Storages.GetAndChange(CreateStorageKey(Prefix_VotersCount));
-                BigInteger votersCount = new BigInteger(item.Value) + amount;
+                BigInteger votersCount = item.GetBigInteger() + amount;
                 item.Value = votersCount.ToByteArray();
             }
         }
@@ -150,7 +150,7 @@ namespace Neo.SmartContract.Native.Tokens
             if (state_account.VoteTo is null ^ voteTo is null)
             {
                 StorageItem item = engine.Snapshot.Storages.GetAndChange(CreateStorageKey(Prefix_VotersCount));
-                BigInteger votersCount = new BigInteger(item.Value);
+                BigInteger votersCount = item.GetBigInteger();
                 if (state_account.VoteTo is null)
                     votersCount += state_account.Balance;
                 else

--- a/src/neo/SmartContract/Native/Tokens/Nep5Token.cs
+++ b/src/neo/SmartContract/Native/Tokens/Nep5Token.cs
@@ -66,13 +66,10 @@ namespace Neo.SmartContract.Native.Tokens
             TState state = storage.GetInteroperable<TState>();
             OnBalanceChanging(engine, account, state, amount);
             state.Balance += amount;
-            storage = engine.Snapshot.Storages.GetAndChange(CreateStorageKey(Prefix_TotalSupply), () => new StorageItem
-            {
-                Value = BigInteger.Zero.ToByteArrayStandard()
-            });
+            storage = engine.Snapshot.Storages.GetAndChange(CreateStorageKey(Prefix_TotalSupply), () => new StorageItem(BigInteger.Zero));
             BigInteger totalSupply = storage.GetBigInteger();
             totalSupply += amount;
-            storage.Value = totalSupply.ToByteArrayStandard();
+            storage.Set(totalSupply);
             engine.SendNotification(Hash, "Transfer", new Array { StackItem.Null, account.ToArray(), amount });
         }
 
@@ -92,7 +89,7 @@ namespace Neo.SmartContract.Native.Tokens
             storage = engine.Snapshot.Storages.GetAndChange(CreateStorageKey(Prefix_TotalSupply));
             BigInteger totalSupply = storage.GetBigInteger();
             totalSupply -= amount;
-            storage.Value = totalSupply.ToByteArrayStandard();
+            storage.Set(totalSupply);
             engine.SendNotification(Hash, "Transfer", new Array { account.ToArray(), StackItem.Null, amount });
         }
 

--- a/src/neo/SmartContract/Native/Tokens/Nep5Token.cs
+++ b/src/neo/SmartContract/Native/Tokens/Nep5Token.cs
@@ -70,7 +70,7 @@ namespace Neo.SmartContract.Native.Tokens
             {
                 Value = BigInteger.Zero.ToByteArrayStandard()
             });
-            BigInteger totalSupply = new BigInteger(storage.Value);
+            BigInteger totalSupply = storage.GetBigInteger();
             totalSupply += amount;
             storage.Value = totalSupply.ToByteArrayStandard();
             engine.SendNotification(Hash, "Transfer", new Array { StackItem.Null, account.ToArray(), amount });
@@ -90,7 +90,7 @@ namespace Neo.SmartContract.Native.Tokens
             else
                 state.Balance -= amount;
             storage = engine.Snapshot.Storages.GetAndChange(CreateStorageKey(Prefix_TotalSupply));
-            BigInteger totalSupply = new BigInteger(storage.Value);
+            BigInteger totalSupply = storage.GetBigInteger();
             totalSupply -= amount;
             storage.Value = totalSupply.ToByteArrayStandard();
             engine.SendNotification(Hash, "Transfer", new Array { account.ToArray(), StackItem.Null, amount });
@@ -101,7 +101,7 @@ namespace Neo.SmartContract.Native.Tokens
         {
             StorageItem storage = snapshot.Storages.TryGet(CreateStorageKey(Prefix_TotalSupply));
             if (storage is null) return BigInteger.Zero;
-            return new BigInteger(storage.Value);
+            return storage.GetBigInteger();
         }
 
         [ContractMethod(0_01000000, CallFlags.AllowStates)]

--- a/src/neo/SmartContract/Native/Tokens/Nep5Token.cs
+++ b/src/neo/SmartContract/Native/Tokens/Nep5Token.cs
@@ -67,9 +67,7 @@ namespace Neo.SmartContract.Native.Tokens
             OnBalanceChanging(engine, account, state, amount);
             state.Balance += amount;
             storage = engine.Snapshot.Storages.GetAndChange(CreateStorageKey(Prefix_TotalSupply), () => new StorageItem(BigInteger.Zero));
-            BigInteger totalSupply = storage.GetBigInteger();
-            totalSupply += amount;
-            storage.Set(totalSupply);
+            storage.Add(amount);
             engine.SendNotification(Hash, "Transfer", new Array { StackItem.Null, account.ToArray(), amount });
         }
 
@@ -87,9 +85,7 @@ namespace Neo.SmartContract.Native.Tokens
             else
                 state.Balance -= amount;
             storage = engine.Snapshot.Storages.GetAndChange(CreateStorageKey(Prefix_TotalSupply));
-            BigInteger totalSupply = storage.GetBigInteger();
-            totalSupply -= amount;
-            storage.Set(totalSupply);
+            storage.Add(-amount);
             engine.SendNotification(Hash, "Transfer", new Array { account.ToArray(), StackItem.Null, amount });
         }
 
@@ -98,7 +94,7 @@ namespace Neo.SmartContract.Native.Tokens
         {
             StorageItem storage = snapshot.Storages.TryGet(CreateStorageKey(Prefix_TotalSupply));
             if (storage is null) return BigInteger.Zero;
-            return storage.GetBigInteger();
+            return storage;
         }
 
         [ContractMethod(0_01000000, CallFlags.AllowStates)]


### PR DESCRIPTION
Close https://github.com/neo-project/neo/pull/1764
Other version for share the snapshot

Based on https://github.com/neo-project/neo/pull/1764#issuecomment-657504153

This cache avoid the second deserialization process

Benchmarks:

```csharp
[TestMethod]
        public void TestGetValidators1()
        {
            var snapshot = Blockchain.Singleton.GetSnapshot();

            using (ScriptBuilder sb = new ScriptBuilder())
            {
                sb.EmitAppCall(NativeContract.NEO.Hash, "getNextBlockValidators", new object[0]);

                // Fake validators

                StorageItem storage = snapshot.Storages.GetAndChange(CreateStorageKey(14), () => new StorageItem());
                storage.Value = NativeContract.NEO.GetValidators(snapshot).ToByteArray();

                // Start benchmark

                Stopwatch sw = Stopwatch.StartNew();

                for (int x = 0; x < 1_000; x++)
                {
                    using var engine = ApplicationEngine.Run(sb.ToArray(), snapshot, testMode: true);

                    var result = engine.ResultStack.Peek();
                    result.GetType().Should().Be(typeof(VM.Types.Array));
                    ((VM.Types.Array)result).Count.Should().Be(7);
                    ((VM.Types.Array)result)[0].GetSpan().ToHexString().Should().Be("02486fd15702c4490a26703112a5cc1d0923fd697a33406bd5a1c00e0013b09a70");
                    ((VM.Types.Array)result)[1].GetSpan().ToHexString().Should().Be("024c7b7fb6c310fccf1ba33b082519d82964ea93868d676662d4a59ad548df0e7d");
                    ((VM.Types.Array)result)[2].GetSpan().ToHexString().Should().Be("02aaec38470f6aad0042c6e877cfd8087d2676b0f516fddd362801b9bd3936399e");
                    ((VM.Types.Array)result)[3].GetSpan().ToHexString().Should().Be("03b209fd4f53a7170ea4444e0cb0a6bb6a53c2bd016926989cf85f9b0fba17a70c");
                    ((VM.Types.Array)result)[4].GetSpan().ToHexString().Should().Be("03b8d9d5771d8f513aa0869b9cc8d50986403b78c6da36890638c3d46a5adce04a");
                    ((VM.Types.Array)result)[5].GetSpan().ToHexString().Should().Be("02ca0e27697b9c248f6f16e085fd0061e26f44da85b58ee835c110caa5ec3ba554");
                    ((VM.Types.Array)result)[6].GetSpan().ToHexString().Should().Be("02df48f60e8f3e01c48ff40b9b7f1310d7a8b2a193188befe1c2e3df740e895093");
                }

                sw.Stop();
                Console.WriteLine(sw.Elapsed);
            }
        }
```

```
Without this PR: 00:00:02.1273432
With this PR: 00:00:00.1614797
```