### PR TITLE
Optimize IInventory serialization

### DIFF
--- a/src/neo/Network/P2P/Payloads/Block.cs
+++ b/src/neo/Network/P2P/Payloads/Block.cs
@@ -21,6 +21,8 @@ namespace Neo.Network.P2P.Payloads
         public ConsensusData ConsensusData;
         public Transaction[] Transactions;
 
+        Message IInventory.OriginalMessage { get; set; }
+
         private Header _header = null;
         public Header Header
         {

--- a/src/neo/Network/P2P/Payloads/ConsensusPayload.cs
+++ b/src/neo/Network/P2P/Payloads/ConsensusPayload.cs
@@ -19,6 +19,8 @@ namespace Neo.Network.P2P.Payloads
         public byte[] Data;
         public Witness Witness;
 
+        Message IInventory.OriginalMessage { get; set; }
+
         private ConsensusMessage _deserializedMessage = null;
         public ConsensusMessage ConsensusMessage
         {

--- a/src/neo/Network/P2P/Payloads/IInventory.cs
+++ b/src/neo/Network/P2P/Payloads/IInventory.cs
@@ -6,6 +6,8 @@ namespace Neo.Network.P2P.Payloads
     {
         UInt256 Hash { get; }
 
+        internal Message OriginalMessage { get; set; }
+
         InventoryType InventoryType { get; }
 
         bool Verify(StoreView snapshot);

--- a/src/neo/Network/P2P/Payloads/Transaction.cs
+++ b/src/neo/Network/P2P/Payloads/Transaction.cs
@@ -42,6 +42,8 @@ namespace Neo.Network.P2P.Payloads
             sizeof(long) +  //NetworkFee
             sizeof(uint);   //ValidUntilBlock
 
+        Message IInventory.OriginalMessage { get; set; }
+
         public TransactionAttribute[] Attributes
         {
             get => attributes;
@@ -142,7 +144,7 @@ namespace Neo.Network.P2P.Payloads
         public Witness[] Witnesses
         {
             get => witnesses;
-            set { witnesses = value; _size = 0; }
+            set { witnesses = value; _size = 0; ((IInventory)this).OriginalMessage = null; }
         }
 
         void ISerializable.Deserialize(BinaryReader reader)

--- a/src/neo/Network/P2P/RemoteNode.ProtocolHandler.cs
+++ b/src/neo/Network/P2P/RemoteNode.ProtocolHandler.cs
@@ -62,10 +62,10 @@ namespace Neo.Network.P2P
                     OnAddrMessageReceived((AddrPayload)msg.Payload);
                     break;
                 case MessageCommand.Block:
-                    OnInventoryReceived((Block)msg.Payload);
+                    OnInventoryReceived(msg, (Block)msg.Payload);
                     break;
                 case MessageCommand.Consensus:
-                    OnInventoryReceived((ConsensusPayload)msg.Payload);
+                    OnInventoryReceived(msg, (ConsensusPayload)msg.Payload);
                     break;
                 case MessageCommand.FilterAdd:
                     OnFilterAddMessageReceived((FilterAddPayload)msg.Payload);
@@ -105,7 +105,7 @@ namespace Neo.Network.P2P
                     break;
                 case MessageCommand.Transaction:
                     if (msg.Payload.Size <= Transaction.MaxTransactionSize)
-                        OnInventoryReceived((Transaction)msg.Payload);
+                        OnInventoryReceived(msg, (Transaction)msg.Payload);
                     break;
                 case MessageCommand.Verack:
                 case MessageCommand.Version:
@@ -284,8 +284,9 @@ namespace Neo.Network.P2P
             EnqueueMessage(Message.Create(MessageCommand.Headers, HeadersPayload.Create(headers.ToArray())));
         }
 
-        private void OnInventoryReceived(IInventory inventory)
+        private void OnInventoryReceived(Message originalMessage, IInventory inventory)
         {
+            inventory.OriginalMessage = originalMessage;
             system.TaskManager.Tell(inventory);
             if (inventory is Transaction transaction)
                 system.Consensus?.Tell(transaction);

--- a/src/neo/Network/P2P/RemoteNode.cs
+++ b/src/neo/Network/P2P/RemoteNode.cs
@@ -157,7 +157,10 @@ namespace Neo.Network.P2P
                 if (bloom_filter != null && !bloom_filter.Test((Transaction)inventory))
                     return;
             }
-            EnqueueMessage((MessageCommand)inventory.InventoryType, inventory);
+            if (inventory.OriginalMessage != null)
+                EnqueueMessage(inventory.OriginalMessage);
+            else
+                EnqueueMessage((MessageCommand)inventory.InventoryType, inventory);
         }
 
         private void OnStartProtocol()


### PR DESCRIPTION
According to https://github.com/neo-project/neo/pull/1766#issuecomment-658515198

This changes trying to avoid the re-serialization of `IInventories` when we send the same block or transaction that we receive previously.