### PR TITLE
[master-2.x] Check Reference before get NetworkFee

### DIFF
--- a/neo/Network/P2P/Payloads/InvocationTransaction.cs
+++ b/neo/Network/P2P/Payloads/InvocationTransaction.cs
@@ -64,7 +64,7 @@ namespace Neo.Network.P2P.Payloads
         public override bool Verify(Snapshot snapshot, IEnumerable<Transaction> mempool)
         {
             if (Gas.GetData() % 100000000 != 0) return false;
-            if (NetworkFee < ProtocolSettings.Default.MinimumNetworkFee) return false;
+            if (References is null || NetworkFee < ProtocolSettings.Default.MinimumNetworkFee) return false;
             return base.Verify(snapshot, mempool);
         }
     }


### PR DESCRIPTION
Close #1968 
Fix exception when `Reference` is null. 

 * Add `Reference` null check before get `NetworkFee`