### PR TITLE
[master-2.x] Avoid null in TaskManager.AvailableTasks

### DIFF
--- a/neo/Network/P2P/TaskManager.cs
+++ b/neo/Network/P2P/TaskManager.cs
@@ -243,7 +243,7 @@ namespace Neo.Network.P2P
             if (session.AvailableTasks.Count > 0)
             {
                 session.AvailableTasks.Remove(knownHashes);
-                session.AvailableTasks.RemoveWhere(p => Blockchain.Singleton.ContainsBlock(p));
+                session.AvailableTasks.RemoveWhere(p => p is null || Blockchain.Singleton.ContainsBlock(p));
                 HashSet<UInt256> hashes = new HashSet<UInt256>(session.AvailableTasks);
                 if (hashes.Count > 0)
                 {


### PR DESCRIPTION
Close https://github.com/neo-project/neo/issues/2088

It's still not clear how this happened. But we can do this to avoid node crashes