### PR TITLE
Allow to add services to plugins

### DIFF
--- a/src/neo/Plugins/RequiredServicesAttribute.cs
+++ b/src/neo/Plugins/RequiredServicesAttribute.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace Neo.Plugins
+{
+    [AttributeUsage(AttributeTargets.Class)]
+    public class RequiredServicesAttribute : Attribute
+    {
+        public Type[] RequiredServices { get; }
+
+        public RequiredServicesAttribute(params Type[] requiredServices)
+        {
+            this.RequiredServices = requiredServices;
+        }
+    }
+}


### PR DESCRIPTION
This PR allows the client to add services to the plugin system. For example, we can add `ConsoleService` in neo-cli to the plugin system to allow the plugins to access to the console.