### PR TITLE
Fix LastSeenMessage and Validators count issue

### DIFF
--- a/neo/Consensus/ConsensusContext.cs
+++ b/neo/Consensus/ConsensusContext.cs
@@ -39,7 +39,7 @@ namespace Neo.Consensus
         public ConsensusPayload[] LastChangeViewPayloads { get; set; }
         // LastSeenMessage array stores the height of the last seen message, for each validator.
         // if this node never heard from validator i, LastSeenMessage[i] will be -1.
-        public int[] LastSeenMessage { get; set; }
+        public Dictionary<ECPoint, int> LastSeenMessage { get; set; }
         public Block Block { get; set; }
         public Snapshot Snapshot { get; private set; }
         private KeyPair keyPair;
@@ -278,9 +278,21 @@ namespace Neo.Consensus
                 CommitPayloads = new ConsensusPayload[Validators.Length];
                 if (LastSeenMessage == null)
                 {
-                    LastSeenMessage = new int[Validators.Length];
-                    for (int i = 0; i < Validators.Length; i++)
-                        LastSeenMessage[i] = -1;
+                    LastSeenMessage = new Dictionary<ECPoint, int>();
+                    foreach (var validator in Validators)
+                        LastSeenMessage[validator] = -1;
+                }
+                if (0 < Snapshot.Height && Snapshot.GetBlock(Snapshot.Height).NextConsensus != Snapshot.GetBlock(Snapshot.Height - 1)?.NextConsensus)
+                {
+                    var old_last_seen_message = LastSeenMessage;
+                    LastSeenMessage = new Dictionary<ECPoint, int>();
+                    foreach (var validator in Validators)
+                    {
+                        if (old_last_seen_message.TryGetValue(validator, out int value))
+                            LastSeenMessage[validator] = value;
+                        else
+                            LastSeenMessage[validator] = -1;
+                    }
                 }
                 keyPair = null;
                 for (int i = 0; i < Validators.Length; i++)
@@ -305,7 +317,7 @@ namespace Neo.Consensus
             Timestamp = 0;
             TransactionHashes = null;
             PreparationPayloads = new ConsensusPayload[Validators.Length];
-            if (MyIndex >= 0) LastSeenMessage[MyIndex] = (int)BlockIndex;
+            if (MyIndex >= 0) LastSeenMessage[Validators[MyIndex]] = (int)BlockIndex;
             _header = null;
         }
 

--- a/neo/Consensus/ConsensusService.cs
+++ b/neo/Consensus/ConsensusService.cs
@@ -271,7 +271,7 @@ namespace Neo.Consensus
             {
                 return;
             }
-            context.LastSeenMessage[payload.ValidatorIndex] = (int)payload.BlockIndex;
+            context.LastSeenMessage[context.Validators[payload.ValidatorIndex]] = (int)payload.BlockIndex;
             foreach (IP2PPlugin plugin in Plugin.P2PPlugins)
                 if (!plugin.OnConsensusMessage(payload))
                     return;

--- a/neo/Consensus/Helper.cs
+++ b/neo/Consensus/Helper.cs
@@ -22,7 +22,7 @@ namespace Neo.Consensus
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int CountCommitted(this IConsensusContext context) => context.CommitPayloads.Count(p => p != null);
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int CountFailed(this IConsensusContext context) => context.LastSeenMessage.Count(p => p < (((int)context.BlockIndex) - 1));
+        public static int CountFailed(this IConsensusContext context) => context.LastSeenMessage.Count(p => p.Value < (((int)context.BlockIndex) - 1));
 
         // Consensus States
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/neo/Consensus/IConsensusContext.cs
+++ b/neo/Consensus/IConsensusContext.cs
@@ -24,7 +24,7 @@ namespace Neo.Consensus
         ConsensusPayload[] PreparationPayloads { get; set; }
         ConsensusPayload[] CommitPayloads { get; set; }
         ConsensusPayload[] ChangeViewPayloads { get; set; }
-        int[] LastSeenMessage { get; set; }
+        Dictionary<ECPoint, int> LastSeenMessage { get; set; }
         Block Block { get; set; }
         Snapshot Snapshot { get; }
 

--- a/neo/Persistence/Snapshot.cs
+++ b/neo/Persistence/Snapshot.cs
@@ -245,7 +245,7 @@ namespace Neo.Persistence
             }
             int count = (int)snapshot.ValidatorsCount.Get().Votes.Select((p, i) => new
             {
-                Count = i,
+                Count = i + 1,
                 Votes = p
             }).Where(p => p.Votes > Fixed8.Zero).ToArray().WeightedFilter(0.25, 0.75, p => p.Votes.GetData(), (p, w) => new
             {


### PR DESCRIPTION
Close #1799 

Changes:
* Use dictionary to store `LastSeenMessage` in order to cover scenario like this:
  * Validators replaced by another account without changing validators count
  * Both validators and validators count changed
* Fix bug in method of counting the number of validators based on votes

**How to test and verify the impact of these changes?**
 * Voting to change validators count or validators to check whether it works right
 * Stop some consensus nodes to check whether failed count is right
 * Don't start validator node you want to add in consensus to check whether failed count is right
 * Switch old version to this fix version and resync blocks to check whether it works well

**Where in the software does this update applies to?**
- Consensus 
- Persistence

@erikzhang @shargon How about fix like this?