### PR TITLE
Add cache for recent on chain transaction hashes

### DIFF
--- a/src/neo/IO/Caching/HashCache.cs
+++ b/src/neo/IO/Caching/HashCache.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Collections.Generic;
+
+namespace Neo.IO.Caching
+{
+    public class HashCache<T> where T : IEquatable<T>
+    {
+        /// <summary>
+        /// Sets where the Hashes are stored
+        /// </summary>      
+        private readonly LinkedList<HashSet<T>> sets = new LinkedList<HashSet<T>>();
+
+        /// <summary>
+        /// Maximum number of buckets for the LinkedList, meaning its maximum cardinality.
+        /// </summary>
+        private readonly int maxBucketCount;
+
+        public int Depth => sets.Count;
+
+        public HashCache(int maxBucketCount = 10)
+        {
+            if (maxBucketCount <= 0) throw new ArgumentOutOfRangeException($"{nameof(maxBucketCount)} should be greater than 0");
+
+            this.maxBucketCount = maxBucketCount;
+            sets.AddFirst(new HashSet<T>());
+        }
+
+        public bool Add(T item)
+        {
+            //if (Contains(item)) return false;
+            return sets.First.Value.Add(item);
+        }
+
+        public bool Contains(T item)
+        {
+            foreach (var set in sets)
+            {
+                if (set.Contains(item)) return true;
+            }
+            return false;
+        }
+
+        public void Refresh ()
+        {
+            var newSet = new HashSet<T>();
+            sets.AddFirst(newSet);
+            if (sets.Count > maxBucketCount)
+            {
+                sets.RemoveLast();
+            }
+        }
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            foreach (var set in sets)
+            {
+                foreach (var item in set)
+                {
+                    yield return item;
+                }
+            }
+        }
+    }
+}

--- a/src/neo/IO/Caching/HashCache.cs
+++ b/src/neo/IO/Caching/HashCache.cs
@@ -27,7 +27,6 @@ namespace Neo.IO.Caching
 
         public bool Add(T item)
         {
-            //if (Contains(item)) return false;
             return sets.First.Value.Add(item);
         }
 

--- a/src/neo/IO/Caching/HashCache.cs
+++ b/src/neo/IO/Caching/HashCache.cs
@@ -40,7 +40,7 @@ namespace Neo.IO.Caching
             return false;
         }
 
-        public void Refresh ()
+        public void Refresh()
         {
             var newSet = new HashSet<T>();
             sets.AddFirst(newSet);

--- a/src/neo/Wallets/Wallet.cs
+++ b/src/neo/Wallets/Wallet.cs
@@ -341,6 +341,7 @@ namespace Neo.Wallets
                     Nonce = (uint)rand.Next(),
                     Script = script,
                     ValidUntilBlock = snapshot.Height + Transaction.MaxValidUntilBlockIncrement,
+                    LastBlockHash = snapshot.CurrentBlockHash,
                     Signers = GetSigners(account, cosigners),
                     Attributes = attributes,
                 };

--- a/tests/neo.UnitTests/Ledger/UT_Blockchain.cs
+++ b/tests/neo.UnitTests/Ledger/UT_Blockchain.cs
@@ -66,20 +66,20 @@ namespace Neo.UnitTests.Ledger
         [TestMethod]
         public void TestContainsTransaction()
         {
-            Blockchain.Singleton.ContainsTransaction(UInt256.Zero).Should().BeFalse();
-            Blockchain.Singleton.ContainsTransaction(txSample.Hash).Should().BeTrue();
+            Blockchain.Singleton.ContainsTransaction(UInt256.Zero, 0).Should().BeFalse();
+            Blockchain.Singleton.ContainsTransaction(txSample.Hash, 0).Should().BeTrue();
         }
 
         [TestMethod]
         public void TestGetCurrentBlockHash()
         {
-            Blockchain.Singleton.CurrentBlockHash.Should().Be(UInt256.Parse("0xecaee33262f1bc7c7c28f2b25b54a5d61d50670871f45c0c6fe755a40cbde4a8"));
+            Blockchain.Singleton.CurrentBlockHash.Should().Be(UInt256.Parse("0x04656ca14f0f80cb936012246d7f12e4b8b5366feccab356533564b004c7c592"));
         }
 
         [TestMethod]
         public void TestGetCurrentHeaderHash()
         {
-            Blockchain.Singleton.CurrentHeaderHash.Should().Be(UInt256.Parse("0xecaee33262f1bc7c7c28f2b25b54a5d61d50670871f45c0c6fe755a40cbde4a8"));
+            Blockchain.Singleton.CurrentHeaderHash.Should().Be(UInt256.Parse("0x04656ca14f0f80cb936012246d7f12e4b8b5366feccab356533564b004c7c592"));
         }
 
         [TestMethod]
