### PR TITLE
Fast serialization

### DIFF
--- a/src/neo/IO/Caching/ReflectionCache.cs
+++ b/src/neo/IO/Caching/ReflectionCache.cs
@@ -39,5 +39,16 @@ namespace Neo.IO.Caching
                 return data.AsSerializable(t);
             return null;
         }
+
+        public static Type GetType(T key)
+        {
+            dictionary.TryGetValue(key, out Type t);
+            return t;
+        }
+
+        public static IEnumerable<Type> GetTypes()
+        {
+            return dictionary.Values;
+        }
     }
 }

--- a/src/neo/IO/Serialization/ArraySerializer.cs
+++ b/src/neo/IO/Serialization/ArraySerializer.cs
@@ -1,12 +1,10 @@
-using System.IO;
-
 namespace Neo.IO.Serialization
 {
     public class ArraySerializer<T> : Serializer<T[]> where T : Serializable
     {
         private static readonly Serializer<T> elementSerializer = (Serializer<T>)GetDefaultSerializer(typeof(T));
 
-        public sealed override T[] Deserialize(BinaryReader reader, SerializedAttribute attribute)
+        public sealed override T[] Deserialize(MemoryReader reader, SerializedAttribute attribute)
         {
             int max = attribute?.Max >= 0 ? attribute.Max : 0x1000000;
             T[] result = new T[reader.ReadVarInt((ulong)max)];
@@ -15,19 +13,19 @@ namespace Neo.IO.Serialization
             return result;
         }
 
-        protected virtual T DeserializeElement(BinaryReader reader)
+        protected virtual T DeserializeElement(MemoryReader reader)
         {
             return elementSerializer.Deserialize(reader, null);
         }
 
-        public sealed override void Serialize(BinaryWriter writer, T[] value)
+        public sealed override void Serialize(MemoryWriter writer, T[] value)
         {
             writer.WriteVarInt(value.Length);
             foreach (T item in value)
                 SerializeElement(writer, item);
         }
 
-        protected virtual void SerializeElement(BinaryWriter writer, T value)
+        protected virtual void SerializeElement(MemoryWriter writer, T value)
         {
             elementSerializer.Serialize(writer, value);
         }

--- a/src/neo/IO/Serialization/ArraySerializer.cs
+++ b/src/neo/IO/Serialization/ArraySerializer.cs
@@ -2,7 +2,7 @@ namespace Neo.IO.Serialization
 {
     public class ArraySerializer<T> : Serializer<T[]> where T : Serializable
     {
-        private static readonly Serializer<T> elementSerializer = (Serializer<T>)GetDefaultSerializer(typeof(T));
+        private static readonly Serializer<T> elementSerializer = GetDefaultSerializer<T>();
 
         public sealed override T[] Deserialize(MemoryReader reader, SerializedAttribute attribute)
         {

--- a/src/neo/IO/Serialization/ArraySerializer.cs
+++ b/src/neo/IO/Serialization/ArraySerializer.cs
@@ -2,7 +2,7 @@ using System.IO;
 
 namespace Neo.IO.Serialization
 {
-    public class ArraySerializer<T> : Serializer<T[]> where T : class, ISerializable
+    public class ArraySerializer<T> : Serializer<T[]> where T : Serializable
     {
         private static readonly Serializer<T> elementSerializer = (Serializer<T>)GetDefaultSerializer(typeof(T));
 

--- a/src/neo/IO/Serialization/ArraySerializer.cs
+++ b/src/neo/IO/Serialization/ArraySerializer.cs
@@ -1,0 +1,35 @@
+using System.IO;
+
+namespace Neo.IO.Serialization
+{
+    public class ArraySerializer<T> : Serializer<T[]> where T : class, ISerializable
+    {
+        private static readonly Serializer<T> elementSerializer = (Serializer<T>)GetDefaultSerializer(typeof(T));
+
+        public sealed override T[] Deserialize(BinaryReader reader, SerializedAttribute attribute)
+        {
+            int max = attribute?.Max >= 0 ? attribute.Max : 0x1000000;
+            T[] result = new T[reader.ReadVarInt((ulong)max)];
+            for (int i = 0; i < result.Length; i++)
+                result[i] = DeserializeElement(reader);
+            return result;
+        }
+
+        protected virtual T DeserializeElement(BinaryReader reader)
+        {
+            return elementSerializer.Deserialize(reader, null);
+        }
+
+        public sealed override void Serialize(BinaryWriter writer, T[] value)
+        {
+            writer.WriteVarInt(value.Length);
+            foreach (T item in value)
+                SerializeElement(writer, item);
+        }
+
+        protected virtual void SerializeElement(BinaryWriter writer, T value)
+        {
+            elementSerializer.Serialize(writer, value);
+        }
+    }
+}

--- a/src/neo/IO/Serialization/BooleanSerializer.cs
+++ b/src/neo/IO/Serialization/BooleanSerializer.cs
@@ -1,8 +1,10 @@
 using Neo.IO.Json;
+using Neo.VM;
+using Neo.VM.Types;
 
 namespace Neo.IO.Serialization
 {
-    public class BooleanSerializer : Serializer<bool>
+    public sealed class BooleanSerializer : Serializer<bool>
     {
         public override bool Deserialize(MemoryReader reader, SerializedAttribute attribute)
         {
@@ -14,12 +16,22 @@ namespace Neo.IO.Serialization
             return json.AsBoolean();
         }
 
+        public override bool FromStackItem(StackItem item, SerializedAttribute attribute)
+        {
+            return item.GetBoolean();
+        }
+
         public override void Serialize(MemoryWriter writer, bool value)
         {
             writer.Write(value);
         }
 
         public override JObject ToJson(bool value)
+        {
+            return value;
+        }
+
+        public override StackItem ToStackItem(bool value, ReferenceCounter referenceCounter)
         {
             return value;
         }

--- a/src/neo/IO/Serialization/BooleanSerializer.cs
+++ b/src/neo/IO/Serialization/BooleanSerializer.cs
@@ -1,0 +1,27 @@
+using Neo.IO.Json;
+
+namespace Neo.IO.Serialization
+{
+    public class BooleanSerializer : Serializer<bool>
+    {
+        public override bool Deserialize(MemoryReader reader, SerializedAttribute attribute)
+        {
+            return reader.ReadBoolean();
+        }
+
+        public override bool FromJson(JObject json, SerializedAttribute attribute)
+        {
+            return json.AsBoolean();
+        }
+
+        public override void Serialize(MemoryWriter writer, bool value)
+        {
+            writer.Write(value);
+        }
+
+        public override JObject ToJson(bool value)
+        {
+            return value;
+        }
+    }
+}

--- a/src/neo/IO/Serialization/ByteArraySerializer.cs
+++ b/src/neo/IO/Serialization/ByteArraySerializer.cs
@@ -1,16 +1,14 @@
-using System.IO;
-
 namespace Neo.IO.Serialization
 {
     public class ByteArraySerializer : Serializer<byte[]>
     {
-        public override byte[] Deserialize(BinaryReader reader, SerializedAttribute attribute)
+        public override byte[] Deserialize(MemoryReader reader, SerializedAttribute attribute)
         {
             int max = attribute?.Max >= 0 ? attribute.Max : 0x1000000;
-            return reader.ReadVarBytes(max);
+            return reader.ReadVarBytes(max).ToArray();
         }
 
-        public override void Serialize(BinaryWriter writer, byte[] value)
+        public override void Serialize(MemoryWriter writer, byte[] value)
         {
             writer.WriteVarBytes(value);
         }

--- a/src/neo/IO/Serialization/ByteArraySerializer.cs
+++ b/src/neo/IO/Serialization/ByteArraySerializer.cs
@@ -1,0 +1,18 @@
+using System.IO;
+
+namespace Neo.IO.Serialization
+{
+    public class ByteArraySerializer : Serializer<byte[]>
+    {
+        public override byte[] Deserialize(BinaryReader reader, SerializedAttribute attribute)
+        {
+            int max = attribute?.Max >= 0 ? attribute.Max : 0x1000000;
+            return reader.ReadVarBytes(max);
+        }
+
+        public override void Serialize(BinaryWriter writer, byte[] value)
+        {
+            writer.WriteVarBytes(value);
+        }
+    }
+}

--- a/src/neo/IO/Serialization/ByteArraySerializer.cs
+++ b/src/neo/IO/Serialization/ByteArraySerializer.cs
@@ -1,3 +1,6 @@
+using Neo.IO.Json;
+using System;
+
 namespace Neo.IO.Serialization
 {
     public class ByteArraySerializer : Serializer<byte[]>
@@ -8,9 +11,22 @@ namespace Neo.IO.Serialization
             return reader.ReadVarBytes(max).ToArray();
         }
 
+        public override byte[] FromJson(JObject json, SerializedAttribute attribute)
+        {
+            int max = attribute?.Max >= 0 ? attribute.Max : 0x1000000;
+            byte[] result = Convert.FromBase64String(json.AsString());
+            if (result.Length > max) throw new FormatException();
+            return result;
+        }
+
         public override void Serialize(MemoryWriter writer, byte[] value)
         {
             writer.WriteVarBytes(value);
+        }
+
+        public override JObject ToJson(byte[] value)
+        {
+            return Convert.ToBase64String(value);
         }
     }
 }

--- a/src/neo/IO/Serialization/CompositeSerializer.cs
+++ b/src/neo/IO/Serialization/CompositeSerializer.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -18,7 +17,7 @@ namespace Neo.IO.Serialization
             serializers = GetSerializers().OrderBy(p => p.Item2.Order).ToArray();
         }
 
-        public sealed override T Deserialize(BinaryReader reader, SerializedAttribute _)
+        public sealed override T Deserialize(MemoryReader reader, SerializedAttribute _)
         {
             var constructorInfo = TargetType.GetConstructor(Type.EmptyTypes);
             var newExpr = Expression.New(constructorInfo);
@@ -53,7 +52,7 @@ namespace Neo.IO.Serialization
             }
         }
 
-        public sealed override void Serialize(BinaryWriter writer, T value)
+        public sealed override void Serialize(MemoryWriter writer, T value)
         {
             foreach (var (info, _, serializer) in serializers)
                 serializer.SerializeProperty(writer, value, info);

--- a/src/neo/IO/Serialization/CompositeSerializer.cs
+++ b/src/neo/IO/Serialization/CompositeSerializer.cs
@@ -1,3 +1,4 @@
+using Neo.IO.Json;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -48,6 +49,15 @@ namespace Neo.IO.Serialization
             }
         }
 
+        public sealed override T FromJson(JObject json, SerializedAttribute _)
+        {
+            EnsureInitialized();
+            T obj = constructor();
+            foreach (var (info, attribute, serializer) in serializers)
+                serializer.PropertyFromJson(json[info.Name.ToLower()], obj, info, attribute);
+            return obj;
+        }
+
         private static Dictionary<string, PropertyInfo> GetProperties(Type type)
         {
             if (type.BaseType is null) return new Dictionary<string, PropertyInfo>();
@@ -87,6 +97,15 @@ namespace Neo.IO.Serialization
             {
                 writer.Write(memory.Span);
             }
+        }
+
+        public sealed override JObject ToJson(T value)
+        {
+            EnsureInitialized();
+            JObject json = new JObject();
+            foreach (var (info, _, serializer) in serializers)
+                json[info.Name.ToLower()] = serializer.PropertyToJson(value, info);
+            return json;
         }
     }
 }

--- a/src/neo/IO/Serialization/CompositeSerializer.cs
+++ b/src/neo/IO/Serialization/CompositeSerializer.cs
@@ -7,7 +7,7 @@ using System.Reflection;
 
 namespace Neo.IO.Serialization
 {
-    public class CompositeSerializer<T> : Serializer<T> where T : class, ISerializable
+    public class CompositeSerializer<T> : Serializer<T> where T : Serializable
     {
         private readonly (PropertyInfo, SerializedAttribute, Serializer)[] serializers;
 

--- a/src/neo/IO/Serialization/CompositeSerializer.cs
+++ b/src/neo/IO/Serialization/CompositeSerializer.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Neo.IO.Serialization
+{
+    public class CompositeSerializer<T> : Serializer<T> where T : class, ISerializable
+    {
+        private readonly (PropertyInfo, SerializedAttribute, Serializer)[] serializers;
+
+        protected virtual Type TargetType { get; } = typeof(T);
+
+        public CompositeSerializer()
+        {
+            serializers = GetSerializers().OrderBy(p => p.Item2.Order).ToArray();
+        }
+
+        public sealed override T Deserialize(BinaryReader reader, SerializedAttribute _)
+        {
+            var constructorInfo = TargetType.GetConstructor(Type.EmptyTypes);
+            var newExpr = Expression.New(constructorInfo);
+            var constructorExpr = Expression.Lambda<Func<object>>(newExpr);
+            var constructor = constructorExpr.Compile();
+            object obj = constructor();
+            foreach (var (info, attribute, serializer) in serializers)
+                serializer.DeserializeProperty(reader, obj, info, attribute);
+            return (T)obj;
+        }
+
+        private static Dictionary<string, PropertyInfo> GetProperties(Type type)
+        {
+            if (type.BaseType is null) return new Dictionary<string, PropertyInfo>();
+            Dictionary<string, PropertyInfo> dictionary = GetProperties(type.BaseType);
+            foreach (PropertyInfo property in type.GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly))
+                dictionary[property.Name] = property;
+            return dictionary;
+        }
+
+        private IEnumerable<(PropertyInfo, SerializedAttribute, Serializer)> GetSerializers()
+        {
+            foreach (PropertyInfo info in GetProperties(TargetType).Values)
+            {
+                if (info.GetMethod is null || info.SetMethod is null) continue;
+                SerializedAttribute attribute = info.GetCustomAttribute<SerializedAttribute>();
+                if (attribute is null) continue;
+                Serializer serializer = attribute.Serializer is null
+                    ? GetDefaultSerializer(info.PropertyType)
+                    : (Serializer)Activator.CreateInstance(attribute.Serializer);
+                yield return (info, attribute, serializer);
+            }
+        }
+
+        public sealed override void Serialize(BinaryWriter writer, T value)
+        {
+            foreach (var (info, _, serializer) in serializers)
+                serializer.SerializeProperty(writer, value, info);
+        }
+    }
+}

--- a/src/neo/IO/Serialization/MemoryReader.cs
+++ b/src/neo/IO/Serialization/MemoryReader.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Buffers.Binary;
+
+namespace Neo.IO.Serialization
+{
+    public sealed class MemoryReader
+    {
+        private readonly ReadOnlyMemory<byte> memory;
+        private int index = 0;
+
+        public ReadOnlySpan<byte> Span => memory.Span[index..];
+
+        public MemoryReader(ReadOnlyMemory<byte> memory)
+        {
+            this.memory = memory;
+        }
+
+        public byte Peek()
+        {
+            return Span[0];
+        }
+
+        public bool ReadBoolean()
+        {
+            return ReadByte() != 0;
+        }
+
+        public byte ReadByte()
+        {
+            byte result = Span[0];
+            index++;
+            return result;
+        }
+
+        public ReadOnlyMemory<byte> ReadBytes(int size)
+        {
+            ReadOnlyMemory<byte> result = memory.Slice(index, size);
+            index += size;
+            return result;
+        }
+
+        public ushort ReadUInt16()
+        {
+            ushort result = BinaryPrimitives.ReadUInt16LittleEndian(Span);
+            index += sizeof(ushort);
+            return result;
+        }
+
+        public uint ReadUInt32()
+        {
+            uint result = BinaryPrimitives.ReadUInt32LittleEndian(Span);
+            index += sizeof(uint);
+            return result;
+        }
+
+        public ulong ReadUInt64()
+        {
+            ulong result = BinaryPrimitives.ReadUInt64LittleEndian(Span);
+            index += sizeof(ulong);
+            return result;
+        }
+
+        public ReadOnlyMemory<byte> ReadVarBytes(int max = 0x1000000)
+        {
+            return ReadBytes((int)ReadVarInt((ulong)max));
+        }
+
+        public ulong ReadVarInt(ulong max = ulong.MaxValue)
+        {
+            byte fb = ReadByte();
+            ulong value;
+            if (fb == 0xFD)
+                value = ReadUInt16();
+            else if (fb == 0xFE)
+                value = ReadUInt32();
+            else if (fb == 0xFF)
+                value = ReadUInt64();
+            else
+                value = fb;
+            if (value > max) throw new FormatException();
+            return value;
+        }
+
+        public string ReadVarString(int max = 0x1000000)
+        {
+            return Utility.StrictUTF8.GetString(ReadVarBytes(max).Span);
+        }
+
+        public static implicit operator MemoryReader(ReadOnlyMemory<byte> memory)
+        {
+            return new MemoryReader(memory);
+        }
+
+        public static implicit operator MemoryReader(byte[] memory)
+        {
+            return new MemoryReader(memory);
+        }
+    }
+}

--- a/src/neo/IO/Serialization/MemoryReader.cs
+++ b/src/neo/IO/Serialization/MemoryReader.cs
@@ -6,13 +6,18 @@ namespace Neo.IO.Serialization
     public sealed class MemoryReader
     {
         private readonly ReadOnlyMemory<byte> memory;
-        private int index = 0;
 
-        public ReadOnlySpan<byte> Span => memory.Span[index..];
+        public int Position { get; private set; }
+        private ReadOnlySpan<byte> Span => memory.Span[Position..];
 
         public MemoryReader(ReadOnlyMemory<byte> memory)
         {
             this.memory = memory;
+        }
+
+        internal ReadOnlyMemory<byte> GetMemory(Range range)
+        {
+            return memory[range];
         }
 
         public byte Peek()
@@ -28,35 +33,35 @@ namespace Neo.IO.Serialization
         public byte ReadByte()
         {
             byte result = Span[0];
-            index++;
+            Position++;
             return result;
         }
 
         public ReadOnlyMemory<byte> ReadBytes(int size)
         {
-            ReadOnlyMemory<byte> result = memory.Slice(index, size);
-            index += size;
+            ReadOnlyMemory<byte> result = memory.Slice(Position, size);
+            Position += size;
             return result;
         }
 
         public ushort ReadUInt16()
         {
             ushort result = BinaryPrimitives.ReadUInt16LittleEndian(Span);
-            index += sizeof(ushort);
+            Position += sizeof(ushort);
             return result;
         }
 
         public uint ReadUInt32()
         {
             uint result = BinaryPrimitives.ReadUInt32LittleEndian(Span);
-            index += sizeof(uint);
+            Position += sizeof(uint);
             return result;
         }
 
         public ulong ReadUInt64()
         {
             ulong result = BinaryPrimitives.ReadUInt64LittleEndian(Span);
-            index += sizeof(ulong);
+            Position += sizeof(ulong);
             return result;
         }
 

--- a/src/neo/IO/Serialization/MemorySerializer.cs
+++ b/src/neo/IO/Serialization/MemorySerializer.cs
@@ -1,3 +1,4 @@
+using Neo.IO.Json;
 using System;
 
 namespace Neo.IO.Serialization
@@ -10,9 +11,22 @@ namespace Neo.IO.Serialization
             return reader.ReadVarBytes(max);
         }
 
+        public override ReadOnlyMemory<byte> FromJson(JObject json, SerializedAttribute attribute)
+        {
+            int max = attribute?.Max >= 0 ? attribute.Max : 0x1000000;
+            byte[] result = Convert.FromBase64String(json.AsString());
+            if (result.Length > max) throw new FormatException();
+            return result;
+        }
+
         public override void Serialize(MemoryWriter writer, ReadOnlyMemory<byte> value)
         {
             writer.WriteVarBytes(value.Span);
+        }
+
+        public override JObject ToJson(ReadOnlyMemory<byte> value)
+        {
+            return Convert.ToBase64String(value.Span);
         }
     }
 }

--- a/src/neo/IO/Serialization/MemorySerializer.cs
+++ b/src/neo/IO/Serialization/MemorySerializer.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace Neo.IO.Serialization
+{
+    public class MemorySerializer : Serializer<ReadOnlyMemory<byte>>
+    {
+        public override ReadOnlyMemory<byte> Deserialize(MemoryReader reader, SerializedAttribute attribute)
+        {
+            int max = attribute?.Max >= 0 ? attribute.Max : 0x1000000;
+            return reader.ReadVarBytes(max);
+        }
+
+        public override void Serialize(MemoryWriter writer, ReadOnlyMemory<byte> value)
+        {
+            writer.WriteVarBytes(value.Span);
+        }
+    }
+}

--- a/src/neo/IO/Serialization/MemoryWriter.cs
+++ b/src/neo/IO/Serialization/MemoryWriter.cs
@@ -1,12 +1,22 @@
+using System;
 using System.IO;
 
 namespace Neo.IO.Serialization
 {
     public sealed class MemoryWriter : BinaryWriter
     {
+        public int Position => (int)BaseStream.Position;
+
         public MemoryWriter()
             : base(new MemoryStream(), Utility.StrictUTF8, false)
         {
+        }
+
+        public ReadOnlyMemory<byte> GetMemory(Range range)
+        {
+            Flush();
+            MemoryStream ms = (MemoryStream)BaseStream;
+            return ms.GetBuffer().AsMemory(range);
         }
 
         public byte[] ToArray()

--- a/src/neo/IO/Serialization/MemoryWriter.cs
+++ b/src/neo/IO/Serialization/MemoryWriter.cs
@@ -1,0 +1,19 @@
+using System.IO;
+
+namespace Neo.IO.Serialization
+{
+    public sealed class MemoryWriter : BinaryWriter
+    {
+        public MemoryWriter()
+            : base(new MemoryStream(), Utility.StrictUTF8, false)
+        {
+        }
+
+        public byte[] ToArray()
+        {
+            Flush();
+            MemoryStream ms = (MemoryStream)BaseStream;
+            return ms.ToArray();
+        }
+    }
+}

--- a/src/neo/IO/Serialization/NullableArraySerializer.cs
+++ b/src/neo/IO/Serialization/NullableArraySerializer.cs
@@ -1,0 +1,19 @@
+using System.IO;
+
+namespace Neo.IO.Serialization
+{
+    public class NullableArraySerializer<T> : ArraySerializer<T> where T : Serializable
+    {
+        protected override T DeserializeElement(BinaryReader reader)
+        {
+            return reader.ReadBoolean() ? base.DeserializeElement(reader) : null;
+        }
+
+        protected override void SerializeElement(BinaryWriter writer, T value)
+        {
+            bool isNull = value is null;
+            writer.Write(!isNull);
+            if (!isNull) base.SerializeElement(writer, value);
+        }
+    }
+}

--- a/src/neo/IO/Serialization/NullableArraySerializer.cs
+++ b/src/neo/IO/Serialization/NullableArraySerializer.cs
@@ -1,6 +1,6 @@
 namespace Neo.IO.Serialization
 {
-    public class NullableArraySerializer<T> : ArraySerializer<T> where T : Serializable
+    public sealed class NullableArraySerializer<T> : ArraySerializer<T> where T : Serializable
     {
         protected override T DeserializeElement(MemoryReader reader)
         {

--- a/src/neo/IO/Serialization/NullableArraySerializer.cs
+++ b/src/neo/IO/Serialization/NullableArraySerializer.cs
@@ -1,15 +1,13 @@
-using System.IO;
-
 namespace Neo.IO.Serialization
 {
     public class NullableArraySerializer<T> : ArraySerializer<T> where T : Serializable
     {
-        protected override T DeserializeElement(BinaryReader reader)
+        protected override T DeserializeElement(MemoryReader reader)
         {
             return reader.ReadBoolean() ? base.DeserializeElement(reader) : null;
         }
 
-        protected override void SerializeElement(BinaryWriter writer, T value)
+        protected override void SerializeElement(MemoryWriter writer, T value)
         {
             bool isNull = value is null;
             writer.Write(!isNull);

--- a/src/neo/IO/Serialization/PolymorphousArraySerializer.ElementSerializer.cs
+++ b/src/neo/IO/Serialization/PolymorphousArraySerializer.ElementSerializer.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace Neo.IO.Serialization
+{
+    partial class PolymorphousArraySerializer<T, TEnum>
+    {
+        private class ElementSerializer : CompositeSerializer<T>
+        {
+            protected override Type TargetType { get; }
+
+            public ElementSerializer(Type type)
+            {
+                TargetType = type;
+            }
+        }
+    }
+}

--- a/src/neo/IO/Serialization/PolymorphousArraySerializer.cs
+++ b/src/neo/IO/Serialization/PolymorphousArraySerializer.cs
@@ -1,15 +1,18 @@
 using Neo.IO.Caching;
 using Neo.IO.Json;
+using Neo.VM;
+using Neo.VM.Types;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using Array = Neo.VM.Types.Array;
 
 namespace Neo.IO.Serialization
 {
-    public partial class PolymorphousArraySerializer<T, TEnum> : ArraySerializer<T>
+    public sealed partial class PolymorphousArraySerializer<T, TEnum> : ArraySerializer<T>
         where T : Serializable
-        where TEnum : Enum
+        where TEnum : unmanaged, Enum
     {
         private static readonly Dictionary<Type, ElementSerializer> serializers = ReflectionCache<TEnum>.GetTypes().ToDictionary(p => p, p => new ElementSerializer(p));
         private static readonly string typeKey = typeof(T).GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance).First(p => p.PropertyType == typeof(TEnum)).Name.ToLower();
@@ -30,10 +33,26 @@ namespace Neo.IO.Serialization
             return serializer.FromJson(json, null);
         }
 
+        protected override T ElementFromStackItem(StackItem item)
+        {
+            Array array = (Array)item;
+            Serializer<TEnum> enumSerializer = GetDefaultSerializer<TEnum>();
+            TEnum e = enumSerializer.FromStackItem(array[0], null);
+            Type type = ReflectionCache<TEnum>.GetType(e);
+            ElementSerializer serializer = serializers[type];
+            return serializer.FromStackItem(item, null);
+        }
+
         protected override JObject ElementToJson(T value)
         {
             ElementSerializer serializer = serializers[value.GetType()];
             return serializer.ToJson(value);
+        }
+
+        protected override StackItem ElementToStackItem(T value, ReferenceCounter referenceCounter)
+        {
+            ElementSerializer serializer = serializers[value.GetType()];
+            return serializer.ToStackItem(value, referenceCounter);
         }
 
         protected override void SerializeElement(MemoryWriter writer, T value)

--- a/src/neo/IO/Serialization/PolymorphousArraySerializer.cs
+++ b/src/neo/IO/Serialization/PolymorphousArraySerializer.cs
@@ -1,0 +1,30 @@
+using Neo.IO.Caching;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Neo.IO.Serialization
+{
+    public partial class PolymorphousArraySerializer<T, TEnum> : ArraySerializer<T>
+        where T : class, ISerializable
+        where TEnum : Enum
+    {
+        private static readonly Dictionary<Type, ElementSerializer> serializers = ReflectionCache<TEnum>.GetTypes().ToDictionary(p => p, p => new ElementSerializer(p));
+
+        protected override T DeserializeElement(BinaryReader reader)
+        {
+            TEnum e = (TEnum)Enum.ToObject(typeof(TEnum), reader.ReadByte());
+            Type type = ReflectionCache<TEnum>.GetType(e);
+            ElementSerializer serializer = serializers[type];
+            reader.BaseStream.Seek(-1, SeekOrigin.Current);
+            return serializer.Deserialize(reader, null);
+        }
+
+        protected override void SerializeElement(BinaryWriter writer, T value)
+        {
+            ElementSerializer serializer = serializers[value.GetType()];
+            serializer.Serialize(writer, value);
+        }
+    }
+}

--- a/src/neo/IO/Serialization/PolymorphousArraySerializer.cs
+++ b/src/neo/IO/Serialization/PolymorphousArraySerializer.cs
@@ -1,7 +1,9 @@
 using Neo.IO.Caching;
+using Neo.IO.Json;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 
 namespace Neo.IO.Serialization
 {
@@ -10,6 +12,7 @@ namespace Neo.IO.Serialization
         where TEnum : Enum
     {
         private static readonly Dictionary<Type, ElementSerializer> serializers = ReflectionCache<TEnum>.GetTypes().ToDictionary(p => p, p => new ElementSerializer(p));
+        private static readonly string typeKey = typeof(T).GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance).First(p => p.PropertyType == typeof(TEnum)).Name.ToLower();
 
         protected override T DeserializeElement(MemoryReader reader)
         {
@@ -17,6 +20,20 @@ namespace Neo.IO.Serialization
             Type type = ReflectionCache<TEnum>.GetType(e);
             ElementSerializer serializer = serializers[type];
             return serializer.Deserialize(reader, null);
+        }
+
+        protected override T ElementFromJson(JObject json)
+        {
+            TEnum e = json[typeKey].TryGetEnum<TEnum>();
+            Type type = ReflectionCache<TEnum>.GetType(e);
+            ElementSerializer serializer = serializers[type];
+            return serializer.FromJson(json, null);
+        }
+
+        protected override JObject ElementToJson(T value)
+        {
+            ElementSerializer serializer = serializers[value.GetType()];
+            return serializer.ToJson(value);
         }
 
         protected override void SerializeElement(MemoryWriter writer, T value)

--- a/src/neo/IO/Serialization/PolymorphousArraySerializer.cs
+++ b/src/neo/IO/Serialization/PolymorphousArraySerializer.cs
@@ -7,7 +7,7 @@ using System.Linq;
 namespace Neo.IO.Serialization
 {
     public partial class PolymorphousArraySerializer<T, TEnum> : ArraySerializer<T>
-        where T : class, ISerializable
+        where T : Serializable
         where TEnum : Enum
     {
         private static readonly Dictionary<Type, ElementSerializer> serializers = ReflectionCache<TEnum>.GetTypes().ToDictionary(p => p, p => new ElementSerializer(p));

--- a/src/neo/IO/Serialization/PolymorphousArraySerializer.cs
+++ b/src/neo/IO/Serialization/PolymorphousArraySerializer.cs
@@ -1,7 +1,6 @@
 using Neo.IO.Caching;
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 
 namespace Neo.IO.Serialization
@@ -12,16 +11,15 @@ namespace Neo.IO.Serialization
     {
         private static readonly Dictionary<Type, ElementSerializer> serializers = ReflectionCache<TEnum>.GetTypes().ToDictionary(p => p, p => new ElementSerializer(p));
 
-        protected override T DeserializeElement(BinaryReader reader)
+        protected override T DeserializeElement(MemoryReader reader)
         {
-            TEnum e = (TEnum)Enum.ToObject(typeof(TEnum), reader.ReadByte());
+            TEnum e = (TEnum)Enum.ToObject(typeof(TEnum), reader.Peek());
             Type type = ReflectionCache<TEnum>.GetType(e);
             ElementSerializer serializer = serializers[type];
-            reader.BaseStream.Seek(-1, SeekOrigin.Current);
             return serializer.Deserialize(reader, null);
         }
 
-        protected override void SerializeElement(BinaryWriter writer, T value)
+        protected override void SerializeElement(MemoryWriter writer, T value)
         {
             ElementSerializer serializer = serializers[value.GetType()];
             serializer.Serialize(writer, value);

--- a/src/neo/IO/Serialization/Serializable.cs
+++ b/src/neo/IO/Serialization/Serializable.cs
@@ -9,5 +9,11 @@ namespace Neo.IO.Serialization
         public int Size => _memory.IsEmpty ? GetSize() : _memory.Length;
 
         protected abstract int GetSize();
+
+        public ReadOnlyMemory<byte> ToArray()
+        {
+            if (_memory.IsEmpty) Serializer.Serialize(this);
+            return _memory;
+        }
     }
 }

--- a/src/neo/IO/Serialization/Serializable.cs
+++ b/src/neo/IO/Serialization/Serializable.cs
@@ -1,0 +1,6 @@
+namespace Neo.IO.Serialization
+{
+    public abstract class Serializable
+    {
+    }
+}

--- a/src/neo/IO/Serialization/Serializable.cs
+++ b/src/neo/IO/Serialization/Serializable.cs
@@ -1,6 +1,13 @@
+using System;
+
 namespace Neo.IO.Serialization
 {
     public abstract class Serializable
     {
+        private ReadOnlyMemory<byte> _memory { get; set; }
+
+        public int Size => _memory.IsEmpty ? GetSize() : _memory.Length;
+
+        protected abstract int GetSize();
     }
 }

--- a/src/neo/IO/Serialization/Serializable.cs
+++ b/src/neo/IO/Serialization/Serializable.cs
@@ -1,4 +1,6 @@
 using Neo.IO.Json;
+using Neo.VM;
+using Neo.VM.Types;
 using System;
 
 namespace Neo.IO.Serialization
@@ -20,6 +22,11 @@ namespace Neo.IO.Serialization
         public JObject ToJson()
         {
             return Serializer.ToJson(this);
+        }
+
+        public StackItem ToStackItem(ReferenceCounter referenceCounter = null)
+        {
+            return Serializer.ToStackItem(this, referenceCounter);
         }
     }
 }

--- a/src/neo/IO/Serialization/Serializable.cs
+++ b/src/neo/IO/Serialization/Serializable.cs
@@ -1,3 +1,4 @@
+using Neo.IO.Json;
 using System;
 
 namespace Neo.IO.Serialization
@@ -14,6 +15,11 @@ namespace Neo.IO.Serialization
         {
             if (_memory.IsEmpty) Serializer.Serialize(this);
             return _memory;
+        }
+
+        public JObject ToJson()
+        {
+            return Serializer.ToJson(this);
         }
     }
 }

--- a/src/neo/IO/Serialization/SerializedAttribute.cs
+++ b/src/neo/IO/Serialization/SerializedAttribute.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace Neo.IO.Serialization
+{
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
+    public class SerializedAttribute : Attribute
+    {
+        public int Order { get; }
+        public Type Serializer { get; set; }
+        public int Max { get; set; } = -1;
+
+        public SerializedAttribute(int order)
+        {
+            this.Order = order;
+        }
+    }
+}

--- a/src/neo/IO/Serialization/Serializer.cs
+++ b/src/neo/IO/Serialization/Serializer.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Neo.IO.Serialization
+{
+    public abstract class Serializer
+    {
+        private static readonly Dictionary<Type, Serializer> defaultSerializers = new Dictionary<Type, Serializer>
+        {
+            [typeof(bool)] = new UnmanagedSerializer<bool>(),
+            [typeof(sbyte)] = new VarIntSerializer<sbyte>(),
+            [typeof(byte)] = new VarIntSerializer<byte>(),
+            [typeof(short)] = new VarIntSerializer<short>(),
+            [typeof(ushort)] = new VarIntSerializer<ushort>(),
+            [typeof(int)] = new VarIntSerializer<int>(),
+            [typeof(uint)] = new VarIntSerializer<uint>(),
+            [typeof(long)] = new VarIntSerializer<long>(),
+            [typeof(ulong)] = new VarIntSerializer<ulong>(),
+            [typeof(string)] = new StringSerializer(),
+            [typeof(byte[])] = new ByteArraySerializer()
+        };
+
+        public abstract void DeserializeProperty(BinaryReader reader, object obj, PropertyInfo property, SerializedAttribute attribute);
+
+        protected static Serializer GetDefaultSerializer(Type type)
+        {
+            if (!defaultSerializers.TryGetValue(type, out Serializer serializer))
+            {
+                if (type.IsEnum)
+                    serializer = (Serializer)Activator.CreateInstance(typeof(UnmanagedSerializer<>).MakeGenericType(type));
+                else if (type.IsArray)
+                    serializer = (Serializer)Activator.CreateInstance(typeof(ArraySerializer<>).MakeGenericType(type.GetElementType()));
+                else
+                    serializer = (Serializer)Activator.CreateInstance(typeof(CompositeSerializer<>).MakeGenericType(type));
+                defaultSerializers.Add(type, serializer);
+            }
+            return serializer;
+        }
+
+        public abstract void SerializeProperty(BinaryWriter writer, object obj, PropertyInfo property);
+    }
+
+    public abstract class Serializer<T> : Serializer
+    {
+        private static readonly ConcurrentDictionary<PropertyInfo, (Delegate, Delegate)> callbacks = new ConcurrentDictionary<PropertyInfo, (Delegate, Delegate)>();
+
+        public abstract T Deserialize(BinaryReader reader, SerializedAttribute attribute);
+
+        public sealed override void DeserializeProperty(BinaryReader reader, object obj, PropertyInfo property, SerializedAttribute attribute)
+        {
+            (_, var setter) = GetCallbacks(property);
+            Action<object, T> action = (Action<object, T>)setter;
+            action(obj, Deserialize(reader, attribute));
+        }
+
+        private static (Delegate, Delegate) GetCallbacks(PropertyInfo property)
+        {
+            return callbacks.GetOrAdd(property, p =>
+            {
+                var instExpr = Expression.Parameter(typeof(object));
+                var convertExpr = Expression.Convert(instExpr, p.DeclaringType);
+                var callExpr = Expression.Call(convertExpr, p.GetMethod);
+                var getterExpr = Expression.Lambda<Func<object, T>>(callExpr, instExpr);
+                var paramExpr = Expression.Parameter(typeof(T));
+                callExpr = Expression.Call(convertExpr, p.SetMethod, paramExpr);
+                var setterExpr = Expression.Lambda<Action<object, T>>(callExpr, instExpr, paramExpr);
+                return (getterExpr.Compile(), setterExpr.Compile());
+            });
+        }
+
+        public abstract void Serialize(BinaryWriter writer, T value);
+
+        public sealed override void SerializeProperty(BinaryWriter writer, object obj, PropertyInfo property)
+        {
+            (var getter, _) = GetCallbacks(property);
+            Func<object, T> func = (Func<object, T>)getter;
+            Serialize(writer, func(obj));
+        }
+    }
+}

--- a/src/neo/IO/Serialization/StringSerializer.cs
+++ b/src/neo/IO/Serialization/StringSerializer.cs
@@ -1,9 +1,11 @@
 using Neo.IO.Json;
+using Neo.VM;
+using Neo.VM.Types;
 using System;
 
 namespace Neo.IO.Serialization
 {
-    public class StringSerializer : Serializer<string>
+    public sealed class StringSerializer : Serializer<string>
     {
         public override string Deserialize(MemoryReader reader, SerializedAttribute attribute)
         {
@@ -19,12 +21,25 @@ namespace Neo.IO.Serialization
             return result;
         }
 
+        public override string FromStackItem(StackItem item, SerializedAttribute attribute)
+        {
+            int max = attribute?.Max >= 0 ? attribute.Max : 0x1000000;
+            ReadOnlySpan<byte> result = item.GetSpan();
+            if (result.Length > max) throw new FormatException();
+            return Utility.StrictUTF8.GetString(result);
+        }
+
         public override void Serialize(MemoryWriter writer, string value)
         {
             writer.WriteVarString(value);
         }
 
         public override JObject ToJson(string value)
+        {
+            return value;
+        }
+
+        public override StackItem ToStackItem(string value, ReferenceCounter referenceCounter)
         {
             return value;
         }

--- a/src/neo/IO/Serialization/StringSerializer.cs
+++ b/src/neo/IO/Serialization/StringSerializer.cs
@@ -1,0 +1,18 @@
+using System.IO;
+
+namespace Neo.IO.Serialization
+{
+    public class StringSerializer : Serializer<string>
+    {
+        public override string Deserialize(BinaryReader reader, SerializedAttribute attribute)
+        {
+            int max = attribute?.Max >= 0 ? attribute.Max : 0x1000000;
+            return reader.ReadVarString(max);
+        }
+
+        public override void Serialize(BinaryWriter writer, string value)
+        {
+            writer.WriteVarString(value);
+        }
+    }
+}

--- a/src/neo/IO/Serialization/StringSerializer.cs
+++ b/src/neo/IO/Serialization/StringSerializer.cs
@@ -1,3 +1,6 @@
+using Neo.IO.Json;
+using System;
+
 namespace Neo.IO.Serialization
 {
     public class StringSerializer : Serializer<string>
@@ -8,9 +11,22 @@ namespace Neo.IO.Serialization
             return reader.ReadVarString(max);
         }
 
+        public override string FromJson(JObject json, SerializedAttribute attribute)
+        {
+            int max = attribute?.Max >= 0 ? attribute.Max : 0x1000000;
+            string result = json.AsString();
+            if (Utility.StrictUTF8.GetByteCount(result) > max) throw new FormatException();
+            return result;
+        }
+
         public override void Serialize(MemoryWriter writer, string value)
         {
             writer.WriteVarString(value);
+        }
+
+        public override JObject ToJson(string value)
+        {
+            return value;
         }
     }
 }

--- a/src/neo/IO/Serialization/StringSerializer.cs
+++ b/src/neo/IO/Serialization/StringSerializer.cs
@@ -1,16 +1,14 @@
-using System.IO;
-
 namespace Neo.IO.Serialization
 {
     public class StringSerializer : Serializer<string>
     {
-        public override string Deserialize(BinaryReader reader, SerializedAttribute attribute)
+        public override string Deserialize(MemoryReader reader, SerializedAttribute attribute)
         {
             int max = attribute?.Max >= 0 ? attribute.Max : 0x1000000;
             return reader.ReadVarString(max);
         }
 
-        public override void Serialize(BinaryWriter writer, string value)
+        public override void Serialize(MemoryWriter writer, string value)
         {
             writer.WriteVarString(value);
         }

--- a/src/neo/IO/Serialization/UnmanagedSerializer.cs
+++ b/src/neo/IO/Serialization/UnmanagedSerializer.cs
@@ -1,21 +1,19 @@
 using System;
-using System.IO;
 
 namespace Neo.IO.Serialization
 {
     public class UnmanagedSerializer<T> : Serializer<T> where T : unmanaged
     {
-        public unsafe override T Deserialize(BinaryReader reader, SerializedAttribute attribute)
+        public unsafe override T Deserialize(MemoryReader reader, SerializedAttribute attribute)
         {
-            Span<byte> buffer = stackalloc byte[sizeof(T)];
-            reader.FillBuffer(buffer);
-            fixed (byte* p = buffer)
+            ReadOnlyMemory<byte> buffer = reader.ReadBytes(sizeof(T));
+            fixed (byte* p = buffer.Span)
             {
                 return *(T*)p;
             }
         }
 
-        public unsafe override void Serialize(BinaryWriter writer, T value)
+        public unsafe override void Serialize(MemoryWriter writer, T value)
         {
             ReadOnlySpan<byte> buffer = new ReadOnlySpan<byte>(&value, sizeof(T));
             writer.Write(buffer);

--- a/src/neo/IO/Serialization/UnmanagedSerializer.cs
+++ b/src/neo/IO/Serialization/UnmanagedSerializer.cs
@@ -1,0 +1,24 @@
+using System;
+using System.IO;
+
+namespace Neo.IO.Serialization
+{
+    public class UnmanagedSerializer<T> : Serializer<T> where T : unmanaged
+    {
+        public unsafe override T Deserialize(BinaryReader reader, SerializedAttribute attribute)
+        {
+            Span<byte> buffer = stackalloc byte[sizeof(T)];
+            reader.FillBuffer(buffer);
+            fixed (byte* p = buffer)
+            {
+                return *(T*)p;
+            }
+        }
+
+        public unsafe override void Serialize(BinaryWriter writer, T value)
+        {
+            ReadOnlySpan<byte> buffer = new ReadOnlySpan<byte>(&value, sizeof(T));
+            writer.Write(buffer);
+        }
+    }
+}

--- a/src/neo/IO/Serialization/UnmanagedSerializer.cs
+++ b/src/neo/IO/Serialization/UnmanagedSerializer.cs
@@ -1,3 +1,4 @@
+using Neo.IO.Json;
 using System;
 
 namespace Neo.IO.Serialization
@@ -13,10 +14,20 @@ namespace Neo.IO.Serialization
             }
         }
 
+        public override T FromJson(JObject json, SerializedAttribute attribute)
+        {
+            return (T)Convert.ChangeType(json.AsNumber(), typeof(T));
+        }
+
         public unsafe override void Serialize(MemoryWriter writer, T value)
         {
             ReadOnlySpan<byte> buffer = new ReadOnlySpan<byte>(&value, sizeof(T));
             writer.Write(buffer);
+        }
+
+        public override JObject ToJson(T value)
+        {
+            return (double)Convert.ChangeType(value, typeof(double));
         }
     }
 }

--- a/src/neo/IO/Serialization/VarIntSerializer.cs
+++ b/src/neo/IO/Serialization/VarIntSerializer.cs
@@ -3,7 +3,7 @@ using System.Buffers.Binary;
 
 namespace Neo.IO.Serialization
 {
-    public class VarIntSerializer<T> : Serializer<T> where T : unmanaged
+    public class VarIntSerializer<T> : UnmanagedSerializer<T> where T : unmanaged
     {
         public unsafe override T Deserialize(MemoryReader reader, SerializedAttribute attribute)
         {

--- a/src/neo/IO/Serialization/VarIntSerializer.cs
+++ b/src/neo/IO/Serialization/VarIntSerializer.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Buffers.Binary;
+using System.IO;
+
+namespace Neo.IO.Serialization
+{
+    public class VarIntSerializer<T> : Serializer<T> where T : unmanaged
+    {
+        public unsafe override T Deserialize(BinaryReader reader, SerializedAttribute attribute)
+        {
+            long max = attribute?.Max >= 0 ? attribute.Max : long.MaxValue;
+            ulong value = reader.ReadVarInt((ulong)max);
+            return *(T*)&value;
+        }
+
+        public unsafe override void Serialize(BinaryWriter writer, T value)
+        {
+            ReadOnlySpan<byte> buffer = new ReadOnlySpan<byte>(&value, sizeof(T));
+            long number = buffer.Length switch
+            {
+                1 => buffer[0],
+                2 => BinaryPrimitives.ReadUInt16LittleEndian(buffer),
+                4 => BinaryPrimitives.ReadUInt32LittleEndian(buffer),
+                8 => BinaryPrimitives.ReadInt64LittleEndian(buffer),
+                _ => throw new NotSupportedException()
+            };
+            writer.WriteVarInt(number);
+        }
+    }
+}

--- a/src/neo/IO/Serialization/VarIntSerializer.cs
+++ b/src/neo/IO/Serialization/VarIntSerializer.cs
@@ -1,19 +1,18 @@
 using System;
 using System.Buffers.Binary;
-using System.IO;
 
 namespace Neo.IO.Serialization
 {
     public class VarIntSerializer<T> : Serializer<T> where T : unmanaged
     {
-        public unsafe override T Deserialize(BinaryReader reader, SerializedAttribute attribute)
+        public unsafe override T Deserialize(MemoryReader reader, SerializedAttribute attribute)
         {
             long max = attribute?.Max >= 0 ? attribute.Max : long.MaxValue;
             ulong value = reader.ReadVarInt((ulong)max);
             return *(T*)&value;
         }
 
-        public unsafe override void Serialize(BinaryWriter writer, T value)
+        public unsafe override void Serialize(MemoryWriter writer, T value)
         {
             ReadOnlySpan<byte> buffer = new ReadOnlySpan<byte>(&value, sizeof(T));
             long number = buffer.Length switch

--- a/src/neo/IO/Serialization/VarIntSerializer.cs
+++ b/src/neo/IO/Serialization/VarIntSerializer.cs
@@ -3,7 +3,7 @@ using System.Buffers.Binary;
 
 namespace Neo.IO.Serialization
 {
-    public class VarIntSerializer<T> : UnmanagedSerializer<T> where T : unmanaged
+    public sealed class VarIntSerializer<T> : UnmanagedSerializer<T> where T : unmanaged
     {
         public unsafe override T Deserialize(MemoryReader reader, SerializedAttribute attribute)
         {


### PR DESCRIPTION
Redesigned the object serialization scheme using reflection.

1. Don't worry about performance, because all reflections will only be executed once. It will be read from the cache later.
2. Object creation and property assignment use precompiled expression trees, which makes them almost the same speed as direct creation and assignment.
3. We don't need to add the `Serialize()` and `Deserialize()` methods for each class, just let it implement the `ISerializable` interface and add the `Serialized` attribute for each property that needs to be serialized. The new serializer will automatically perform serialization and deserialization.

@neo-project/core What do you think? If you think it's good, I will complete it.