### PR TITLE
add catch in OnRecoveryMessage

### DIFF
--- a/src/neo/Consensus/ConsensusService.cs
+++ b/src/neo/Consensus/ConsensusService.cs
@@ -371,9 +371,9 @@ namespace Neo.Consensus
                         if (ReverifyAndProcessPayload(commitPayload)) validCommits++;
                 }
             }
-            catch (IndexOutOfRangeException e)
+            catch (Exception e)
             {
-                Log($"invalid recovery message with illegal validator index. {e}");
+                Log($"invalid recovery message. {e}");
             }
             finally
             {

--- a/src/neo/Consensus/ConsensusService.cs
+++ b/src/neo/Consensus/ConsensusService.cs
@@ -371,6 +371,10 @@ namespace Neo.Consensus
                         if (ReverifyAndProcessPayload(commitPayload)) validCommits++;
                 }
             }
+            catch (IndexOutOfRangeException e)
+            {
+                Log($"invalid recovery message with illegal validator index. {e}");
+            }
             finally
             {
                 Log($"{nameof(OnRecoveryMessageReceived)}: finished (valid/total) " +


### PR DESCRIPTION
Fix https://github.com/neo-project/neo/pull/1803#issuecomment-670361121

We have a risk that one validator can easily stop all c# consensus nodes with put out of range validator index in some payloads in recovery message.

* Catch`IndexOutOfRangeException`