@@ -91,7 +91,7 @@ namespace Neo.UnitTests.Ledger
         [TestMethod]
         public void TestGetBlockHash()
         {
-            Blockchain.Singleton.GetBlockHash(0).Should().Be(UInt256.Parse("0xecaee33262f1bc7c7c28f2b25b54a5d61d50670871f45c0c6fe755a40cbde4a8"));
+            Blockchain.Singleton.GetBlockHash(0).Should().Be(UInt256.Parse("0x04656ca14f0f80cb936012246d7f12e4b8b5366feccab356533564b004c7c592"));
             Blockchain.Singleton.GetBlockHash(10).Should().BeNull();
         }
 

--- a/tests/neo.UnitTests/Ledger/UT_PoolItem.cs
+++ b/tests/neo.UnitTests/Ledger/UT_PoolItem.cs
@@ -35,10 +35,10 @@ namespace Neo.UnitTests.Ledger
         [TestMethod]
         public void PoolItem_CompareTo_Fee()
         {
-            int size1 = 51;
+            int size1 = 83;
             int netFeeSatoshi1 = 1;
             var tx1 = GenerateTx(netFeeSatoshi1, size1);
-            int size2 = 51;
+            int size2 = 83;
             int netFeeSatoshi2 = 2;
             var tx2 = GenerateTx(netFeeSatoshi2, size2);
 
@@ -55,7 +55,7 @@ namespace Neo.UnitTests.Ledger
         [TestMethod]
         public void PoolItem_CompareTo_Hash()
         {
-            int sizeFixed = 51;
+            int sizeFixed = 83;
             int netFeeSatoshiFixed = 1;
 
             var tx1 = GenerateTxWithFirstByteOfHashGreaterThanOrEqualTo(0x80, netFeeSatoshiFixed, sizeFixed);

--- a/tests/neo.UnitTests/Ledger/UT_TransactionState.cs
+++ b/tests/neo.UnitTests/Ledger/UT_TransactionState.cs
@@ -61,7 +61,7 @@ namespace Neo.UnitTests.Ledger
         [TestMethod]
         public void TestGetSize()
         {
-            ((ISerializable)origin).Size.Should().Be(63);
+            ((ISerializable)origin).Size.Should().Be(95);
         }
     }
 }

--- a/tests/neo.UnitTests/Network/P2P/Payloads/UT_Block.cs
+++ b/tests/neo.UnitTests/Network/P2P/Payloads/UT_Block.cs
@@ -59,7 +59,7 @@ namespace Neo.UnitTests.Network.P2P.Payloads
                 TestUtils.GetTransaction(UInt160.Zero)
             };
 
-            uut.Size.Should().Be(167);
+            uut.Size.Should().Be(199);
         }
 
         [TestMethod]
@@ -75,7 +75,7 @@ namespace Neo.UnitTests.Network.P2P.Payloads
                 TestUtils.GetTransaction(UInt160.Zero)
             };
 
-            uut.Size.Should().Be(273);
+            uut.Size.Should().Be(369);
         }
 
         [TestMethod]
@@ -84,7 +84,7 @@ namespace Neo.UnitTests.Network.P2P.Payloads
             UInt256 val256 = UInt256.Zero;
             TestUtils.SetupBlockWithValues(uut, val256, out var _, out var _, out var _, out var _, out var _, out var _, 1);
 
