### PR TITLE
[2x] Optimize GetStateRootsPayload

### DIFF
--- a/neo/Network/P2P/Payloads/GetStateRootsPayload.cs
+++ b/neo/Network/P2P/Payloads/GetStateRootsPayload.cs
@@ -24,6 +24,7 @@ namespace Neo.Network.P2P.Payloads
         {
             StartIndex = reader.ReadUInt32();
             Count = reader.ReadUInt32();
+            if (Count == 0) throw new FormatException();
         }
 
         void ISerializable.Serialize(BinaryWriter writer)

--- a/neo/Network/P2P/Payloads/StateRootsPayload.cs
+++ b/neo/Network/P2P/Payloads/StateRootsPayload.cs
@@ -1,4 +1,5 @@
 using Neo.IO;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -24,6 +25,12 @@ namespace Neo.Network.P2P.Payloads
                 yield return payload;
                 state_roots = state_roots.Skip(MaxStateRootsCount);
             }
+        }
+
+        public static StateRootsPayload Create(params StateRoot[] state_roots)
+        {
+            if (state_roots.Length > MaxStateRootsCount) throw new ArgumentException();
+            return new StateRootsPayload() { StateRoots = state_roots };
         }
 
         void ISerializable.Deserialize(BinaryReader reader)

--- a/neo/Network/P2P/ProtocolHandler.cs
+++ b/neo/Network/P2P/ProtocolHandler.cs
@@ -175,10 +175,8 @@ namespace Neo.Network.P2P
                     break;
                 state_roots.Add(state.StateRoot);
             }
-            foreach (StateRootsPayload pl in StateRootsPayload.Create(state_roots))
-            {
-                Context.Parent.Tell(Message.Create("roots", pl));
-            }
+            if (state_roots.Count == 0) return;
+            Context.Parent.Tell(Message.Create("roots", StateRootsPayload.Create(state_roots.ToArray())));
         }
 
         private void OnStateRootsReceived(StateRootsPayload payload)


### PR DESCRIPTION
`foreach (StateRootsPayload pl in StateRootsPayload.Create(state_roots))` 
will never be more than 2k , so we can create the payload directly and avoid a lot of linq sentences

