### PR TITLE
Optimize ReadOnlyView

### DIFF
--- a/src/neo/Persistence/MemorySnapshot.cs
+++ b/src/neo/Persistence/MemorySnapshot.cs
@@ -1,6 +1,5 @@
 using Neo.IO;
 using Neo.IO.Caching;
-using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;

--- a/src/neo/Persistence/MemoryStore.cs
+++ b/src/neo/Persistence/MemoryStore.cs
@@ -1,6 +1,5 @@
 using Neo.IO;
 using Neo.IO.Caching;
-using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/neo/Persistence/ReadOnlyView.cs
+++ b/src/neo/Persistence/ReadOnlyView.cs
@@ -12,14 +12,78 @@ namespace Neo.Persistence
     {
         private readonly IReadOnlyStore store;
 
-        public override DataCache<UInt256, TrimmedBlock> Blocks => new StoreDataCache<UInt256, TrimmedBlock>(store, Prefixes.DATA_Block);
-        public override DataCache<UInt256, TransactionState> Transactions => new StoreDataCache<UInt256, TransactionState>(store, Prefixes.DATA_Transaction);
-        public override DataCache<UInt160, ContractState> Contracts => new StoreDataCache<UInt160, ContractState>(store, Prefixes.ST_Contract);
-        public override DataCache<StorageKey, StorageItem> Storages => new StoreDataCache<StorageKey, StorageItem>(store, Prefixes.ST_Storage);
-        public override DataCache<SerializableWrapper<uint>, HeaderHashList> HeaderHashList => new StoreDataCache<SerializableWrapper<uint>, HeaderHashList>(store, Prefixes.IX_HeaderHashList);
-        public override MetaDataCache<HashIndexState> BlockHashIndex => new StoreMetaDataCache<HashIndexState>(store, Prefixes.IX_CurrentBlock);
-        public override MetaDataCache<HashIndexState> HeaderHashIndex => new StoreMetaDataCache<HashIndexState>(store, Prefixes.IX_CurrentHeader);
-        public override MetaDataCache<ContractIdState> ContractId => new StoreMetaDataCache<ContractIdState>(store, Prefixes.IX_ContractId);
+        private StoreDataCache<UInt256, TrimmedBlock> _Blocks;
+        private StoreDataCache<UInt256, TransactionState> _Transactions;
+        private StoreDataCache<UInt160, ContractState> _Contracts;
+        private StoreDataCache<StorageKey, StorageItem> _Storages;
+        private StoreDataCache<SerializableWrapper<uint>, HeaderHashList> _HeaderHashList;
+        private StoreMetaDataCache<HashIndexState> _BlockHashIndex, _HeaderHashIndex;
+        private StoreMetaDataCache<ContractIdState> _ContractId;
+
+        public override DataCache<UInt256, TrimmedBlock> Blocks
+        {
+            get
+            {
+                _Blocks ??= new StoreDataCache<UInt256, TrimmedBlock>(store, Prefixes.DATA_Block);
+                return _Blocks;
+            }
+        }
+        public override DataCache<UInt256, TransactionState> Transactions
+        {
+            get
+            {
+                _Transactions ??= new StoreDataCache<UInt256, TransactionState>(store, Prefixes.DATA_Transaction);
+                return _Transactions;
+            }
+        }
+        public override DataCache<UInt160, ContractState> Contracts
+        {
+            get
+            {
+                _Contracts ??= new StoreDataCache<UInt160, ContractState>(store, Prefixes.ST_Contract);
+                return _Contracts;
+            }
+        }
+        public override DataCache<StorageKey, StorageItem> Storages
+        {
+            get
+            {
+                _Storages ??= new StoreDataCache<StorageKey, StorageItem>(store, Prefixes.ST_Storage);
+                return _Storages;
+            }
+        }
+        public override DataCache<SerializableWrapper<uint>, HeaderHashList> HeaderHashList
+        {
+            get
+            {
+                _HeaderHashList ??= new StoreDataCache<SerializableWrapper<uint>, HeaderHashList>(store, Prefixes.IX_HeaderHashList);
+                return _HeaderHashList;
+            }
+        }
+        public override MetaDataCache<HashIndexState> BlockHashIndex
+        {
+            get
+            {
+                _BlockHashIndex ??= new StoreMetaDataCache<HashIndexState>(store, Prefixes.IX_CurrentBlock);
+                return _BlockHashIndex;
+            }
+        }
+        public override MetaDataCache<HashIndexState> HeaderHashIndex
+        {
+            get
+            {
+                _HeaderHashIndex ??= new StoreMetaDataCache<HashIndexState>(store, Prefixes.IX_CurrentHeader);
+                return _HeaderHashIndex;
+            }
+        }
+        public override MetaDataCache<ContractIdState> ContractId
+        {
+            get
+            {
+                _ContractId ??= new StoreMetaDataCache<ContractIdState>(store, Prefixes.IX_ContractId);
+                return _ContractId;
+            }
+        }
 
         public ReadOnlyView(IReadOnlyStore store)
         {

--- a/tests/neo.UnitTests/Persistence/UT_ReadOnlyView.cs
+++ b/tests/neo.UnitTests/Persistence/UT_ReadOnlyView.cs
@@ -9,6 +9,20 @@ namespace Neo.UnitTests.Persistence
     public class UT_ReadOnlyView
     {
         [TestMethod]
+        public void ReferenceEquals()
+        {
+            var r = new ReadOnlyView(new MemoryStore());
+            Assert.IsTrue(object.ReferenceEquals(r.Blocks, r.Blocks));
+            Assert.IsTrue(object.ReferenceEquals(r.Transactions, r.Transactions));
+            Assert.IsTrue(object.ReferenceEquals(r.Contracts, r.Contracts));
+            Assert.IsTrue(object.ReferenceEquals(r.Storages, r.Storages));
+            Assert.IsTrue(object.ReferenceEquals(r.HeaderHashList, r.HeaderHashList));
+            Assert.IsTrue(object.ReferenceEquals(r.BlockHashIndex, r.BlockHashIndex));
+            Assert.IsTrue(object.ReferenceEquals(r.HeaderHashIndex, r.HeaderHashIndex));
+            Assert.IsTrue(object.ReferenceEquals(r.ContractId, r.ContractId));
+        }
+
+        [TestMethod]
         public void CommitException()
         {
             var r = new ReadOnlyView(new MemoryStore());


### PR DESCRIPTION
Previously we create a new class for each call to each property.

```csharp
var r = new ReadOnlyView(new MemoryStore());
Assert.IsFalse(object.ReferenceEquals(r.Blocks, r.Blocks));
```