### PR TITLE
Make verifywitness public

### DIFF
--- a/src/neo/SmartContract/Helper.cs
+++ b/src/neo/SmartContract/Helper.cs
@@ -151,7 +151,7 @@ namespace Neo.SmartContract
             return new UInt160(Crypto.Hash160(script));
         }
 
-        internal static bool VerifyWitnesses(this IVerifiable verifiable, StoreView snapshot, long gas)
+        public static bool VerifyWitnesses(this IVerifiable verifiable, StoreView snapshot, long gas)
         {
             if (gas < 0) return false;
             if (gas > MaxVerificationGas) gas = MaxVerificationGas;


### PR DESCRIPTION
Since `IVerifiable` is public. I want to define `IVerifiable` in plugin.
Making `VerifyWitness` public is reasonable.