### PR TITLE
[master-2.x] Force sync state root from all peers

### DIFF
--- a/neo/Network/P2P/TaskManager.cs
+++ b/neo/Network/P2P/TaskManager.cs
@@ -57,14 +57,11 @@ namespace Neo.Network.P2P
 
         private void OnInternalTaskCompleted(UInt256 hash)
         {
-            if (hash != StateRootTaskHash)
-            {
-                if (!sessions.TryGetValue(Sender, out TaskSession session))
-                    return;
-                session.Tasks.Remove(hash);
-                RequestTasks(session);
-            }
+            if (!sessions.TryGetValue(Sender, out TaskSession session))
+                return;
+            if (hash != StateRootTaskHash) session.Tasks.Remove(hash);
             DecrementGlobalTask(hash);
+            RequestTasks(session);
         }
 
         private void OnNewTasks(InvPayload payload)

--- a/neo/Network/P2P/TaskManager.cs
+++ b/neo/Network/P2P/TaskManager.cs
@@ -284,11 +284,11 @@ namespace Neo.Network.P2P
             {
                 if (Blockchain.Singleton.ExpectStateRootIndex < Blockchain.Singleton.Height)
                 {
-                      var start_index = Blockchain.Singleton.ExpectStateRootIndex;
-                      var count = Math.Min(Blockchain.Singleton.Height - start_index, StateRootsPayload.MaxStateRootsCount);
-                      StateRootSyncTime = DateTime.UtcNow;
-                      IncrementGlobalTask(StateRootTaskHash);
-                      system.LocalNode.Tell(Message.Create("getroots", GetStateRootsPayload.Create(start_index, count)));
+                    var start_index = Blockchain.Singleton.ExpectStateRootIndex;
+                    var count = Math.Min(Blockchain.Singleton.Height - start_index, StateRootsPayload.MaxStateRootsCount);
+                    StateRootSyncTime = DateTime.UtcNow;
+                    IncrementGlobalTask(StateRootTaskHash);
+                    system.LocalNode.Tell(Message.Create("getroots", GetStateRootsPayload.Create(start_index, count)));
                 }
             }
         }

--- a/neo/Network/P2P/TaskManager.cs
+++ b/neo/Network/P2P/TaskManager.cs
@@ -289,15 +289,11 @@ namespace Neo.Network.P2P
                 var height = Blockchain.Singleton.Height;
                 if (state_height + 1 < height)
                 {
-                    var state = Blockchain.Singleton.GetStateRoot((uint)(state_height + 1));
-                    if (state is null || state.Flag == StateRootVerifyFlag.Unverified)
-                    {
-                        var start_index = (uint)(state_height + 1);
-                        var count = Math.Min(height - start_index, StateRootsPayload.MaxStateRootsCount);
-                        StateRootSyncTime = DateTime.UtcNow;
-                        IncrementGlobalTask(StateRootTaskHash);
-                        system.LocalNode.Tell(Message.Create("getroots", GetStateRootsPayload.Create(start_index, count)));
-                    }
+                    var start_index = (uint)(state_height + 1);
+                    var count = Math.Min(height - start_index, StateRootsPayload.MaxStateRootsCount);
+                    StateRootSyncTime = DateTime.UtcNow;
+                    IncrementGlobalTask(StateRootTaskHash);
+                    system.LocalNode.Tell(Message.Create("getroots", GetStateRootsPayload.Create(start_index, count)));
                 }
             }
         }

--- a/neo/Network/P2P/TaskManager.cs
+++ b/neo/Network/P2P/TaskManager.cs
@@ -59,7 +59,7 @@ namespace Neo.Network.P2P
         {
             if (!sessions.TryGetValue(Sender, out TaskSession session))
                 return;
-            if (hash != StateRootTaskHash) session.Tasks.Remove(hash);
+            session.Tasks.Remove(hash);
             DecrementGlobalTask(hash);
             RequestTasks(session);
         }


### PR DESCRIPTION
Fix root sync slowly in `mast-2.x`, especially many peers are `2.10.3`.

 * Treat state root sync task as global task
 * Ask all connected peers when get state roots

 > Risk: peers will do repeated work and node will receive some redundant messages from different peers.