### PR TITLE
Fix bloom filter with empty verification script

### DIFF
--- a/src/neo/Cryptography/Helper.cs
+++ b/src/neo/Cryptography/Helper.cs
@@ -117,7 +117,7 @@ namespace Neo.Cryptography
         internal static bool Test(this BloomFilter filter, Transaction tx)
         {
             if (filter.Check(tx.Hash.ToArray())) return true;
-            if (tx.Witnesses.Any(p => filter.Check(p.ScriptHash.ToArray())))
+            if (tx.Signers.Any(p => filter.Check(p.Account.ToArray())))
                 return true;
             return false;
         }

--- a/tests/neo.UnitTests/Cryptography/UT_Cryptography_Helper.cs
+++ b/tests/neo.UnitTests/Cryptography/UT_Cryptography_Helper.cs
@@ -3,6 +3,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Neo.Cryptography;
 using Neo.IO;
 using Neo.Network.P2P.Payloads;
+using Neo.SmartContract;
 using System;
 using System.Security;
 using System.Text;
@@ -153,7 +154,7 @@ namespace Neo.UnitTests.Cryptography
             {
                 Script = TestUtils.GetByteArray(32, 0x42),
                 SystemFee = 4200000000,
-                Signers = Array.Empty<Signer>(),
+                Signers = new Signer[] { new Signer() { Account = (new byte[0]).ToScriptHash() } },
                 Attributes = Array.Empty<TransactionAttribute>(),
                 Witnesses = new[]
                 {


### PR DESCRIPTION
`Witness.ScriptHash` it's wrong when `VerificationScript` it's empty. We need to use `Signers` instead of `Witnesses`