### PR TITLE
[neox-2.x] Share ROOT_KEY

### DIFF
--- a/neo/Ledger/TrieReadOnlyStore.cs
+++ b/neo/Ledger/TrieReadOnlyStore.cs
@@ -1,5 +1,6 @@
 using Neo.IO.Data.LevelDB;
 using Neo.Persistence;
+using Neo.Persistence.LevelDB;
 using Neo.Trie;
 using Neo.Trie.MPT;
 using System.Text;
@@ -11,7 +12,7 @@ namespace Neo.Ledger
         private readonly Store store;
         private readonly byte prefix;
 
-        private static readonly byte[] ROOT_KEY = Blockchain.GenesisBlock.Hash.ToArray();
+        private readonly byte[] ROOT_KEY = Prefixes.ROOT_KEY;
 
         public TrieReadOnlyStore(Store store, byte prefix)
         {

--- a/neo/Ledger/TrieReadOnlyStore.cs
+++ b/neo/Ledger/TrieReadOnlyStore.cs
@@ -1,9 +1,6 @@
-using Neo.IO.Data.LevelDB;
 using Neo.Persistence;
 using Neo.Persistence.LevelDB;
 using Neo.Trie;
-using Neo.Trie.MPT;
-using System.Text;
 
 namespace Neo.Ledger
 {

--- a/neo/Ledger/TrieReadOnlyStore.cs
+++ b/neo/Ledger/TrieReadOnlyStore.cs
@@ -12,7 +12,7 @@ namespace Neo.Ledger
         private readonly Store store;
         private readonly byte prefix;
 
-        private readonly byte[] ROOT_KEY = Prefixes.ROOT_KEY;
+        private static readonly byte[] ROOT_KEY = Prefixes.ROOT_KEY;
 
         public TrieReadOnlyStore(Store store, byte prefix)
         {

--- a/neo/Persistence/LevelDB/DbTrieStore.cs
+++ b/neo/Persistence/LevelDB/DbTrieStore.cs
@@ -12,7 +12,7 @@ namespace Neo.Persistence.LevelDB
         private readonly WriteBatch batch;
         private readonly byte prefix;
 
-        private readonly byte[] ROOT_KEY = Prefixes.ROOT_KEY;
+        private static readonly byte[] ROOT_KEY = Prefixes.ROOT_KEY;
 
         public DbTrieStore(DB db, ReadOptions options, WriteBatch batch, byte prefix)
         {

--- a/neo/Persistence/LevelDB/DbTrieStore.cs
+++ b/neo/Persistence/LevelDB/DbTrieStore.cs
@@ -1,7 +1,6 @@
 using Neo.IO.Data.LevelDB;
 using Neo.Trie;
 using Neo.Trie.MPT;
-using Neo.Ledger;
 
 namespace Neo.Persistence.LevelDB
 {

--- a/neo/Persistence/LevelDB/DbTrieStore.cs
+++ b/neo/Persistence/LevelDB/DbTrieStore.cs
@@ -12,7 +12,7 @@ namespace Neo.Persistence.LevelDB
         private readonly WriteBatch batch;
         private readonly byte prefix;
 
-        private readonly byte[] ROOT_KEY = Blockchain.GenesisBlock.Hash.ToArray();
+        private readonly byte[] ROOT_KEY = Prefixes.ROOT_KEY;
 
         public DbTrieStore(DB db, ReadOptions options, WriteBatch batch, byte prefix)
         {

--- a/neo/Persistence/LevelDB/Prefixes.cs
+++ b/neo/Persistence/LevelDB/Prefixes.cs
@@ -1,4 +1,6 @@
-﻿namespace Neo.Persistence.LevelDB
+﻿using Neo.Ledger;
+
+namespace Neo.Persistence.LevelDB
 {
     internal static class Prefixes
     {
@@ -22,10 +24,11 @@
         public const byte IX_CurrentStateRoot = 0xc2;
 
         public const byte SYS_Version = 0xf0;
-
         /* Prefixes 0xf1 to 0xff are reserved for external use.
          *
          * Note: The saved consensus state uses the Prefix 0xf4
          */
+
+        public static readonly byte[] ROOT_KEY = Blockchain.GenesisBlock.Hash.ToArray();
     }
 }

--- a/neo/Persistence/LevelDB/Prefixes.cs
+++ b/neo/Persistence/LevelDB/Prefixes.cs
@@ -1,4 +1,4 @@
-﻿using Neo.Ledger;
+﻿using System;
 
 namespace Neo.Persistence.LevelDB
 {
@@ -29,6 +29,6 @@ namespace Neo.Persistence.LevelDB
          * Note: The saved consensus state uses the Prefix 0xf4
          */
 
-        public static readonly byte[] ROOT_KEY = Blockchain.GenesisBlock.Hash.ToArray();
+        public static readonly byte[] ROOT_KEY = BitConverter.GetBytes(ProtocolSettings.Default.Magic);
     }
 }


### PR DESCRIPTION
Resolve https://github.com/neo-project/neo/pull/1803#discussion_r463452427

 * Define `ROOT_KEY` in `LevelDB/Prefixes.cs` and use in `TrieReadOnlyStore ` and `DbTrieStore `.