### PR TITLE
Public SignatureContractCost

### DIFF
--- a/src/neo/Network/P2P/Payloads/Transaction.cs
+++ b/src/neo/Network/P2P/Payloads/Transaction.cs
@@ -303,9 +303,9 @@ namespace Neo.Network.P2P.Payloads
             for (int i = 0; i < hashes.Length; i++)
             {
                 if (witnesses[i].VerificationScript.IsSignatureContract())
-                    net_fee -= SmartContract.Helper.SignatureContractCost(execFeeFactor);
+                    net_fee -= execFeeFactor * SmartContract.Helper.SignatureContractCost();
                 else if (witnesses[i].VerificationScript.IsMultiSigContract(out int m, out int n))
-                    net_fee -= SmartContract.Helper.MultiSignatureContractCost(execFeeFactor, m, n);
+                    net_fee -= execFeeFactor * SmartContract.Helper.MultiSignatureContractCost(m, n);
                 else
                 {
                     if (!this.VerifyWitness(null, hashes[i], witnesses[i], net_fee, out long fee))

--- a/src/neo/Network/P2P/Payloads/Transaction.cs
+++ b/src/neo/Network/P2P/Payloads/Transaction.cs
@@ -35,18 +35,6 @@ namespace Neo.Network.P2P.Payloads
         private byte[] script;
         private Witness[] witnesses;
 
-        private static long SignatureContractCost(uint execFeeFactor) => execFeeFactor * (
-            ApplicationEngine.OpCodePrices[OpCode.PUSHDATA1] * 2 +
-            ApplicationEngine.OpCodePrices[OpCode.PUSHNULL] +
-            ApplicationEngine.OpCodePrices[OpCode.SYSCALL] +
-            ApplicationEngine.ECDsaVerifyPrice);
-        private static long MultiSignatureContractCost(uint execFeeFactor, int m, int n) => execFeeFactor * (
-            ApplicationEngine.OpCodePrices[OpCode.PUSHDATA1] * (m + n) +
-            ApplicationEngine.OpCodePrices[OpCode.PUSHINT8] * 2 +
-            ApplicationEngine.OpCodePrices[OpCode.PUSHNULL] +
-            ApplicationEngine.OpCodePrices[OpCode.SYSCALL] +
-            ApplicationEngine.ECDsaVerifyPrice * n);
-
         public const int HeaderSize =
             sizeof(byte) +  //Version
             sizeof(uint) +  //Nonce
@@ -315,9 +303,9 @@ namespace Neo.Network.P2P.Payloads
             for (int i = 0; i < hashes.Length; i++)
             {
                 if (witnesses[i].VerificationScript.IsSignatureContract())
-                    net_fee -= SignatureContractCost(execFeeFactor);
+                    net_fee -= SmartContract.Helper.SignatureContractCost(execFeeFactor);
                 else if (witnesses[i].VerificationScript.IsMultiSigContract(out int m, out int n))
-                    net_fee -= MultiSignatureContractCost(execFeeFactor, m, n);
+                    net_fee -= SmartContract.Helper.MultiSignatureContractCost(execFeeFactor, m, n);
                 else
                 {
                     if (!this.VerifyWitness(null, hashes[i], witnesses[i], net_fee, out long fee))

--- a/src/neo/SmartContract/Helper.cs
+++ b/src/neo/SmartContract/Helper.cs
@@ -14,6 +14,23 @@ namespace Neo.SmartContract
     {
         public const long MaxVerificationGas = 0_50000000;
 
+        public static long SignatureContractCost(uint execFeeFactor)
+        {
+            return execFeeFactor * (ApplicationEngine.OpCodePrices[OpCode.PUSHDATA1] * 2 +
+                ApplicationEngine.OpCodePrices[OpCode.PUSHNULL] +
+                ApplicationEngine.OpCodePrices[OpCode.SYSCALL] +
+                ApplicationEngine.ECDsaVerifyPrice);
+        }
+
+        public static long MultiSignatureContractCost(uint execFeeFactor, int m, int n)
+        {
+            return execFeeFactor * (ApplicationEngine.OpCodePrices[OpCode.PUSHDATA1] * (m + n) +
+                ApplicationEngine.OpCodePrices[OpCode.PUSHINT8] * 2 +
+                ApplicationEngine.OpCodePrices[OpCode.PUSHNULL] +
+                ApplicationEngine.OpCodePrices[OpCode.SYSCALL] +
+                ApplicationEngine.ECDsaVerifyPrice * n);
+        }
+
         public static UInt160 GetContractHash(UInt160 sender, byte[] script)
         {
             using var sb = new ScriptBuilder();

--- a/src/neo/SmartContract/Helper.cs
+++ b/src/neo/SmartContract/Helper.cs
@@ -14,22 +14,18 @@ namespace Neo.SmartContract
     {
         public const long MaxVerificationGas = 0_50000000;
 
-        public static long SignatureContractCost(uint execFeeFactor)
-        {
-            return execFeeFactor * (ApplicationEngine.OpCodePrices[OpCode.PUSHDATA1] * 2 +
-                ApplicationEngine.OpCodePrices[OpCode.PUSHNULL] +
-                ApplicationEngine.OpCodePrices[OpCode.SYSCALL] +
-                ApplicationEngine.ECDsaVerifyPrice);
-        }
+        public static long SignatureContractCost() =>
+            ApplicationEngine.OpCodePrices[OpCode.PUSHDATA1] * 2 +
+            ApplicationEngine.OpCodePrices[OpCode.PUSHNULL] +
+            ApplicationEngine.OpCodePrices[OpCode.SYSCALL] +
+            ApplicationEngine.ECDsaVerifyPrice;
 
-        public static long MultiSignatureContractCost(uint execFeeFactor, int m, int n)
-        {
-            return execFeeFactor * (ApplicationEngine.OpCodePrices[OpCode.PUSHDATA1] * (m + n) +
-                ApplicationEngine.OpCodePrices[OpCode.PUSHINT8] * 2 +
-                ApplicationEngine.OpCodePrices[OpCode.PUSHNULL] +
-                ApplicationEngine.OpCodePrices[OpCode.SYSCALL] +
-                ApplicationEngine.ECDsaVerifyPrice * n);
-        }
+        public static long MultiSignatureContractCost(int m, int n) =>
+            ApplicationEngine.OpCodePrices[OpCode.PUSHDATA1] * (m + n) +
+            ApplicationEngine.OpCodePrices[OpCode.PUSHINT8] * 2 +
+            ApplicationEngine.OpCodePrices[OpCode.PUSHNULL] +
+            ApplicationEngine.OpCodePrices[OpCode.SYSCALL] +
+            ApplicationEngine.ECDsaVerifyPrice * n;
 
         public static UInt160 GetContractHash(UInt160 sender, byte[] script)
         {


### PR DESCRIPTION
`MultiSignatureContractCost` can be used in OracleService directly. 

https://github.com/neo-project/neo-modules/pull/326/files#diff-139ea468a507377af47a2a352b1e885cae5ce09b0fb5fd7dd8ca0ba54f516864R328-R335