### PR TITLE
Remove useless data during VerificationContract serialization

### DIFF
--- a/src/neo/Wallets/SQLite/VerificationContract.cs
+++ b/src/neo/Wallets/SQLite/VerificationContract.cs
@@ -8,11 +8,10 @@ namespace Neo.Wallets.SQLite
 {
     public class VerificationContract : SmartContract.Contract, IEquatable<VerificationContract>, ISerializable
     {
-        public int Size => 20 + ParameterList.GetVarSize() + Script.GetVarSize();
+        public int Size => ParameterList.GetVarSize() + Script.GetVarSize();
 
         public void Deserialize(BinaryReader reader)
         {
-            reader.ReadSerializable<UInt160>();
             ParameterList = reader.ReadVarBytes().Select(p =>
             {
                 var ret = (ContractParameterType)p;
@@ -42,7 +41,6 @@ namespace Neo.Wallets.SQLite
 
         public void Serialize(BinaryWriter writer)
         {
-            writer.Write(new UInt160());
             writer.WriteVarBytes(ParameterList.Select(p => (byte)p).ToArray());
             writer.WriteVarBytes(Script);
         }

--- a/tests/neo.UnitTests/Wallets/SQLite/UT_VerificationContract.cs
+++ b/tests/neo.UnitTests/Wallets/SQLite/UT_VerificationContract.cs
@@ -1,4 +1,5 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.IO;
 using Neo.SmartContract;
 using Neo.Wallets;
 using Neo.Wallets.SQLite;
@@ -113,18 +114,13 @@ namespace Neo.UnitTests
                 Script = Neo.SmartContract.Contract.CreateSignatureRedeemScript(key.PublicKey),
                 ParameterList = new[] { ContractParameterType.Signature }
             };
-            MemoryStream stream = new MemoryStream();
-            BinaryWriter writer = new BinaryWriter(stream);
-            contract1.Serialize(writer);
-            stream.Seek(0, SeekOrigin.Begin);
-            byte[] byteArray = new byte[stream.Length];
-            stream.Read(byteArray, 0, (int)stream.Length);
+            byte[] byteArray = contract1.ToArray();
             byte[] script = Neo.SmartContract.Contract.CreateSignatureRedeemScript(key.PublicKey);
-            byte[] result = new byte[64];
-            result[20] = 0x01;
-            result[21] = (byte)ContractParameterType.Signature;
-            result[22] = 0x29;
-            Array.Copy(script, 0, result, 23, 41);
+            byte[] result = new byte[44];
+            result[0] = 0x01;
+            result[1] = (byte)ContractParameterType.Signature;
+            result[2] = 0x29;
+            Array.Copy(script, 0, result, 3, 41);
             CollectionAssert.AreEqual(result, byteArray);
         }
 
@@ -142,7 +138,7 @@ namespace Neo.UnitTests
                 Script = Neo.SmartContract.Contract.CreateSignatureRedeemScript(key.PublicKey),
                 ParameterList = new[] { ContractParameterType.Signature }
             };
-            Assert.AreEqual(64, contract1.Size);
+            Assert.AreEqual(44, contract1.Size);
         }
     }
 }


### PR DESCRIPTION
Because neo2 wallets won't be compatible with neo3 wallets, we can clean the serialization of `VerificationContract`