-            var hex = "000000000000000000000000000000000000000000000000000000000000000000000000add6632f6f3d29cdf94555bb191fb5296683e5446f9937c56bb94c8608023044e913ff854c00000000000000000000000000000000000000000000000000000001000111020000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000001000100010000";
+            var hex = "00000000000000000000000000000000000000000000000000000000000000000000000092cc2ac42bc71e3f1a53f8edeb6a7b001499f2161416ce6b91aac88466b1a249e913ff854c000000000000000000000000000000000000000000000000000000010001110200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000001000100010000";
             uut.ToArray().ToHexString().Should().Be(hex);
         }
 
@@ -94,7 +94,7 @@ namespace Neo.UnitTests.Network.P2P.Payloads
             UInt256 val256 = UInt256.Zero;
             TestUtils.SetupBlockWithValues(new Block(), val256, out var merkRoot, out var val160, out var timestampVal, out var indexVal, out var scriptVal, out var transactionsVal, 1);
 
-            var hex = "000000000000000000000000000000000000000000000000000000000000000000000000add6632f6f3d29cdf94555bb191fb5296683e5446f9937c56bb94c8608023044e913ff854c00000000000000000000000000000000000000000000000000000001000111020000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000001000100010000";
+            var hex = "00000000000000000000000000000000000000000000000000000000000000000000000092cc2ac42bc71e3f1a53f8edeb6a7b001499f2161416ce6b91aac88466b1a249e913ff854c000000000000000000000000000000000000000000000000000000010001110200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000001000100010000";
 
             using (MemoryStream ms = new MemoryStream(hex.HexToBytes(), false))
             using (BinaryReader reader = new BinaryReader(ms))
@@ -199,11 +199,11 @@ namespace Neo.UnitTests.Network.P2P.Payloads
 
             JObject jObj = uut.ToJson();
             jObj.Should().NotBeNull();
-            jObj["hash"].AsString().Should().Be("0x9a164d5b9a1ab8745c97dbaaaef8eb30b0d80a00205acdc82daf502bee69bc20");
-            jObj["size"].AsNumber().Should().Be(167);
+            jObj["hash"].AsString().Should().Be("0x70b9f744c43ec6db3b048fad4f433e4baa8b4daa48f17fd5faa1a9396aaf07d5");
+            jObj["size"].AsNumber().Should().Be(199);
             jObj["version"].AsNumber().Should().Be(0);
             jObj["previousblockhash"].AsString().Should().Be("0x0000000000000000000000000000000000000000000000000000000000000000");
-            jObj["merkleroot"].AsString().Should().Be("0x44300208864cb96bc537996f44e5836629b51f19bb5545f9cd293d6f2f63d6ad");
+            jObj["merkleroot"].AsString().Should().Be("0x49a2b16684c8aa916bce161416f29914007b6aebedf8531a3f1ec72bc42acc92");
             jObj["time"].AsNumber().Should().Be(328665601001);
             jObj["index"].AsNumber().Should().Be(0);
             jObj["nextconsensus"].AsString().Should().Be("NKuyBkoGdZZSLyPbJEetheRhMjeznFZszf");
@@ -214,8 +214,8 @@ namespace Neo.UnitTests.Network.P2P.Payloads
 
             jObj["tx"].Should().NotBeNull();
             JArray txObj = (JArray)jObj["tx"];
-            txObj[0]["hash"].AsString().Should().Be("0x995ce8ff19c30f6b0d6b03e5ed8bd30b08027c92177923782d3a64f573421931");
-            txObj[0]["size"].AsNumber().Should().Be(53);
+            txObj[0]["hash"].AsString().Should().Be("0xafce5f1d3a752e13bf166fe66db0131fa5e0138c2e1327febdf87af0760dee1f");
+            txObj[0]["size"].AsNumber().Should().Be(85);
             txObj[0]["version"].AsNumber().Should().Be(0);
             ((JArray)txObj[0]["attributes"]).Count.Should().Be(0);
             txObj[0]["netfee"].AsString().Should().Be("0");

