### PR TITLE
Remove unused native callback

### DIFF
--- a/src/neo/SmartContract/ApplicationEngine.cs
+++ b/src/neo/SmartContract/ApplicationEngine.cs
@@ -27,7 +27,6 @@ namespace Neo.SmartContract
 
         private class InvocationState
         {
-            public Type ReturnType;
             public CheckReturnType NeedCheckReturnValue;
         }
 
@@ -79,20 +78,6 @@ namespace Neo.SmartContract
         {
             FaultException = e;
             base.OnFault(e);
-        }
-
-        internal void CallFromNativeContract(UInt160 hash, string method, params StackItem[] args)
-        {
-            InvocationState state = GetInvocationState(CurrentContext);
-            state.ReturnType = typeof(void);
-            CallContract(hash, method, new VMArray(args));
-        }
-
-        internal void CallFromNativeContract<T>(UInt160 hash, string method, params StackItem[] args)
-        {
-            InvocationState state = GetInvocationState(CurrentContext);
-            state.ReturnType = typeof(T);
-            CallContract(hash, method, new VMArray(args));
         }
 
         protected override void ContextUnloaded(ExecutionContext context)

--- a/src/neo/SmartContract/ApplicationEngine.cs
+++ b/src/neo/SmartContract/ApplicationEngine.cs
@@ -28,7 +28,6 @@ namespace Neo.SmartContract
         private class InvocationState
         {
             public Type ReturnType;
-            public Delegate Callback;
             public CheckReturnType NeedCheckReturnValue;
         }
 
@@ -82,19 +81,17 @@ namespace Neo.SmartContract
             base.OnFault(e);
         }
 
-        internal void CallFromNativeContract(Action onComplete, UInt160 hash, string method, params StackItem[] args)
+        internal void CallFromNativeContract(UInt160 hash, string method, params StackItem[] args)
         {
             InvocationState state = GetInvocationState(CurrentContext);
             state.ReturnType = typeof(void);
-            state.Callback = onComplete;
             CallContract(hash, method, new VMArray(args));
         }
 
-        internal void CallFromNativeContract<T>(Action<T> onComplete, UInt160 hash, string method, params StackItem[] args)
+        internal void CallFromNativeContract<T>(UInt160 hash, string method, params StackItem[] args)
         {
             InvocationState state = GetInvocationState(CurrentContext);
             state.ReturnType = typeof(T);
-            state.Callback = onComplete;
             CallContract(hash, method, new VMArray(args));
         }
 
@@ -120,17 +117,6 @@ namespace Neo.SmartContract
                             throw new InvalidOperationException();
                         break;
                     }
-            }
-            switch (state.Callback)
-            {
-                case null:
-                    break;
-                case Action action:
-                    action();
-                    break;
-                default:
-                    state.Callback.DynamicInvoke(Convert(Pop(), new InteropParameterDescriptor(state.ReturnType)));
-                    break;
             }
         }
 

--- a/src/neo/SmartContract/Native/Oracle/OracleContract.cs
+++ b/src/neo/SmartContract/Native/Oracle/OracleContract.cs
@@ -45,7 +45,7 @@ namespace Neo.SmartContract.Native.Oracle
             OracleRequest request = GetRequest(engine.Snapshot, response.Id);
             if (request == null) throw new ArgumentException("Oracle request was not found");
             StackItem userData = BinarySerializer.Deserialize(request.UserData, engine.MaxStackSize, engine.MaxItemSize, engine.ReferenceCounter);
-            engine.CallFromNativeContract(null, request.CallbackContract, request.CallbackMethod, request.Url, userData, (int)response.Code, response.Result);
+            engine.CallFromNativeContract(request.CallbackContract, request.CallbackMethod, request.Url, userData, (int)response.Code, response.Result);
         }
 
         private UInt256 GetOriginalTxid(ApplicationEngine engine)

--- a/src/neo/SmartContract/Native/Oracle/OracleContract.cs
+++ b/src/neo/SmartContract/Native/Oracle/OracleContract.cs
@@ -45,7 +45,8 @@ namespace Neo.SmartContract.Native.Oracle
             OracleRequest request = GetRequest(engine.Snapshot, response.Id);
             if (request == null) throw new ArgumentException("Oracle request was not found");
             StackItem userData = BinarySerializer.Deserialize(request.UserData, engine.MaxStackSize, engine.MaxItemSize, engine.ReferenceCounter);
-            engine.CallFromNativeContract(request.CallbackContract, request.CallbackMethod, request.Url, userData, (int)response.Code, response.Result);
+            var args = new VM.Types.Array(engine.ReferenceCounter, new StackItem[] { request.Url, userData, (int)response.Code, response.Result });
+            engine.CallContract(request.CallbackContract, request.CallbackMethod, args);
         }
 
         private UInt256 GetOriginalTxid(ApplicationEngine engine)


### PR DESCRIPTION
It was added for oracles, and at the end was not used. Also was fixed the array creation, it was not used `ReferenceCounter`