### PR TITLE
Fix Native Contracts serialization

### DIFF
--- a/src/neo/Ledger/StorageItem.cs
+++ b/src/neo/Ledger/StorageItem.cs
@@ -9,6 +9,9 @@ namespace Neo.Ledger
 {
     public class StorageItem : ICloneable<StorageItem>, ISerializable
     {
+        public const int MaxInteropEntries = 32;
+        public const int MaxIteropEntrySize = 512;
+
         private byte[] value;
         private object cache;
         public bool IsConstant;
@@ -86,7 +89,7 @@ namespace Neo.Ledger
             if (cache is null)
             {
                 var interoperable = new T();
-                interoperable.FromStackItem(BinarySerializer.Deserialize(value, 16, 34));
+                interoperable.FromStackItem(BinarySerializer.Deserialize(value, MaxInteropEntries, MaxIteropEntrySize));
                 cache = interoperable;
             }
             value = null;

--- a/src/neo/Network/P2P/Payloads/Witness.cs
+++ b/src/neo/Network/P2P/Payloads/Witness.cs
@@ -8,6 +8,17 @@ namespace Neo.Network.P2P.Payloads
 {
     public class Witness : ISerializable
     {
+        /// <summary>
+        /// This is designed to allow a MultiSig 21/11 (committee)
+        /// Invocation = 11 * (64 + 2) = 726
+        /// </summary>
+        private const int MaxInvocationScript = 1024;
+
+        /// <summary>
+        /// Verification = m + (PUSH_PubKey * 21) + length + null + syscall = 1 + ((2 + 33) * 21) + 2 + 1 + 5 = 744
+        /// </summary>
+        private const int MaxVerificationScript = 1024;
+
         public byte[] InvocationScript;
         public byte[] VerificationScript;
 
@@ -32,11 +43,8 @@ namespace Neo.Network.P2P.Payloads
 
         void ISerializable.Deserialize(BinaryReader reader)
         {
-            // This is designed to allow a MultiSig 10/10 (around 1003 bytes) ~1024 bytes
-            // Invocation = 10 * 64 + 10 = 650 ~ 664  (exact is 653)
-            InvocationScript = reader.ReadVarBytes(663);
-            // Verification = 10 * 33 + 10 = 340 ~ 360   (exact is 351)
-            VerificationScript = reader.ReadVarBytes(361);
+            InvocationScript = reader.ReadVarBytes(MaxInvocationScript);
+            VerificationScript = reader.ReadVarBytes(MaxVerificationScript);
         }
 
         void ISerializable.Serialize(BinaryWriter writer)

--- a/src/neo/SmartContract/Native/Designate/DesignateContract.cs
+++ b/src/neo/SmartContract/Native/Designate/DesignateContract.cs
@@ -43,7 +43,7 @@ namespace Neo.SmartContract.Native.Designate
         [ContractMethod(0, CallFlags.AllowModifyStates)]
         private void DesignateAsRole(ApplicationEngine engine, Role role, ECPoint[] nodes)
         {
-            if (nodes.Length == 0) throw new ArgumentException(nameof(nodes));
+            if (nodes.Length == 0 || nodes.Length > StorageItem.MaxInteropEntries) throw new ArgumentException(nameof(nodes));
             if (!Enum.IsDefined(typeof(Role), role))
                 throw new ArgumentOutOfRangeException(nameof(role));
             if (!CheckCommittee(engine)) throw new InvalidOperationException();

--- a/src/neo/SmartContract/Native/Oracle/OracleContract.cs
+++ b/src/neo/SmartContract/Native/Oracle/OracleContract.cs
@@ -17,7 +17,7 @@ namespace Neo.SmartContract.Native.Oracle
 {
     public sealed class OracleContract : NativeContract
     {
-        private const int MaxUrlLength = 256;
+        private const int MaxUrlLength = byte.MaxValue;
         private const int MaxFilterLength = 128;
         private const int MaxCallbackLength = 32;
         private const int MaxUserDataLength = 512;
@@ -157,7 +157,10 @@ namespace Neo.SmartContract.Native.Oracle
             }));
 
             //Add the id to the IdList
-            engine.Snapshot.Storages.GetAndChange(CreateStorageKey(Prefix_IdList).Add(GetUrlHash(url)), () => new StorageItem(new IdList())).GetInteroperable<IdList>().Add(id);
+            var list = engine.Snapshot.Storages.GetAndChange(CreateStorageKey(Prefix_IdList).Add(GetUrlHash(url)), () => new StorageItem(new IdList())).GetInteroperable<IdList>();
+            if (list.Count + 1 > StorageItem.MaxInteropEntries)
+                throw new InvalidOperationException("There are a lot of pending responses for this url");
+            list.Add(id);
         }
 
         [ContractMethod(0_01000000, CallFlags.None)]

--- a/src/neo/SmartContract/Native/Oracle/OracleContract.cs
+++ b/src/neo/SmartContract/Native/Oracle/OracleContract.cs
@@ -7,6 +7,7 @@ using Neo.Network.P2P.Payloads;
 using Neo.Persistence;
 using Neo.SmartContract.Manifest;
 using Neo.SmartContract.Native.Designate;
+using Neo.VM;
 using Neo.VM.Types;
 using System;
 using System.Collections.Generic;
@@ -168,6 +169,20 @@ namespace Neo.SmartContract.Native.Oracle
         {
             Transaction tx = (Transaction)engine.ScriptContainer;
             return tx?.GetAttribute<OracleResponse>() != null;
+        }
+
+        private class IdList : List<ulong>, IInteroperable
+        {
+            public void FromStackItem(StackItem stackItem)
+            {
+                foreach (StackItem item in (VM.Types.Array)stackItem)
+                    Add((ulong)item.GetInteger());
+            }
+
+            public StackItem ToStackItem(ReferenceCounter referenceCounter)
+            {
+                return new VM.Types.Array(referenceCounter, this.Select(p => (Integer)p));
+            }
         }
     }
 }

--- a/src/neo/SmartContract/Native/PolicyContract.cs
+++ b/src/neo/SmartContract/Native/PolicyContract.cs
@@ -134,6 +134,7 @@ namespace Neo.SmartContract.Native
             StorageItem storage = engine.Snapshot.Storages.GetOrAdd(key, () => new StorageItem(new byte[1]));
             List<UInt160> accounts = storage.GetSerializableList<UInt160>();
             if (accounts.Contains(account)) return false;
+            if ((accounts.Count + 1) > StorageItem.MaxInteropEntries) throw new ArgumentException("Maximum number of blocked accounts exceeded");
             engine.Snapshot.Storages.GetAndChange(key);
             accounts.Add(account);
             accounts.Sort();

--- a/tests/neo.UnitTests/Network/P2P/Payloads/UT_Witness.cs
+++ b/tests/neo.UnitTests/Network/P2P/Payloads/UT_Witness.cs
@@ -28,13 +28,13 @@ namespace Neo.UnitTests.Network.P2P.Payloads
             uut.InvocationScript.Should().BeNull();
         }
 
