### PR TITLE
Fix VerifyWitnesses

### DIFF
--- a/src/neo/SmartContract/Helper.cs
+++ b/src/neo/SmartContract/Helper.cs
@@ -164,7 +164,7 @@ namespace Neo.SmartContract
                 }
                 using (ApplicationEngine engine = ApplicationEngine.Create(TriggerType.Verification, verifiable, snapshot.Clone(), gas))
                 {
-                    engine.LoadScript(verification, CallFlags.ReadOnly).InstructionPointer = offset;
+                    engine.LoadScript(verification, CallFlags.None).InstructionPointer = offset;
                     engine.LoadScript(verifiable.Witnesses[i].InvocationScript, CallFlags.None);
                     if (engine.Execute() == VMState.FAULT) return false;
                     if (engine.ResultStack.Count != 1 || !engine.ResultStack.Pop().GetBoolean()) return false;


### PR DESCRIPTION
If we want to put `VerifyWitnesses()` in the method `Verify()` instead of `VerifyForEachBlock()`, the `CallFlags` of `VerifyWitnesses()` must be `None`.