### PR TITLE
Update BigDecimal.Parse

### DIFF
--- a/src/neo/BigDecimal.cs
+++ b/src/neo/BigDecimal.cs
@@ -38,7 +38,7 @@ namespace Neo
 
         public static BigDecimal Parse(string s, byte decimals)
         {
-            if (!TryParse(s, decimals, out BigDecimal result))
+            if (!TryParse(Convert.ToDecimal(s).ToString(), decimals, out BigDecimal result))
                 throw new FormatException();
             return result;
         }


### PR DESCRIPTION
Support thousands separator like this

```c#
string input = "1,234.01";
```