### PR TITLE
MemoryPool: state-dependent concurrent verification in TryAdd

### DIFF
--- a/src/neo/Ledger/TransactionRouter.cs
+++ b/src/neo/Ledger/TransactionRouter.cs
@@ -1,35 +1,58 @@
 using Akka.Actor;
 using Akka.Routing;
+using Neo.Network.P2P;
 using Neo.Network.P2P.Payloads;
 using System;
 
 namespace Neo.Ledger
 {
-    internal class TransactionRouter : UntypedActor
+    public sealed class TransactionRouter : UntypedActor
     {
-        public class Task { public Transaction Transaction; public bool Relay; }
+        private readonly NeoSystem system;
+        private readonly Blockchain chain;
 
-        private readonly IActorRef blockchain;
-
-        public TransactionRouter(NeoSystem system)
+        public TransactionRouter(NeoSystem system, Blockchain bc)
         {
-            this.blockchain = system.Blockchain;
+            this.system = system;
+            this.chain = bc;
         }
 
         protected override void OnReceive(object message)
         {
-            if (!(message is Task task)) return;
-            blockchain.Tell(new Blockchain.PreverifyCompleted
+            switch (message)
             {
-                Transaction = task.Transaction,
-                Result = task.Transaction.VerifyStateIndependent(),
-                Relay = task.Relay
-            }, Sender);
+                case Transaction tx:
+                    OnTransaction(tx, true);
+                    break;
+                case Transaction[] transactions:
+                    // This message comes from a mempool's revalidation, already relayed
+                    foreach (var tx in transactions) OnTransaction(tx, false);
+                    break;
+            }
         }
 
-        internal static Props Props(NeoSystem system)
+        private void OnTransaction(Transaction tx, bool relay)
         {
-            return Akka.Actor.Props.Create(() => new TransactionRouter(system)).WithRouter(new SmallestMailboxPool(Environment.ProcessorCount));
+            VerifyResult res = chain.MemPool.TryAdd(tx);
+            if (relay && res == VerifyResult.Succeed)
+                system.LocalNode.Tell(new LocalNode.RelayDirectly { Inventory = tx });
+            SendRelayResult(tx, res);
+        }
+
+        private void SendRelayResult(IInventory inventory, VerifyResult result)
+        {
+            Blockchain.RelayResult rr = new Blockchain.RelayResult
+            {
+                Inventory = inventory,
+                Result = result
+            };
+            Sender.Tell(rr);
+            Context.System.EventStream.Publish(rr);
+        }
+
+        public static Props Props(NeoSystem system, Blockchain bc)
+        {
+            return Akka.Actor.Props.Create(() => new TransactionRouter(system, bc)).WithRouter(new SmallestMailboxPool(Environment.ProcessorCount));
         }
     }
 }

--- a/src/neo/NeoSystem.cs
+++ b/src/neo/NeoSystem.cs
@@ -18,6 +18,7 @@ namespace Neo
             $"remote-node-mailbox {{ mailbox-type: \"{typeof(RemoteNodeMailbox).AssemblyQualifiedName}\" }}" +
             $"consensus-service-mailbox {{ mailbox-type: \"{typeof(ConsensusServiceMailbox).AssemblyQualifiedName}\" }}");
         public IActorRef Blockchain { get; }
+        public IActorRef TransactionRouter { get; }
         public IActorRef LocalNode { get; }
         internal IActorRef TaskManager { get; }
         public IActorRef Consensus { get; private set; }
@@ -39,6 +40,7 @@ namespace Neo
                 ? new MemoryStore()
                 : Plugin.Storages[storageEngine].GetStore();
             this.Blockchain = ActorSystem.ActorOf(Ledger.Blockchain.Props(this, store));
+            this.TransactionRouter = ActorSystem.ActorOf(Ledger.TransactionRouter.Props(this, Ledger.Blockchain.Singleton));
             this.LocalNode = ActorSystem.ActorOf(Network.P2P.LocalNode.Props(this));
             this.TaskManager = ActorSystem.ActorOf(Network.P2P.TaskManager.Props(this));
             foreach (var plugin in Plugin.Plugins)

