### PR TITLE
[master-2.x] Fix killed

### DIFF
--- a/neo/Ledger/BlockChain.State.cs
+++ b/neo/Ledger/BlockChain.State.cs
@@ -27,7 +27,7 @@ namespace Neo.Ledger
 
         public StateRootState GetStateRoot(uint index)
         {
-            return currentSnapshot.StateRoots.TryGet(index);
+            return Store.GetStateRoots().TryGet(index);
         }
 
         public bool GetStateProof(UInt256 root, StorageKey skey, out HashSet<byte[]> proof)

--- a/neo/Network/P2P/Payloads/StateRootsPayload.cs
+++ b/neo/Network/P2P/Payloads/StateRootsPayload.cs
@@ -7,7 +7,7 @@ namespace Neo.Network.P2P.Payloads
 {
     public class StateRootsPayload : ISerializable
     {
-        public const int MaxStateRootsCount = 2000;
+        public const int MaxStateRootsCount = 200;
 
         public StateRoot[] StateRoots;
 

--- a/neo/Network/P2P/Payloads/StateRootsPayload.cs
+++ b/neo/Network/P2P/Payloads/StateRootsPayload.cs
@@ -7,7 +7,7 @@ namespace Neo.Network.P2P.Payloads
 {
     public class StateRootsPayload : ISerializable
     {
-        public const int MaxStateRootsCount = 200;
+        public const int MaxStateRootsCount = 2000;
 
         public StateRoot[] StateRoots;
 

--- a/neo/Network/P2P/ProtocolHandler.cs
+++ b/neo/Network/P2P/ProtocolHandler.cs
@@ -427,6 +427,7 @@ namespace Neo.Network.P2P
                 case "getblocks":
                 case "getdata":
                 case "getheaders":
+                case "getroots":
                 case "mempool":
                     return queue.OfType<Message>().Any(p => p.Command == msg.Command);
                 default:

--- a/neo/Network/P2P/ProtocolHandler.cs
+++ b/neo/Network/P2P/ProtocolHandler.cs
@@ -175,7 +175,6 @@ namespace Neo.Network.P2P
                     break;
                 state_roots.Add(state.StateRoot);
             }
-            if (state_roots.Count == 0) return;
             foreach (StateRootsPayload pl in StateRootsPayload.Create(state_roots))
             {
                 Context.Parent.Tell(Message.Create("roots", pl));

--- a/neo/Network/P2P/ProtocolHandler.cs
+++ b/neo/Network/P2P/ProtocolHandler.cs
@@ -175,6 +175,7 @@ namespace Neo.Network.P2P
                     break;
                 state_roots.Add(state.StateRoot);
             }
+            if (state_roots.Count == 0) return;
             foreach (StateRootsPayload pl in StateRootsPayload.Create(state_roots))
             {
                 Context.Parent.Tell(Message.Create("roots", pl));

--- a/neo/Network/P2P/RemoteNode.cs
+++ b/neo/Network/P2P/RemoteNode.cs
@@ -63,6 +63,8 @@ namespace Neo.Network.P2P
                 case "getaddr":
                 case "getblocks":
                 case "getheaders":
+                case "getroots":
+                case "roots":
                 case "mempool":
                 case "ping":
                 case "pong":

--- a/neo/Network/P2P/RemoteNode.cs
+++ b/neo/Network/P2P/RemoteNode.cs
@@ -64,7 +64,6 @@ namespace Neo.Network.P2P
                 case "getblocks":
                 case "getheaders":
                 case "getroots":
-                case "roots":
                 case "mempool":
                 case "ping":
                 case "pong":

--- a/neo/Network/P2P/TaskManager.cs
+++ b/neo/Network/P2P/TaskManager.cs
@@ -284,6 +284,9 @@ namespace Neo.Network.P2P
             {
                 if (Blockchain.Singleton.ExpectStateRootIndex < Blockchain.Singleton.Height)
                 {
+                    var state_root_state = Blockchain.Singleton.GetStateRoot(Blockchain.Singleton.ExpectStateRootIndex);
+                    if (state_root_state is null || state_root_state.Flag == StateRootVerifyFlag.Invalid)
+                        return;
                     var start_index = Blockchain.Singleton.ExpectStateRootIndex;
                     var count = Math.Min(Blockchain.Singleton.Height - start_index, StateRootsPayload.MaxStateRootsCount);
                     StateRootSyncTime = DateTime.UtcNow;


### PR DESCRIPTION
Changes:
 * Use `Store.GetStateRoots()` instead `currentSnapshot` to get `StateRoot`
 * Stop sync state roots when verified failed
 * Drop spam `getroots` message from `ProtocolHandlerMailBox` and `MessageQueue`

@erikzhang @shargon Can you review this one first？