### PR TITLE
Add incentive for committee

### DIFF
--- a/src/neo/SmartContract/Native/Tokens/NeoToken.cs
+++ b/src/neo/SmartContract/Native/Tokens/NeoToken.cs
@@ -98,6 +98,9 @@ namespace Neo.SmartContract.Native.Tokens
             base.OnPersist(engine);
             StorageItem storage = engine.Snapshot.Storages.GetAndChange(CreateStorageKey(Prefix_NextValidators), () => new StorageItem());
             storage.Value = GetValidators(engine.Snapshot).ToByteArray();
+
+            // Distribute GAS for committee
+            var committee = GetCommittee(engine.Snapshot);
         }
 
         [ContractMethod(0_03000000, CallFlags.AllowStates)]


### PR DESCRIPTION
The additional GAS allocation is as follows:

- _10% will be distributed to all NEO holders according to the weight of NEO._
- **5% divided equally among 21 members. (Implemented by this PR)**
- _85% will be allocated to the voters who voted for the top 21 nodes. The voters who voted for a consensus node are assigned 2/28 of this part according to the voting weight, and the voters who voted for a committee member (non-consensus node) are assigned 1/28 of this part according to the voting weight._