--- a/src/neo/Network/P2P/Payloads/Transaction.cs
+++ b/src/neo/Network/P2P/Payloads/Transaction.cs
@@ -281,7 +281,7 @@ namespace Neo.Network.P2P.Payloads
             return Verify(snapshot, null) == VerifyResult.Succeed;
         }
 
-        public virtual VerifyResult VerifyStateDependent(StoreView snapshot, TransactionVerificationContext context)
+        public virtual VerifyResult VerifyStateDependent(StoreView snapshot)
         {
             if (ValidUntilBlock <= snapshot.Height || ValidUntilBlock > snapshot.Height + MaxValidUntilBlockIncrement)
                 return VerifyResult.Expired;
@@ -290,7 +290,6 @@ namespace Neo.Network.P2P.Payloads
                     return VerifyResult.PolicyFail;
             if (NativeContract.Policy.GetMaxBlockSystemFee(snapshot) < SystemFee)
                 return VerifyResult.PolicyFail;
-            if (!(context?.CheckTransaction(this, snapshot) ?? true)) return VerifyResult.InsufficientFunds;
             foreach (TransactionAttribute attribute in Attributes)
                 if (!attribute.Verify(snapshot, this))
                     return VerifyResult.Invalid;
@@ -313,7 +312,7 @@ namespace Neo.Network.P2P.Payloads
         {
             VerifyResult result = VerifyStateIndependent();
             if (result != VerifyResult.Succeed) return result;
-            result = VerifyStateDependent(snapshot, context);
+            result = VerifyStateDependent(snapshot);
             return result;
         }
 

--- a/src/neo/Network/P2P/RemoteNode.ProtocolHandler.cs
+++ b/src/neo/Network/P2P/RemoteNode.ProtocolHandler.cs
@@ -287,9 +287,11 @@ namespace Neo.Network.P2P
         private void OnInventoryReceived(IInventory inventory)
         {
             pendingKnownHashes.Remove(inventory.Hash);
+            bool isTx = false;
             switch (inventory)
             {
                 case Transaction transaction:
+                    isTx = true;
                     system.Consensus?.Tell(transaction);
                     break;
                 case Block block:
@@ -299,7 +301,10 @@ namespace Neo.Network.P2P
             }
             knownHashes.Add(inventory.Hash);
             system.TaskManager.Tell(inventory);
-            system.Blockchain.Tell(inventory);
+            if (isTx)
+                system.TransactionRouter.Tell(inventory);
+            else
+                system.Blockchain.Tell(inventory);
         }
 
         private void OnInvMessageReceived(InvPayload payload)

--- a/tests/neo.UnitTests/Ledger/UT_Blockchain.cs
+++ b/tests/neo.UnitTests/Ledger/UT_Blockchain.cs
@@ -54,7 +54,7 @@ namespace Neo.UnitTests.Ledger
         public void Initialize()
         {
             system = TestBlockchain.TheNeoSystem;
-            Blockchain.Singleton.MemPool.TryAdd(txSample, Blockchain.Singleton.GetSnapshot());
+            Blockchain.Singleton.MemPool.TryAdd(txSample);
         }
 
         [TestMethod]
@@ -122,15 +122,15 @@ namespace Neo.UnitTests.Ledger
             typeof(Blockchain)
                 .GetMethod("UpdateCurrentSnapshot", BindingFlags.Instance | BindingFlags.NonPublic)
                 .Invoke(Blockchain.Singleton, null);
-
+            Blockchain.Singleton.MemPool.InitSnapshot(snapshot); // normally done via UpdatePoolForBlockPersisted
             // Make transaction
 
             var tx = CreateValidTx(walletA, acc.ScriptHash, 0);
 
-            senderProbe.Send(system.Blockchain, tx);
+            senderProbe.Send(system.TransactionRouter, tx);
             senderProbe.ExpectMsg<Blockchain.RelayResult>(p => p.Result == VerifyResult.Succeed);
 
-            senderProbe.Send(system.Blockchain, tx);
+            senderProbe.Send(system.TransactionRouter, tx);
             senderProbe.ExpectMsg<Blockchain.RelayResult>(p => p.Result == VerifyResult.AlreadyExists);
         }
 