--- a/tests/neo.UnitTests/Network/P2P/Payloads/UT_Transaction.cs
+++ b/tests/neo.UnitTests/Network/P2P/Payloads/UT_Transaction.cs
@@ -97,7 +97,7 @@ namespace Neo.UnitTests.Network.P2P.Payloads
             uut.Version.Should().Be(0);
             uut.Script.Length.Should().Be(32);
             uut.Script.GetVarSize().Should().Be(33);
-            uut.Size.Should().Be(63);
+            uut.Size.Should().Be(95);
         }
 
         [TestMethod]
@@ -177,8 +177,8 @@ namespace Neo.UnitTests.Network.P2P.Payloads
 
                 var sizeGas = tx.Size * NativeContract.Policy.GetFeePerByte(snapshot);
                 Assert.AreEqual(2000810, verificationGas);
-                Assert.AreEqual(347000, sizeGas);
-                Assert.AreEqual(2347810, tx.NetworkFee);
+                Assert.AreEqual(379000, sizeGas);
+                Assert.AreEqual(2379810, tx.NetworkFee);
             }
         }
 
@@ -219,7 +219,7 @@ namespace Neo.UnitTests.Network.P2P.Payloads
                 Assert.IsNull(tx.Witnesses);
 
                 // check pre-computed network fee (already guessing signature sizes)
-                tx.NetworkFee.Should().Be(1244390L);
+                tx.NetworkFee.Should().Be(1276390L);
 
                 // ----
                 // Sign
@@ -261,12 +261,12 @@ namespace Neo.UnitTests.Network.P2P.Payloads
                 // ------------------
                 // check tx_size cost
                 // ------------------
-                Assert.AreEqual(244, tx.Size);
+                Assert.AreEqual(276, tx.Size);
 
                 // will verify tx size, step by step
 
                 // Part I
-                Assert.AreEqual(25, Transaction.HeaderSize);
+                Assert.AreEqual(57, Transaction.HeaderSize);
                 // Part II
                 Assert.AreEqual(1, tx.Attributes.GetVarSize());
                 Assert.AreEqual(0, tx.Attributes.Length);
@@ -278,13 +278,13 @@ namespace Neo.UnitTests.Network.P2P.Payloads
                 // Part IV
                 Assert.AreEqual(110, tx.Witnesses.GetVarSize());
                 // I + II + III + IV
-                Assert.AreEqual(25 + 22 + 1 + 86 + 110, tx.Size);
+                Assert.AreEqual(25 + 22 + 1 + 86 + 110 + 32, tx.Size);
 
                 Assert.AreEqual(1000, NativeContract.Policy.GetFeePerByte(snapshot));
                 var sizeGas = tx.Size * NativeContract.Policy.GetFeePerByte(snapshot);
 
                 // final check: verification_cost and tx_size
-                Assert.AreEqual(244000, sizeGas);
+                Assert.AreEqual(276000, sizeGas);
                 Assert.AreEqual(1000390, verificationGas);
 
                 // final assert
@@ -372,7 +372,7 @@ namespace Neo.UnitTests.Network.P2P.Payloads
                 // get sizeGas
                 var sizeGas = tx.Size * NativeContract.Policy.GetFeePerByte(snapshot);
                 // final check on sum: verification_cost + tx_size
-                Assert.AreEqual(1244390, verificationGas + sizeGas);
+                Assert.AreEqual(1276390, verificationGas + sizeGas);
                 // final assert
                 Assert.AreEqual(tx.NetworkFee, verificationGas + sizeGas);
             }
@@ -459,7 +459,7 @@ namespace Neo.UnitTests.Network.P2P.Payloads
                 // get sizeGas
                 var sizeGas = tx.Size * NativeContract.Policy.GetFeePerByte(snapshot);
                 // final check on sum: verification_cost + tx_size
-                Assert.AreEqual(1265390, verificationGas + sizeGas);
+                Assert.AreEqual(1297390, verificationGas + sizeGas);
                 // final assert
                 Assert.AreEqual(tx.NetworkFee, verificationGas + sizeGas);
             }
@@ -549,7 +549,7 @@ namespace Neo.UnitTests.Network.P2P.Payloads
                 // get sizeGas
                 var sizeGas = tx.Size * NativeContract.Policy.GetFeePerByte(snapshot);
                 // final check on sum: verification_cost + tx_size
