### PR TITLE
Fix #1834

### DIFF
--- a/src/neo/Consensus/ConsensusContext.cs
+++ b/src/neo/Consensus/ConsensusContext.cs
@@ -59,7 +59,7 @@ namespace Neo.Consensus
         {
             get
             {
-                if (LastSeenMessage == null || Block.Index <= 1) return 0;
+                if (LastSeenMessage == null) return 0;
                 return Validators.Count(p => !LastSeenMessage.TryGetValue(p, out var value) || value < (Block.Index - 1));
             }
         }

--- a/src/neo/Consensus/ConsensusService.cs
+++ b/src/neo/Consensus/ConsensusService.cs
@@ -291,7 +291,7 @@ namespace Neo.Consensus
             {
                 return;
             }
-            context.LastSeenMessage[context.Validators[payload.ValidatorIndex]] = (int)payload.BlockIndex;
+            context.LastSeenMessage[context.Validators[payload.ValidatorIndex]] = payload.BlockIndex;
             foreach (IP2PPlugin plugin in Plugin.P2PPlugins)
                 if (!plugin.OnConsensusMessage(payload))
                     return;

--- a/tests/neo.UnitTests/Consensus/UT_Consensus.cs
+++ b/tests/neo.UnitTests/Consensus/UT_Consensus.cs
@@ -170,10 +170,6 @@ namespace Neo.UnitTests.Consensus
             Console.WriteLine("Forcing Failed nodes for recovery request... ");
             mockContext.Object.CountFailed.Should().Be(0);
             mockContext.Object.LastSeenMessage.Clear();
-            foreach (var validator in mockContext.Object.Validators)
-            {
-                mockContext.Object.LastSeenMessage[validator] = -1;
-            }
             mockContext.Object.CountFailed.Should().Be(7);
             Console.WriteLine("\nWaiting for recovery due to failed nodes... ");
             var backupOnRecoveryDueToFailedNodes = subscriber.ExpectMsg<LocalNode.SendDirectly>();
@@ -275,10 +271,6 @@ namespace Neo.UnitTests.Consensus
             Console.WriteLine($"Generated keypairs PKey:");
             //refresh LastSeenMessage
             mockContext.Object.LastSeenMessage.Clear();
-            foreach (var item in mockContext.Object.Validators)
-            {
-                mockContext.Object.LastSeenMessage[item] = -1;
-            }
             for (int i = 0; i < mockContext.Object.Validators.Length; i++)
                 Console.WriteLine($"{mockContext.Object.Validators[i]}/{Contract.CreateSignatureContract(mockContext.Object.Validators[i]).ScriptHash}");
             var updatedContract = Contract.CreateMultiSigContract(mockContext.Object.M, mockContext.Object.Validators);
@@ -398,10 +390,6 @@ namespace Neo.UnitTests.Consensus
             Console.WriteLine($"\nModifying CountFailed and asserting 7...");
             // This will ensure a non-deterministic behavior after last recovery
             mockContext.Object.LastSeenMessage.Clear();
-            foreach (var validator in mockContext.Object.Validators)
-            {
-                mockContext.Object.LastSeenMessage[validator] = -1;
-            }
             mockContext.Object.CountFailed.Should().Be(7);
 
             TellConsensusPayload(actorConsensus, rmPayload);


### PR DESCRIPTION
We need to ensure that all the indexes can fit in LastSeenMessage, if we use a integer type, we have the half available chain.

Also, if heigh it's 0, `LastSeenMessage?.Count(p => Block.Index > 0 && p.Value < (Block.Index - 1)) ?? 0;` it will produce an integer overflow, and the condition always will be true.