### PR TITLE
Remove ShallDrop from PriorityMailbox

### DIFF
--- a/src/neo/IO/Actors/IDropeable.cs
+++ b/src/neo/IO/Actors/IDropeable.cs
@@ -1,0 +1,9 @@
+using System.Collections;
+
+namespace Neo.IO.Actors
+{
+    internal interface IDropeable
+    {
+        bool ShallDrop(object message, IEnumerable queue);
+    }
+}

--- a/src/neo/IO/Actors/PriorityMailbox.cs
+++ b/src/neo/IO/Actors/PriorityMailbox.cs
@@ -2,7 +2,6 @@ using Akka.Actor;
 using Akka.Configuration;
 using Akka.Dispatch;
 using Akka.Dispatch.MessageQueues;
-using System.Collections;
 
 namespace Neo.IO.Actors
 {
@@ -15,10 +14,10 @@ namespace Neo.IO.Actors
 
         public override IMessageQueue Create(IActorRef owner, ActorSystem system)
         {
-            return new PriorityMessageQueue(ShallDrop, IsHighPriority);
+            if (this is IDropeable dropeable) return new PriorityMessageQueue(dropeable.ShallDrop, IsHighPriority);
+            return new PriorityMessageQueue(null, IsHighPriority);
         }
 
         internal protected virtual bool IsHighPriority(object message) => false;
-        internal protected virtual bool ShallDrop(object message, IEnumerable queue) => false;
     }
 }

--- a/src/neo/IO/Actors/PriorityMessageQueue.cs
+++ b/src/neo/IO/Actors/PriorityMessageQueue.cs
@@ -34,7 +34,7 @@ namespace Neo.IO.Actors
         {
             Interlocked.Increment(ref idle);
             if (envelope.Message is Idle) return;
-            if (dropper(envelope.Message, high.Concat(low).Select(p => p.Message)))
+            if (dropper != null && dropper(envelope.Message, high.Concat(low).Select(p => p.Message)))
                 return;
             ConcurrentQueue<Envelope> queue = priority_generator(envelope.Message) ? high : low;
             queue.Enqueue(envelope);

--- a/src/neo/Network/P2P/RemoteNode.cs
+++ b/src/neo/Network/P2P/RemoteNode.cs
@@ -201,7 +201,7 @@ namespace Neo.Network.P2P
         }
     }
 
-    internal class RemoteNodeMailbox : PriorityMailbox
+    internal class RemoteNodeMailbox : PriorityMailbox, IDropeable
     {
         public RemoteNodeMailbox(Settings settings, Config config) : base(settings, config) { }
 
@@ -232,7 +232,7 @@ namespace Neo.Network.P2P
             }
         }
 
-        internal protected override bool ShallDrop(object message, IEnumerable queue)
+        bool IDropeable.ShallDrop(object message, IEnumerable queue)
         {
             if (!(message is Message msg)) return false;
             switch (msg.Command)

--- a/src/neo/Network/P2P/RemoteNode.cs
+++ b/src/neo/Network/P2P/RemoteNode.cs
@@ -232,7 +232,7 @@ namespace Neo.Network.P2P
             }
         }
 
-        bool IDropeable.ShallDrop(object message, IEnumerable queue)
+        public bool ShallDrop(object message, IEnumerable queue)
         {
             if (!(message is Message msg)) return false;
             switch (msg.Command)

--- a/src/neo/Network/P2P/TaskManager.cs
+++ b/src/neo/Network/P2P/TaskManager.cs
@@ -328,7 +328,7 @@ namespace Neo.Network.P2P
         }
     }
 
-    internal class TaskManagerMailbox : PriorityMailbox
+    internal class TaskManagerMailbox : PriorityMailbox, IDropeable
     {
         public TaskManagerMailbox(Akka.Actor.Settings settings, Config config)
             : base(settings, config)
@@ -351,7 +351,7 @@ namespace Neo.Network.P2P
             }
         }
 
-        internal protected override bool ShallDrop(object message, IEnumerable queue)
+        bool IDropeable.ShallDrop(object message, IEnumerable queue)
         {
             if (!(message is TaskManager.NewTasks tasks)) return false;
             // Remove duplicate tasks


### PR DESCRIPTION
We can avoid the linq instruction when `dropper` it's null or empty.

```csharp
high.Concat(low).Select(p => p.Message)
```

*Note: It's a small optimization but also I think that it's more organized*