-                Assert.AreEqual(1265390, verificationGas + sizeGas);
+                Assert.AreEqual(1297390, verificationGas + sizeGas);
                 // final assert
                 Assert.AreEqual(tx.NetworkFee, verificationGas + sizeGas);
             }
@@ -691,7 +691,7 @@ namespace Neo.UnitTests.Network.P2P.Payloads
                 // get sizeGas
                 var sizeGas = tx.Size * NativeContract.Policy.GetFeePerByte(snapshot);
                 // final check on sum: verification_cost + tx_size
-                Assert.AreEqual(1285390, verificationGas + sizeGas);
+                Assert.AreEqual(1317390, verificationGas + sizeGas);
                 // final assert
                 Assert.AreEqual(tx.NetworkFee, verificationGas + sizeGas);
             }
@@ -787,6 +787,7 @@ namespace Neo.UnitTests.Network.P2P.Payloads
                 SystemFee = (long)BigInteger.Pow(10, 8), // 1 GAS 
                 NetworkFee = 0x0000000000000001,
                 ValidUntilBlock = 0x01020304,
+                LastBlockHash = UInt256.Zero,
                 Signers = new Signer[] { new Signer() { Account = UInt160.Zero } },
                 Attributes = Array.Empty<TransactionAttribute>(),
                 Script = new byte[] { (byte)OpCode.PUSH1 },
@@ -801,7 +802,8 @@ namespace Neo.UnitTests.Network.P2P.Payloads
                 "04030201" + // nonce
                 "00e1f50500000000" + // system fee (1 GAS)
                 "0100000000000000" + // network fee (1 satoshi)
-                "04030201" + // timelimit 
+                "04030201" + // timelimit
+                "0000000000000000000000000000000000000000000000000000000000000000" + // lastblockhash
                 "01000000000000000000000000000000000000000000" + // empty signer
                 "00" + // no attributes
                 "0111" + // push1 script
@@ -862,7 +864,7 @@ namespace Neo.UnitTests.Network.P2P.Payloads
             byte[] sTx = txDoubleCosigners.ToArray();
 
             // no need for detailed hexstring here (see basic tests for it)
-            sTx.ToHexString().Should().Be("000403020100e1f505000000000100000000000000040302010209080706050403020100090807060504030201008009080706050403020100090807060504030201000100011100");
+            sTx.ToHexString().Should().Be("000403020100e1f5050000000001000000000000000403020100000000000000000000000000000000000000000000000000000000000000000209080706050403020100090807060504030201008009080706050403020100090807060504030201000100011100");
 
             // back to transaction (should fail, due to non-distinct cosigners)
             Transaction tx2 = null;
@@ -1041,7 +1043,7 @@ namespace Neo.UnitTests.Network.P2P.Payloads
                 // get sizeGas
                 var sizeGas = tx.Size * NativeContract.Policy.GetFeePerByte(snapshot);
                 // final check on sum: verification_cost + tx_size
-                Assert.AreEqual(1244390, verificationGas + sizeGas);
+                Assert.AreEqual(1276390, verificationGas + sizeGas);
                 // final assert
                 Assert.AreEqual(tx.NetworkFee, verificationGas + sizeGas);
             }
@@ -1065,8 +1067,8 @@ namespace Neo.UnitTests.Network.P2P.Payloads
 
             JObject jObj = uut.ToJson();
             jObj.Should().NotBeNull();
-            jObj["hash"].AsString().Should().Be("0xe17382d26702bde77b00a9f23ea156b77c418764cbc45b2692088b5fde0336e3");
-            jObj["size"].AsNumber().Should().Be(84);
+            jObj["hash"].AsString().Should().Be("0xbfc45132f97aa923cc17fa2906ae2d2312107d3d94a2668a28a778ac2e04b5d6");
+            jObj["size"].AsNumber().Should().Be(116);
             jObj["version"].AsNumber().Should().Be(0);
             ((JArray)jObj["attributes"]).Count.Should().Be(0);
             jObj["netfee"].AsString().Should().Be("0");