-        private Witness PrepareDummyWitness(int maxAccounts)
+        private Witness PrepareDummyWitness(int pubKeys, int m)
         {
-            var address = new WalletAccount[maxAccounts];
-            var wallets = new NEP6Wallet[maxAccounts];
-            var walletsUnlocks = new IDisposable[maxAccounts];
+            var address = new WalletAccount[pubKeys];
+            var wallets = new NEP6Wallet[pubKeys];
+            var walletsUnlocks = new IDisposable[pubKeys];
 
-            for (int x = 0; x < maxAccounts; x++)
+            for (int x = 0; x < pubKeys; x++)
             {
                 wallets[x] = TestUtils.GenerateTestWallet();
                 walletsUnlocks[x] = wallets[x].Unlock("123");
@@ -43,9 +43,9 @@ namespace Neo.UnitTests.Network.P2P.Payloads
 
             // Generate multisignature
 
-            var multiSignContract = Contract.CreateMultiSigContract(maxAccounts, address.Select(a => a.GetKey().PublicKey).ToArray());
+            var multiSignContract = Contract.CreateMultiSigContract(m, address.Select(a => a.GetKey().PublicKey).ToArray());
 
-            for (int x = 0; x < maxAccounts; x++)
+            for (int x = 0; x < pubKeys; x++)
             {
                 wallets[x].CreateAccount(multiSignContract, address[x].GetKey());
             }
@@ -69,7 +69,7 @@ namespace Neo.UnitTests.Network.P2P.Payloads
                 Witnesses = new Witness[0]
             });
 
-            for (int x = 0; x < maxAccounts; x++)
+            for (int x = 0; x < m; x++)
             {
                 Assert.IsTrue(wallets[x].Sign(data));
             }
@@ -81,7 +81,7 @@ namespace Neo.UnitTests.Network.P2P.Payloads
         [TestMethod]
         public void MaxSize_OK()
         {
-            var witness = PrepareDummyWitness(10);
+            var witness = PrepareDummyWitness(10, 10);
 
             // Check max size
 
@@ -100,11 +100,20 @@ namespace Neo.UnitTests.Network.P2P.Payloads
         [TestMethod]
         public void MaxSize_Error()
         {
-            var witness = PrepareDummyWitness(11);
+            var witness = new Witness
+            {
+                InvocationScript = new byte[1025],
+                VerificationScript = new byte[10]
+            };
 
             // Check max size
 
-            Assert.IsTrue(witness.Size > 1024);
+            Assert.ThrowsException<FormatException>(() => witness.ToArray().AsSerializable<Witness>());
+
+            // Check max size
+
+            witness.InvocationScript = new byte[10];
+            witness.VerificationScript = new byte[1025];
             Assert.ThrowsException<FormatException>(() => witness.ToArray().AsSerializable<Witness>());
         }
 

--- a/tests/neo.UnitTests/SmartContract/Native/Tokens/UT_NeoToken.cs
+++ b/tests/neo.UnitTests/SmartContract/Native/Tokens/UT_NeoToken.cs
@@ -618,6 +618,11 @@ namespace Neo.UnitTests.SmartContract.Native.Tokens
             (VM.Types.Boolean, bool) result1 = Check_SetGasPerBlock(snapshot, 10 * NativeContract.GAS.Factor);
             result1.Item2.Should().BeTrue();
             result1.Item1.GetBoolean().Should().BeTrue();
+
+            snapshot.PersistingBlock.Index++;
+            result = Check_GetGasPerBlock(snapshot);
+            result.Item2.Should().BeTrue();
+            result.Item1.Should().Be(10 * NativeContract.GAS.Factor);
         }
 
         [TestMethod]


### PR DESCRIPTION
Related to https://github.com/neo-project/neo/pull/1978

- Changed from `GetInteroperable` to `GetSerializableList` when the interoperable object it's a list.
- It's possible to create a Denial of Service if we store more than 16 entries.

