### PR TITLE
Recalculate committee every 28 blocks

### DIFF
--- a/src/neo/SmartContract/Native/Tokens/NeoToken.cs
+++ b/src/neo/SmartContract/Native/Tokens/NeoToken.cs
@@ -109,7 +109,7 @@ namespace Neo.SmartContract.Native.Tokens
         protected override void OnPersist(ApplicationEngine engine)
         {
             base.OnPersist(engine);
-            
+
             // Set next committee
             if (ShouldRefreshCommittee(engine.Snapshot.Height))
             {
@@ -255,7 +255,7 @@ namespace Neo.SmartContract.Native.Tokens
             ECPoint[] committees = GetCommittee(snapshot);
             return Contract.CreateMultiSigRedeemScript(committees.Length - (committees.Length - 1) / 2, committees).ToScriptHash();
         }
-        
+
         private IEnumerable<ECPoint> GetCommitteeFromCache(StoreView snapshot)
         {
             return snapshot.Storages[CreateStorageKey(Prefix_Committee)].GetSerializableList<ECPoint>();

--- a/src/neo/SmartContract/Native/Tokens/NeoToken.cs
+++ b/src/neo/SmartContract/Native/Tokens/NeoToken.cs
@@ -89,7 +89,7 @@ namespace Neo.SmartContract.Native.Tokens
             return value * sum * NeoHolderRewardRatio / 100 / TotalAmount;
         }
 
-        private bool shouldRefreshCommittee(uint height) => height % (ProtocolSettings.Default.CommitteeMembersCount + ProtocolSettings.Default.ValidatorsCount) == 0;
+        private bool ShouldRefreshCommittee(uint height) => height % (ProtocolSettings.Default.CommitteeMembersCount + ProtocolSettings.Default.ValidatorsCount) == 0;
 
         internal override void Initialize(ApplicationEngine engine)
         {
@@ -109,7 +109,7 @@ namespace Neo.SmartContract.Native.Tokens
             base.OnPersist(engine);
 
             // Set next committee
-            if (shouldRefreshCommittee(engine.Snapshot.Height))
+            if (ShouldRefreshCommittee(engine.Snapshot.Height))
             {
                 StorageItem storage = engine.Snapshot.Storages.GetAndChange(CreateStorageKey(Prefix_NextCommittee), () => new StorageItem());
                 storage.Value = GetNextCommitteeMembers(engine.Snapshot).ToArray().ToByteArray();

--- a/src/neo/SmartContract/Native/Tokens/NeoToken.cs
+++ b/src/neo/SmartContract/Native/Tokens/NeoToken.cs
@@ -89,7 +89,7 @@ namespace Neo.SmartContract.Native.Tokens
             return value * sum * NeoHolderRewardRatio / 100 / TotalAmount;
         }
 
-        private bool shouldRefreshCommittee(StoreView snapshot) => snapshot.Height % (ProtocolSettings.Default.CommitteeMembersCount + ProtocolSettings.Default.ValidatorsCount) == 0;
+        private bool shouldRefreshCommittee(uint height) => height % (ProtocolSettings.Default.CommitteeMembersCount + ProtocolSettings.Default.ValidatorsCount) == 0;
 
         internal override void Initialize(ApplicationEngine engine)
         {
@@ -118,7 +118,7 @@ namespace Neo.SmartContract.Native.Tokens
             GAS.Mint(engine, account, gasPerBlock * CommitteeRewardRatio / 100);
 
             // Set next committee
-            if (shouldRefreshCommittee(engine.Snapshot))
+            if (shouldRefreshCommittee(engine.Snapshot.Height))
             {
                 StorageItem storage = engine.Snapshot.Storages.GetAndChange(CreateStorageKey(Prefix_NextCommittee), () => new StorageItem());
                 storage.Value = committee.ToArray().ToByteArray();
@@ -259,7 +259,7 @@ namespace Neo.SmartContract.Native.Tokens
 
         private IEnumerable<ECPoint> GetCommitteeMembers(StoreView snapshot)
         {
-            if (!shouldRefreshCommittee(snapshot))
+            if (!shouldRefreshCommittee(snapshot.Height))
             {
                 StorageItem storage = snapshot.Storages.TryGet(CreateStorageKey(Prefix_NextCommittee));
                 if (storage != null) return storage.GetSerializableList<ECPoint>().ToArray();

--- a/tests/neo.UnitTests/Consensus/UT_Consensus.cs
+++ b/tests/neo.UnitTests/Consensus/UT_Consensus.cs
@@ -56,7 +56,7 @@ namespace Neo.UnitTests.Consensus
                     UT_Crypto.generateKey(32),
                     UT_Crypto.generateKey(32),
                     UT_Crypto.generateKey(32)
-                };
+                }.OrderBy(p => p.PublicKey).ToArray();
 
             var timeValues = new[] {
               new DateTime(1980, 06, 01, 0, 0, 1, 001, DateTimeKind.Utc),  // For tests, used below


### PR DESCRIPTION
This PR changes committee/validator calculation from every block to every 28 blocks to realize this [comment in #1848](https://github.com/neo-project/neo/pull/1848/files#r481830217)

In this PR I assume that ProtocolSettings.Default.ValidatorsCount does not change. Please correct me if I'm wrong.