### PR TITLE
Distribute more GAS reward for committee

### DIFF
--- a/src/neo/SmartContract/Native/Tokens/NeoToken.cs
+++ b/src/neo/SmartContract/Native/Tokens/NeoToken.cs
@@ -32,8 +32,8 @@ namespace Neo.SmartContract.Native.Tokens
         private const byte Prefix_VoterRewardPerCommittee = 23;
 
         private const byte NeoHolderRewardRatio = 10;
-        private const byte CommitteeRewardRatio = 5;
-        private const byte VoterRewardRatio = 85;
+        private const byte CommitteeRewardRatio = 10;
+        private const byte VoterRewardRatio = 80;
 
         internal NeoToken()
         {

--- a/tests/neo.UnitTests/SmartContract/Native/Tokens/UT_GasToken.cs
+++ b/tests/neo.UnitTests/SmartContract/Native/Tokens/UT_GasToken.cs
@@ -44,7 +44,7 @@ namespace Neo.UnitTests.SmartContract.Native.Tokens
             var keyCount = snapshot.Storages.GetChangeSet().Count();
 
             var supply = NativeContract.GAS.TotalSupply(snapshot);
-            supply.Should().Be(3000000025000000); // 3000000000000000 + 25000000 (neo holder reward)
+            supply.Should().Be(3000000050000000); // 3000000000000000 + 50000000 (neo holder reward)
 
             // Check unclaim
 
@@ -68,7 +68,7 @@ namespace Neo.UnitTests.SmartContract.Native.Tokens
             unclaim.State.Should().BeTrue();
 
             supply = NativeContract.GAS.TotalSupply(snapshot);
-            supply.Should().Be(3000050025000000);
+            supply.Should().Be(3000050050000000);
 
             snapshot.Storages.GetChangeSet().Count().Should().Be(keyCount + 3); // Gas
 

--- a/tests/neo.UnitTests/SmartContract/Native/Tokens/UT_NeoToken.cs
+++ b/tests/neo.UnitTests/SmartContract/Native/Tokens/UT_NeoToken.cs
@@ -420,8 +420,8 @@ namespace Neo.UnitTests.SmartContract.Native.Tokens
                 engine.State.Should().Be(VM.VMState.HALT);
 
                 var committee = Blockchain.StandbyCommittee;
-                NativeContract.GAS.BalanceOf(snapshot, Contract.CreateSignatureContract(committee[0]).ScriptHash.ToArray()).Should().Be(25000000);
-                NativeContract.GAS.BalanceOf(snapshot, Contract.CreateSignatureContract(committee[1]).ScriptHash.ToArray()).Should().Be(25000000);
+                NativeContract.GAS.BalanceOf(snapshot, Contract.CreateSignatureContract(committee[0]).ScriptHash.ToArray()).Should().Be(50000000);
+                NativeContract.GAS.BalanceOf(snapshot, Contract.CreateSignatureContract(committee[1]).ScriptHash.ToArray()).Should().Be(50000000);
                 NativeContract.GAS.BalanceOf(snapshot, Contract.CreateSignatureContract(committee[2]).ScriptHash.ToArray()).Should().Be(0);
             }
         }
@@ -742,7 +742,7 @@ namespace Neo.UnitTests.SmartContract.Native.Tokens
             NativeContract.NEO.BalanceOf(snapshot, Contract.CreateSignatureContract(accountA).ScriptHash).Should().Be(0);
 
             StorageItem storageItem = snapshot.Storages.TryGet(new KeyBuilder(-1, 23).Add(accountA).AddBigEndian(1));
-            new BigInteger(storageItem.Value).Should().Be(31875000000);
+            new BigInteger(storageItem.Value).Should().Be(30000000000);
 
             snapshot.Storages.TryGet(new KeyBuilder(-1, 23).Add(accountB).AddBigEndian(uint.MaxValue - 1)).Should().BeNull();
 
@@ -754,7 +754,7 @@ namespace Neo.UnitTests.SmartContract.Native.Tokens
             NativeContract.NEO.BalanceOf(snapshot, Contract.CreateSignatureContract(committee[1]).ScriptHash).Should().Be(0);
 
             storageItem = snapshot.Storages.TryGet(new KeyBuilder(-1, 23).Add(committee[1]).AddBigEndian(1));
-            new BigInteger(storageItem.Value).Should().Be(31875000000);
+            new BigInteger(storageItem.Value).Should().Be(30000000000);
 
             // Next block
 
@@ -765,7 +765,7 @@ namespace Neo.UnitTests.SmartContract.Native.Tokens
             NativeContract.NEO.BalanceOf(snapshot, Contract.CreateSignatureContract(committee[2]).ScriptHash).Should().Be(0);
 
             storageItem = snapshot.Storages.TryGet(new KeyBuilder(-1, 23).Add(committee[2]).AddBigEndian(22));
-            new BigInteger(storageItem.Value).Should().Be(31875000000 * 2);
+            new BigInteger(storageItem.Value).Should().Be(30000000000 * 2);
 
 
             // Claim GAS
@@ -779,7 +779,7 @@ namespace Neo.UnitTests.SmartContract.Native.Tokens
             }));
             NativeContract.NEO.BalanceOf(snapshot, account).Should().Be(1999800);
             BigInteger value = NativeContract.NEO.UnclaimedGas(snapshot, account, 29 + 3);
-            value.Should().Be(1999800 * 31875000000 / 100000000L + (1999800L * 10 * 5 * 29 / 100));
+            value.Should().Be(1999800 * 30000000000 / 100000000L + (1999800L * 10 * 5 * 29 / 100));
         }
 
         [TestMethod]


### PR DESCRIPTION
As we discussed before that each committee needs to operate one full node and half of the operations staff. Currently, 5% of the GAS will be distributed for committee, each will receive about 25 028 GAS. Therefore, we may need to increase their incentives to cover their costs.