### PR TITLE
Remove unused crypto

### DIFF
--- a/src/neo/Cryptography/ECC/ECFieldElement.cs
+++ b/src/neo/Cryptography/ECC/ECFieldElement.cs
@@ -41,53 +41,6 @@ namespace Neo.Cryptography.ECC
             return Value.Equals(other.Value) && curve.Equals(other.curve);
         }
 
-        private static BigInteger[] FastLucasSequence(BigInteger p, BigInteger P, BigInteger Q, BigInteger k)
-        {
-            int n = k.GetBitLength();
-            int s = k.GetLowestSetBit();
-
-            BigInteger Uh = 1;
-            BigInteger Vl = 2;
-            BigInteger Vh = P;
-            BigInteger Ql = 1;
-            BigInteger Qh = 1;
-
-            for (int j = n - 1; j >= s + 1; --j)
-            {
-                Ql = (Ql * Qh).Mod(p);
-
-                if (k.TestBit(j))
-                {
-                    Qh = (Ql * Q).Mod(p);
-                    Uh = (Uh * Vh).Mod(p);
-                    Vl = (Vh * Vl - P * Ql).Mod(p);
-                    Vh = ((Vh * Vh) - (Qh << 1)).Mod(p);
-                }
-                else
-                {
-                    Qh = Ql;
-                    Uh = (Uh * Vl - Ql).Mod(p);
-                    Vh = (Vh * Vl - P * Ql).Mod(p);
-                    Vl = ((Vl * Vl) - (Ql << 1)).Mod(p);
-                }
-            }
-
-            Ql = (Ql * Qh).Mod(p);
-            Qh = (Ql * Q).Mod(p);
-            Uh = (Uh * Vl - Ql).Mod(p);
-            Vl = (Vh * Vl - P * Ql).Mod(p);
-            Ql = (Ql * Qh).Mod(p);
-
-            for (int j = 1; j <= s; ++j)
-            {
-                Uh = Uh * Vl * p;
-                Vl = ((Vl * Vl) - (Ql << 1)).Mod(p);
-                Ql = (Ql * Ql).Mod(p);
-            }
-
-            return new BigInteger[] { Uh, Vl };
-        }
-
         public override int GetHashCode()
         {
             return Value.GetHashCode();
@@ -100,39 +53,8 @@ namespace Neo.Cryptography.ECC
                 ECFieldElement z = new ECFieldElement(BigInteger.ModPow(Value, (curve.Q >> 2) + 1, curve.Q), curve);
                 return z.Square().Equals(this) ? z : null;
             }
-            BigInteger qMinusOne = curve.Q - 1;
-            BigInteger legendreExponent = qMinusOne >> 1;
-            if (BigInteger.ModPow(Value, legendreExponent, curve.Q) != 1)
-                return null;
-            BigInteger u = qMinusOne >> 2;
-            BigInteger k = (u << 1) + 1;
-            BigInteger Q = this.Value;
-            BigInteger fourQ = (Q << 2).Mod(curve.Q);
-            BigInteger U, V;
-            do
-            {
-                Random rand = new Random();
-                BigInteger P;
-                do
-                {
-                    P = rand.NextBigInteger(curve.Q.GetBitLength());
-                }
-                while (P >= curve.Q || BigInteger.ModPow(P * P - fourQ, legendreExponent, curve.Q) != qMinusOne);
-                BigInteger[] result = FastLucasSequence(curve.Q, P, Q, k);
-                U = result[0];
-                V = result[1];
-                if ((V * V).Mod(curve.Q) == fourQ)
-                {
-                    if (V.TestBit(0))
-                    {
-                        V += curve.Q;
-                    }
-                    V >>= 1;
-                    return new ECFieldElement(V, curve);
-                }
-            }
-            while (U.Equals(BigInteger.One) || U.Equals(qMinusOne));
-            return null;
+
+            throw new NotImplementedException();
         }
 
         public ECFieldElement Square()

--- a/tests/neo.UnitTests/Cryptography/ECC/UT_ECFieldElement.cs
+++ b/tests/neo.UnitTests/Cryptography/ECC/UT_ECFieldElement.cs
@@ -73,7 +73,7 @@ namespace Neo.UnitTests.Cryptography.ECC
                 BigInteger.Parse("00FFFFFFFF00000000FFFFFFFFFFFFFFFFBCE6FAADA7179E84F3B9CAC2FC632551", NumberStyles.AllowHexSpecifier),
                 ("04" + "6B17D1F2E12C4247F8BCE6E563A440F277037D812DEB33A0F4A13945D898C296" + "4FE342E2FE1A7F9B8EE7EB4A7C0F9E162BCE33576B315ECECBB6406837BF51F5").HexToBytes() }) as ECCurve;
             element = new ECFieldElement(new BigInteger(200), testCruve);
-            element.Sqrt().Should().Be(null);
+            Assert.ThrowsException<NotImplementedException>(() => element.Sqrt());
         }
 
         [TestMethod]


### PR DESCRIPTION
Currently we doesn't have any curve that doesn't fit the condition of

```csharp
if (curve.Q.TestBit(1))
```

So I think that we should remove this part of code because can't be tested and compared with official projects.