### PR TITLE
Fix sync stop

### DIFF
--- a/src/neo/Network/P2P/TaskManager.cs
+++ b/src/neo/Network/P2P/TaskManager.cs
@@ -46,6 +46,7 @@ namespace Neo.Network.P2P
             this.knownHashes = new HashSetCache<UInt256>(Blockchain.Singleton.MemPool.Capacity * 2 / 5);
             this.lastTaskIndex = Blockchain.Singleton.Height;
             Context.System.EventStream.Subscribe(Self, typeof(Blockchain.PersistCompleted));
+            Context.System.EventStream.Subscribe(Self, typeof(Blockchain.RelayResult));
         }
 
         private bool AssignSyncTask(uint index, TaskSession filterSession = null)


### PR DESCRIPTION
Close #1825 
In this case, the node will continue to request blocks from the Preview2 node.
So a blacklist mechanism needs to be added to the node health.