### PR TITLE
Support null PersistingBlock in NeoToken.DistributeGas 

### DIFF
--- a/src/neo/SmartContract/Native/Tokens/NeoToken.cs
+++ b/src/neo/SmartContract/Native/Tokens/NeoToken.cs
@@ -56,6 +56,9 @@ namespace Neo.SmartContract.Native.Tokens
 
         private void DistributeGas(ApplicationEngine engine, UInt160 account, NeoAccountState state)
         {
+            // PersistingBlock is null when running under the debugger
+            if (engine.Snapshot.PersistingBlock == null) return;
+
             BigInteger gas = CalculateBonus(engine.Snapshot, state.Balance, state.BalanceHeight, engine.Snapshot.PersistingBlock.Index);
             state.BalanceHeight = engine.Snapshot.PersistingBlock.Index;
             GAS.Mint(engine, account, gas);


### PR DESCRIPTION
When running under the debugger, engine.Snapshot.PersistingBlock will be null. This leads to a null ref exception in NeoToken.DistributeGas. This change updates NeoToken.DistributeGas to be a no-op instead of throwing an exception when engine.Snapshot.PersistingBlock is null.