### PR TITLE
add magic parameter overloads to GetHashData and Sign

### DIFF
--- a/src/neo/Network/P2P/Helper.cs
+++ b/src/neo/Network/P2P/Helper.cs
@@ -1,3 +1,4 @@
+using Neo.Cryptography;
 using Neo.Network.P2P.Payloads;
 using System.IO;
 
@@ -20,6 +21,16 @@ namespace Neo.Network.P2P
                 writer.Flush();
                 return ms.ToArray();
             }
+        }
+
+        public static UInt256 CalculateHash(this IVerifiable verifiable)
+        {
+            return CalculateHash(verifiable, ProtocolSettings.Default.Magic);
+        }
+
+        public static UInt256 CalculateHash(this IVerifiable verifiable, uint magic)
+        {
+            return new UInt256(Crypto.Hash256(verifiable.GetHashData(magic)));
         }
     }
 }

--- a/src/neo/Network/P2P/Helper.cs
+++ b/src/neo/Network/P2P/Helper.cs
@@ -25,7 +25,7 @@ namespace Neo.Network.P2P
 
         public static UInt256 CalculateHash(this IVerifiable verifiable)
         {
-            return CalculateHash(verifiable, ProtocolSettings.Default.Magic);
+            return new UInt256(Crypto.Hash256(verifiable.GetHashData(ProtocolSettings.Default.Magic)));
         }
 
         public static UInt256 CalculateHash(this IVerifiable verifiable, uint magic)

--- a/src/neo/Network/P2P/Helper.cs
+++ b/src/neo/Network/P2P/Helper.cs
@@ -7,10 +7,15 @@ namespace Neo.Network.P2P
     {
         public static byte[] GetHashData(this IVerifiable verifiable)
         {
+            return GetHashData(verifiable, ProtocolSettings.Default.Magic);
+        }
+
+        public static byte[] GetHashData(this IVerifiable verifiable, uint magic)
+        {
             using (MemoryStream ms = new MemoryStream())
             using (BinaryWriter writer = new BinaryWriter(ms))
             {
-                writer.Write(ProtocolSettings.Default.Magic);
+                writer.Write(magic);
                 verifiable.SerializeUnsigned(writer);
                 writer.Flush();
                 return ms.ToArray();

--- a/src/neo/Network/P2P/Payloads/BlockBase.cs
+++ b/src/neo/Network/P2P/Payloads/BlockBase.cs
@@ -26,7 +26,7 @@ namespace Neo.Network.P2P.Payloads
             {
                 if (_hash == null)
                 {
-                    _hash = new UInt256(Crypto.Hash256(this.GetHashData()));
+                    _hash = this.CalculateHash();
                 }
                 return _hash;
             }

--- a/src/neo/Network/P2P/Payloads/ConsensusPayload.cs
+++ b/src/neo/Network/P2P/Payloads/ConsensusPayload.cs
@@ -45,7 +45,7 @@ namespace Neo.Network.P2P.Payloads
             {
                 if (_hash == null)
                 {
-                    _hash = new UInt256(Crypto.Hash256(this.GetHashData()));
+                    _hash = this.CalculateHash();
                 }
                 return _hash;
             }

--- a/src/neo/Network/P2P/Payloads/Transaction.cs
+++ b/src/neo/Network/P2P/Payloads/Transaction.cs
@@ -62,7 +62,7 @@ namespace Neo.Network.P2P.Payloads
             {
                 if (_hash == null)
                 {
-                    _hash = new UInt256(Crypto.Hash256(this.GetHashData()));
+                    _hash = this.CalculateHash();
                 }
                 return _hash;
             }

--- a/src/neo/Wallets/Helper.cs
+++ b/src/neo/Wallets/Helper.cs
@@ -10,7 +10,12 @@ namespace Neo.Wallets
     {
         public static byte[] Sign(this IVerifiable verifiable, KeyPair key)
         {
-            return Crypto.Sign(verifiable.GetHashData(), key.PrivateKey, key.PublicKey.EncodePoint(false)[1..]);
+            return Sign(verifiable, key, ProtocolSettings.Default.Magic);
+        }
+
+        public static byte[] Sign(this IVerifiable verifiable, KeyPair key, uint magic)
+        {
+            return Crypto.Sign(verifiable.GetHashData(magic), key.PrivateKey, key.PublicKey.EncodePoint(false)[1..]);
         }
 
         public static string ToAddress(this UInt160 scriptHash)


### PR DESCRIPTION
fixes #1900 

Once this is merged, will need to add an overload to RpcClient TransactionManager.Sign[Async] that takes an explicit Magic uint parameter and calls the explicit magic overload of IVerifiable.Sign extension method (which calls explicit magic overload of IVerifiable.GetHashData)