--- a/tests/neo.UnitTests/Ledger/UT_TransactionVerificationContext.cs
+++ b/tests/neo.UnitTests/Ledger/UT_TransactionVerificationContext.cs
@@ -29,7 +29,7 @@ namespace Neo.UnitTests.Ledger
             random.NextBytes(randomBytes);
             Mock<Transaction> mock = new Mock<Transaction>();
             mock.Setup(p => p.Verify(It.IsAny<StoreView>(), It.IsAny<TransactionVerificationContext>())).Returns(VerifyResult.Succeed);
-            mock.Setup(p => p.VerifyStateDependent(It.IsAny<StoreView>(), It.IsAny<TransactionVerificationContext>())).Returns(VerifyResult.Succeed);
+            mock.Setup(p => p.VerifyStateDependent(It.IsAny<StoreView>())).Returns(VerifyResult.Succeed);
             mock.Setup(p => p.VerifyStateIndependent()).Returns(VerifyResult.Succeed);
             mock.Object.Script = randomBytes;
             mock.Object.NetworkFee = networkFee;

--- a/tests/neo.UnitTests/Network/P2P/Payloads/UT_Transaction.cs
+++ b/tests/neo.UnitTests/Network/P2P/Payloads/UT_Transaction.cs
@@ -773,7 +773,7 @@ namespace Neo.UnitTests.Network.P2P.Payloads
             };
             UInt160[] hashes = txSimple.GetScriptHashesForVerifying(snapshot);
             Assert.AreEqual(1, hashes.Length);
-            Assert.AreNotEqual(VerifyResult.Succeed, txSimple.VerifyStateDependent(snapshot, new TransactionVerificationContext()));
+            Assert.AreNotEqual(VerifyResult.Succeed, txSimple.VerifyStateDependent(snapshot));
         }
 
         [TestMethod]
@@ -1162,9 +1162,7 @@ namespace Neo.UnitTests.Network.P2P.Payloads
                 Version = 0,
                 Witnesses = new Witness[0],
             };
-            tx.VerifyStateDependent(snapshot, new TransactionVerificationContext()).Should().Be(VerifyResult.Invalid);
-            tx.SystemFee = 10;
-            tx.VerifyStateDependent(snapshot, new TransactionVerificationContext()).Should().Be(VerifyResult.InsufficientFunds);
+            tx.VerifyStateDependent(snapshot).Should().Be(VerifyResult.Invalid);
 
             var walletA = TestUtils.GenerateTestWallet();
             var walletB = TestUtils.GenerateTestWallet();
@@ -1214,7 +1212,7 @@ namespace Neo.UnitTests.Network.P2P.Payloads
                 Assert.IsTrue(data.Completed);
 
                 tx.Witnesses = data.GetWitnesses();
-                tx.VerifyStateDependent(snapshot, new TransactionVerificationContext()).Should().Be(VerifyResult.Succeed);
+                tx.VerifyStateDependent(snapshot).Should().Be(VerifyResult.Succeed);
             }
         }
 


### PR DESCRIPTION
MemoryPool contents is always valid (verified) against some snapshot. This
snapshot is only changed when new block is added. Between blocks we only have
one valid chain state that can be read by multiple threads without any issues,
thus we can execute concurrently not only state-independent, but also
state-dependent parts of transaction verification.

To simplify execution flow (minimize single-threaded Blockchain message
handling and eliminate duplicate DB accesses for ContainsTransaction)
TransactionRouter is an independent entity now, though of course we can also
attach the same actor functionality to MemoryPool itself.

TransactionVerificationContext balance checking is moved to MemoryPool from
Transaction with this, Transaction shouldn't care (it can check overall GAS
balance though).

This is directly related to #2045 work (it solves state access problem there)
and in some sense is an alternative to #2054 (makes fee calculation easier,
though IsStandardContract() trick to optimize out these contracts during
reverification is still relevant and can be added here). At this stage it's
just a prototype, some additional optimizations and simplifications are
possible of course, but this prototype shows the direction and the main
question for now is whether this direction is interesting for us.