@@ -1159,9 +1161,14 @@ namespace Neo.UnitTests.Network.P2P.Payloads
                 Signers = new Signer[] { new Signer() { Account = UInt160.Zero } },
                 SystemFee = 0,
                 ValidUntilBlock = snapshot.Height + 1,
+                LastBlockHash = UInt256.Zero,
                 Version = 0,
                 Witnesses = new Witness[0],
             };
+            tx.VerifyStateDependent(snapshot, new TransactionVerificationContext()).Should().Be(VerifyResult.Invalid);
+            tx.LastBlockHash = snapshot.CurrentBlockHash;
+            tx.VerifyStateDependent(snapshot, new TransactionVerificationContext()).Should().Be(VerifyResult.Invalid);
+            tx.ValidUntilBlock = snapshot.Height + Transaction.MaxValidUntilBlockIncrement;
             tx.VerifyStateDependent(snapshot, new TransactionVerificationContext()).Should().Be(VerifyResult.Invalid);
             tx.SystemFee = 10;
             tx.VerifyStateDependent(snapshot, new TransactionVerificationContext()).Should().Be(VerifyResult.InsufficientFunds);

--- a/tests/neo.UnitTests/SmartContract/UT_ContractParameterContext.cs
+++ b/tests/neo.UnitTests/SmartContract/UT_ContractParameterContext.cs
@@ -45,13 +45,13 @@ namespace Neo.UnitTests.SmartContract
             var context = new ContractParametersContext(tx);
             context.Add(contract, 0, new byte[] { 0x01 });
             string str = context.ToString();
-            str.Should().Be(@"{""type"":""Neo.Network.P2P.Payloads.Transaction"",""hex"":""AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFmUJDLobcPtqo9vZKIdjXsd8fVGwEAAQA="",""items"":{}}");
+            str.Should().Be(@"{""type"":""Neo.Network.P2P.Payloads.Transaction"",""hex"":""AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWZQkMuhtw\u002B2qj29koh2Nex3x9UbAQABAA=="",""items"":{}}");
         }
 
         [TestMethod]
         public void TestParse()
         {
-            var ret = ContractParametersContext.Parse("{\"type\":\"Neo.Network.P2P.Payloads.Transaction\",\"hex\":\"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFmUJDLobcPtqo9vZKIdjXsd8fVGwEAAQA=\",\"items\":{\"0xbecaad15c0ea585211faf99738a4354014f177f2\":{\"script\":\"IQJv8DuUkkHOHa3UNRnmlg4KhbQaaaBcMoEDqivOFZTKFmh0dHaq\",\"parameters\":[{\"type\":\"Signature\",\"value\":\"AQ==\"}]}}}");
+            var ret = ContractParametersContext.Parse("{\"type\":\"Neo.Network.P2P.Payloads.Transaction\",\"hex\":\"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWZQkMuhtw\u002B2qj29koh2Nex3x9UbAQABAA==\",\"items\":{\"0xbecaad15c0ea585211faf99738a4354014f177f2\":{\"script\":\"IQJv8DuUkkHOHa3UNRnmlg4KhbQaaaBcMoEDqivOFZTKFmh0dHaq\",\"parameters\":[{\"type\":\"Signature\",\"value\":\"AQ==\"}]}}}");
             ret.ScriptHashes[0].ToString().Should().Be("0x1bd5c777ec35768892bd3daab60fb7a1cb905066");
             ((Transaction)ret.Verifiable).Script.ToHexString().Should().Be(new byte[1].ToHexString());
         }


### PR DESCRIPTION
Partially Close #1734.

In this PR a new feature, `UInt256 LastBlockHash` is added to class Transaction, to work together with `uint ValidUntilBlock` to prove that transaction sender provides an honest ValidUntilBlock. So that other people can be sure that this Transaction must be created no earlier than Height = ValidUntilBlock - MaxValidUntilBlockIncrement.

We can use this feature to judge whether we need to search this transaction only in cache to make sure no duplicate transactions will be onchain. Thus lots of time wasted in hard disk reading whilst DB searching, upon incoming transactions, will be saved.