### PR TITLE
Implement Base58 Encode and Decode Interops on Neo

### DIFF
--- a/src/neo/SmartContract/ApplicationEngine.Binary.cs
+++ b/src/neo/SmartContract/ApplicationEngine.Binary.cs
@@ -1,3 +1,4 @@
+using Neo.Cryptography;
 using Neo.VM.Types;
 using static System.Convert;
 
@@ -9,6 +10,8 @@ namespace Neo.SmartContract
         public static readonly InteropDescriptor System_Binary_Deserialize = Register("System.Binary.Deserialize", nameof(BinaryDeserialize), 0_00500000, CallFlags.None, true);
         public static readonly InteropDescriptor System_Binary_Base64Encode = Register("System.Binary.Base64Encode", nameof(Base64Encode), 0_00100000, CallFlags.None, true);
         public static readonly InteropDescriptor System_Binary_Base64Decode = Register("System.Binary.Base64Decode", nameof(Base64Decode), 0_00100000, CallFlags.None, true);
+        public static readonly InteropDescriptor System_Binary_Base58Encode = Register("System.Binary.Base58Encode", nameof(Base58Encode), 0_00100000, CallFlags.None, true);
+        public static readonly InteropDescriptor System_Binary_Base58Decode = Register("System.Binary.Base58Decode", nameof(Base58Decode), 0_00100000, CallFlags.None, true);
 
         protected internal byte[] BinarySerialize(StackItem item)
         {
@@ -28,6 +31,16 @@ namespace Neo.SmartContract
         protected internal byte[] Base64Decode(string s)
         {
             return FromBase64String(s);
+        }
+
+        internal string Base58Encode(byte[] data)
+        {
+            return Base58.Encode(data);
+        }
+
+        internal byte[] Base58Decode(string s)
+        {
+            return Base58.Decode(s);
         }
     }
 }

--- a/src/neo/SmartContract/ApplicationEngine.Binary.cs
+++ b/src/neo/SmartContract/ApplicationEngine.Binary.cs
@@ -33,12 +33,12 @@ namespace Neo.SmartContract
             return FromBase64String(s);
         }
 
-        internal string Base58Encode(byte[] data)
+        protected internal string Base58Encode(byte[] data)
         {
             return Base58.Encode(data);
         }
 
-        internal byte[] Base58Decode(string s)
+        protected internal byte[] Base58Decode(string s)
         {
             return Base58.Decode(s);
         }

--- a/tests/neo.UnitTests/Cryptography/ECC/UT_ECDSA.cs
+++ b/tests/neo.UnitTests/Cryptography/ECC/UT_ECDSA.cs
@@ -24,6 +24,7 @@ namespace Neo.UnitTests.Cryptography.ECC
             Assert.IsFalse(ecdsa.VerifySignature(new byte[] { 2 }, sig[0], sig[1]));
             Assert.IsFalse(ecdsa.VerifySignature(new byte[] { 1 }, sig[0] + 1, sig[1]));
             Assert.IsFalse(ecdsa.VerifySignature(new byte[] { 1 }, sig[0], sig[1] + 1));
+            Assert.IsFalse(ecdsa.VerifySignature(new byte[33], sig[0], sig[1]));
         }
     }
 }

--- a/tests/neo.UnitTests/SmartContract/UT_ApplicationEngine.cs
+++ b/tests/neo.UnitTests/SmartContract/UT_ApplicationEngine.cs
@@ -26,10 +26,16 @@ namespace Neo.UnitTests.SmartContract
             var data = new byte[0];
             CollectionAssert.AreEqual(data, engine.Base64Decode(engine.Base64Encode(data)));
 
+            CollectionAssert.AreEqual(data, engine.Base58Decode(engine.Base58Encode(data)));
+
             data = new byte[] { 1, 2, 3 };
             CollectionAssert.AreEqual(data, engine.Base64Decode(engine.Base64Encode(data)));
 
+            CollectionAssert.AreEqual(data, engine.Base58Decode(engine.Base58Encode(data)));
+
             Assert.AreEqual("AQIDBA==", engine.Base64Encode(new byte[] { 1, 2, 3, 4 }));
+
+            Assert.AreEqual("2VfUX", engine.Base58Encode(new byte[] { 1, 2, 3, 4 }));
         }
 
         [TestMethod]


### PR DESCRIPTION
Included two new interops:
- `System.Binary.Base58Encode`
- `System.Binary.Base58Decode`