### PR TITLE
Make ConsensusContext public (master-2.x)

### DIFF
--- a/neo/Consensus/ConsensusContext.cs
+++ b/neo/Consensus/ConsensusContext.cs
@@ -14,7 +14,7 @@ using System.Linq;
 
 namespace Neo.Consensus
 {
-    internal class ConsensusContext : IConsensusContext
+    public class ConsensusContext : IConsensusContext
     {
         private StateRoot PreviousBlockStateRoot;
         /// <summary>


### PR DESCRIPTION
neo express must duplicate ConsensusContext implementation for gas preload. If ConsensusContext was public, neo-express could simply use it