### PR TITLE
Transaction optimization

### DIFF
--- a/src/neo/Network/P2P/Payloads/Transaction.cs
+++ b/src/neo/Network/P2P/Payloads/Transaction.cs
@@ -331,7 +331,6 @@ namespace Neo.Network.P2P.Payloads
                 return VerifyResult.Invalid;
             }
             UInt160[] hashes = GetScriptHashesForVerifying(null);
-            if (hashes.Length != witnesses.Length) return VerifyResult.Invalid;
             for (int i = 0; i < hashes.Length; i++)
                 if (witnesses[i].VerificationScript.IsStandardContract())
                     if (!this.VerifyWitness(null, hashes[i], witnesses[i], SmartContract.Helper.MaxVerificationGas, out _))

--- a/src/neo/Network/P2P/Payloads/Transaction.cs
+++ b/src/neo/Network/P2P/Payloads/Transaction.cs
@@ -154,7 +154,7 @@ namespace Neo.Network.P2P.Payloads
                 startPosition = (int)reader.BaseStream.Position;
             DeserializeUnsigned(reader);
             Witnesses = reader.ReadSerializableArray<Witness>(Signers.Length);
-            if (Witnesses.Length == Signers.Length) throw new FormatException();
+            if (Witnesses.Length != Signers.Length) throw new FormatException();
             if (startPosition >= 0)
                 _size = (int)reader.BaseStream.Position - startPosition;
         }

--- a/src/neo/Network/P2P/Payloads/Transaction.cs
+++ b/src/neo/Network/P2P/Payloads/Transaction.cs
@@ -153,8 +153,8 @@ namespace Neo.Network.P2P.Payloads
             if (reader.BaseStream.CanSeek)
                 startPosition = (int)reader.BaseStream.Position;
             DeserializeUnsigned(reader);
-            Witnesses = reader.ReadSerializableArray<Witness>();
-            if (Witnesses.Length == 0) throw new FormatException();
+            Witnesses = reader.ReadSerializableArray<Witness>(Signers.Length);
+            if (Witnesses.Length == Signers.Length) throw new FormatException();
             if (startPosition >= 0)
                 _size = (int)reader.BaseStream.Position - startPosition;
         }

--- a/src/neo/Wallets/Wallet.cs
+++ b/src/neo/Wallets/Wallet.cs
@@ -241,7 +241,7 @@ namespace Neo.Wallets
             return account;
         }
 
-        public Transaction MakeTransaction(TransferOutput[] outputs, UInt160 from = null, Signer[] cosigners = null, DataCache snapshot = null)
+        public Transaction MakeTransaction(TransferOutput[] outputs, UInt160 from = null, Signer[] cosigners = null)
         {
             UInt160[] accounts;
             if (from is null)
@@ -252,7 +252,7 @@ namespace Neo.Wallets
             {
                 accounts = new[] { from };
             }
-            snapshot ??= Blockchain.Singleton.View;
+            DataCache snapshot = Blockchain.Singleton.View;
             Dictionary<UInt160, Signer> cosignerList = cosigners?.ToDictionary(p => p.Account) ?? new Dictionary<UInt160, Signer>();
             byte[] script;
             List<(UInt160 Account, BigInteger Value)> balances_gas = null;
@@ -310,7 +310,7 @@ namespace Neo.Wallets
             return MakeTransaction(snapshot, script, cosignerList.Values.ToArray(), Array.Empty<TransactionAttribute>(), balances_gas);
         }
 
-        public Transaction MakeTransaction(byte[] script, UInt160 sender = null, Signer[] cosigners = null, TransactionAttribute[] attributes = null, long maxGas = ApplicationEngine.TestModeGas, DataCache snapshot = null)
+        public Transaction MakeTransaction(byte[] script, UInt160 sender = null, Signer[] cosigners = null, TransactionAttribute[] attributes = null, long maxGas = ApplicationEngine.TestModeGas)
         {
             UInt160[] accounts;
             if (sender is null)
@@ -321,7 +321,7 @@ namespace Neo.Wallets
             {
                 accounts = new[] { sender };
             }
-            snapshot ??= Blockchain.Singleton.View;
+            DataCache snapshot = Blockchain.Singleton.View;
             var balances_gas = accounts.Select(p => (Account: p, Value: NativeContract.GAS.BalanceOf(snapshot, p))).Where(p => p.Value.Sign > 0).ToList();
             return MakeTransaction(snapshot, script, cosigners ?? Array.Empty<Signer>(), attributes ?? Array.Empty<TransactionAttribute>(), balances_gas, maxGas);
         }

--- a/src/neo/Wallets/Wallet.cs
+++ b/src/neo/Wallets/Wallet.cs
@@ -241,7 +241,7 @@ namespace Neo.Wallets
             return account;
         }
 
-        public Transaction MakeTransaction(TransferOutput[] outputs, UInt160 from = null, Signer[] cosigners = null)
+        public Transaction MakeTransaction(TransferOutput[] outputs, UInt160 from = null, Signer[] cosigners = null, DataCache snapshot = null)
         {
             UInt160[] accounts;
             if (from is null)
@@ -252,7 +252,7 @@ namespace Neo.Wallets
             {
                 accounts = new[] { from };
             }
-            DataCache snapshot = Blockchain.Singleton.View;
+            snapshot ??= Blockchain.Singleton.View;
             Dictionary<UInt160, Signer> cosignerList = cosigners?.ToDictionary(p => p.Account) ?? new Dictionary<UInt160, Signer>();
             byte[] script;
             List<(UInt160 Account, BigInteger Value)> balances_gas = null;
@@ -310,7 +310,7 @@ namespace Neo.Wallets
             return MakeTransaction(snapshot, script, cosignerList.Values.ToArray(), Array.Empty<TransactionAttribute>(), balances_gas);
         }
 
-        public Transaction MakeTransaction(byte[] script, UInt160 sender = null, Signer[] cosigners = null, TransactionAttribute[] attributes = null, long maxGas = ApplicationEngine.TestModeGas)
+        public Transaction MakeTransaction(byte[] script, UInt160 sender = null, Signer[] cosigners = null, TransactionAttribute[] attributes = null, long maxGas = ApplicationEngine.TestModeGas, DataCache snapshot = null)
         {
             UInt160[] accounts;
             if (sender is null)
@@ -321,7 +321,7 @@ namespace Neo.Wallets
             {
                 accounts = new[] { sender };
             }
-            DataCache snapshot = Blockchain.Singleton.View;
+            snapshot ??= Blockchain.Singleton.View;
             var balances_gas = accounts.Select(p => (Account: p, Value: NativeContract.GAS.BalanceOf(snapshot, p))).Where(p => p.Value.Sign > 0).ToList();
             return MakeTransaction(snapshot, script, cosigners ?? Array.Empty<Signer>(), attributes ?? Array.Empty<TransactionAttribute>(), balances_gas, maxGas);
         }

--- a/tests/neo.UnitTests/Ledger/UT_MemoryPool.cs
+++ b/tests/neo.UnitTests/Ledger/UT_MemoryPool.cs
@@ -93,8 +93,8 @@ namespace Neo.UnitTests.Ledger
             {
                 new Witness
                 {
-                    InvocationScript = new byte[0],
-                    VerificationScript = new byte[0]
+                    InvocationScript = Array.Empty<byte>(),
+                    VerificationScript = Array.Empty<byte>()
                 }
             };
             return mock.Object;

--- a/tests/neo.UnitTests/Network/P2P/Payloads/UT_Transaction.cs
+++ b/tests/neo.UnitTests/Network/P2P/Payloads/UT_Transaction.cs
@@ -910,8 +910,7 @@ namespace Neo.UnitTests.Network.P2P.Payloads
             byte[] sTx1 = txCosigners1.ToArray();
 
             // back to transaction (should fail, due to non-distinct cosigners)
-            Transaction tx1 = Neo.IO.Helper.AsSerializable<Transaction>(sTx1);
-            Assert.IsNotNull(tx1);
+            Assert.ThrowsException<FormatException>(() => Neo.IO.Helper.AsSerializable<Transaction>(sTx1));
 
             // ----------------------------
             // this should fail (max + 1)
@@ -1110,11 +1109,18 @@ namespace Neo.UnitTests.Network.P2P.Payloads
                 SystemFee = 0,
                 ValidUntilBlock = 0,
                 Version = 0,
-                Witnesses = new Witness[0],
+                Witnesses = new[]
+                {
+                    new Witness
+                    {
+                        InvocationScript = Array.Empty<byte>(),
+                        VerificationScript = Array.Empty<byte>()
+                    }
+                }
             };
             tx.VerifyStateIndependent().Should().Be(VerifyResult.Invalid);
             tx.Script = new byte[0];
-            tx.VerifyStateIndependent().Should().Be(VerifyResult.Invalid);
+            tx.VerifyStateIndependent().Should().Be(VerifyResult.Succeed);
 
             var walletA = TestUtils.GenerateTestWallet();
             var walletB = TestUtils.GenerateTestWallet();

--- a/tests/neo.UnitTests/Network/P2P/Payloads/UT_Transaction.cs
+++ b/tests/neo.UnitTests/Network/P2P/Payloads/UT_Transaction.cs
@@ -1178,7 +1178,7 @@ namespace Neo.UnitTests.Network.P2P.Payloads
         [TestMethod]
         public void Test_VerifyStateDependent()
         {
-            var snapshot = Blockchain.Singleton.GetSnapshot().CreateSnapshot();
+            var snapshot = Blockchain.Singleton.GetSnapshot();
             var height = NativeContract.Ledger.CurrentIndex(snapshot);
             var tx = new Transaction()
             {
@@ -1228,12 +1228,14 @@ namespace Neo.UnitTests.Network.P2P.Payloads
 
                 // Fake balance
 
+                snapshot = Blockchain.Singleton.GetSnapshot();
                 key = NativeContract.GAS.CreateStorageKey(20, acc.ScriptHash);
                 balance = snapshot.GetAndChange(key, () => new StorageItem(new AccountState()));
                 balance.GetInteroperable<AccountState>().Balance = 10000 * NativeContract.GAS.Factor;
 
                 // Make transaction
 
+                snapshot.Commit();
                 tx = walletA.MakeTransaction(new TransferOutput[]
                 {
                     new TransferOutput()
@@ -1242,7 +1244,7 @@ namespace Neo.UnitTests.Network.P2P.Payloads
                          ScriptHash = acc.ScriptHash,
                          Value = new BigDecimal(BigInteger.One,8)
                     }
-                }, acc.ScriptHash, snapshot: snapshot);
+                }, acc.ScriptHash);
 
                 // Sign
 

--- a/tests/neo.UnitTests/Network/P2P/Payloads/UT_Transaction.cs
+++ b/tests/neo.UnitTests/Network/P2P/Payloads/UT_Transaction.cs
@@ -854,13 +854,13 @@ namespace Neo.UnitTests.Network.P2P.Payloads
                     }
                 },
                 Script = new byte[] { (byte)OpCode.PUSH1 },
-                Witnesses = new Witness[] { new Witness() { InvocationScript = new byte[0], VerificationScript = Array.Empty<byte>() } }
+                Witnesses = new Witness[] { new Witness() { InvocationScript = Array.Empty<byte>(), VerificationScript = Array.Empty<byte>() } }
             };
 
             byte[] sTx = txDoubleCosigners.ToArray();
 
             // no need for detailed hexstring here (see basic tests for it)
-            sTx.ToHexString().Should().Be("000403020100e1f505000000000100000000000000040302010209080706050403020100090807060504030201008009080706050403020100090807060504030201000100011100");
+            sTx.ToHexString().Should().Be("000403020100e1f5050000000001000000000000000403020102090807060504030201000908070605040302010080090807060504030201000908070605040302010001000111010000");
 
             // back to transaction (should fail, due to non-distinct cosigners)
             Transaction tx2 = null;
@@ -1172,7 +1172,7 @@ namespace Neo.UnitTests.Network.P2P.Payloads
         [TestMethod]
         public void Test_VerifyStateDependent()
         {
-            var snapshot = Blockchain.Singleton.GetSnapshot();
+            var snapshot = Blockchain.Singleton.GetSnapshot().CreateSnapshot();
             var height = NativeContract.Ledger.CurrentIndex(snapshot);
             var tx = new Transaction()
             {
@@ -1225,7 +1225,6 @@ namespace Neo.UnitTests.Network.P2P.Payloads
                 key = NativeContract.GAS.CreateStorageKey(20, acc.ScriptHash);
                 balance = snapshot.GetAndChange(key, () => new StorageItem(new AccountState()));
                 balance.GetInteroperable<AccountState>().Balance = 10000 * NativeContract.GAS.Factor;
-                snapshot.Commit();
 
                 // Make transaction
 
@@ -1237,7 +1236,7 @@ namespace Neo.UnitTests.Network.P2P.Payloads
                          ScriptHash = acc.ScriptHash,
                          Value = new BigDecimal(BigInteger.One,8)
                     }
-                }, acc.ScriptHash);
+                }, acc.ScriptHash, snapshot: snapshot);
 
                 // Sign
 

--- a/tests/neo.UnitTests/Network/P2P/UT_Message.cs
+++ b/tests/neo.UnitTests/Network/P2P/UT_Message.cs
@@ -131,16 +131,16 @@ namespace Neo.UnitTests.Network.P2P
             {
                 Nonce = 1,
                 Version = 0,
-                Attributes = new TransactionAttribute[0],
+                Attributes = Array.Empty<TransactionAttribute>(),
                 Script = new byte[] { (byte)OpCode.PUSH1 },
                 Signers = new Signer[] { new Signer() { Account = UInt160.Zero } },
-                Witnesses = new Witness[0],
+                Witnesses = new Witness[] { new Witness() { InvocationScript = Array.Empty<byte>(), VerificationScript = new byte[0] } },
             };
 
             var msg = Message.Create(MessageCommand.Transaction, payload);
             var buffer = msg.ToArray();
 
-            buffer.Length.Should().Be(54);
+            buffer.Length.Should().Be(56);
 
             payload.Script = new byte[100];
             for (int i = 0; i < payload.Script.Length; i++) payload.Script[i] = (byte)OpCode.PUSH2;


### PR DESCRIPTION
- `Witnesses` length are checked during verification against `Signers`.
-  `GetScriptHashesForVerifying` was called twice during `VerifyStateDependent`.
- `if (hashes.Length != witnesses.Length)` was already called during `VerifyStateIndependent`.
- added `if (net_fee < 0) return VerifyResult.InsufficientFunds;` because if we doesn't have funds for pay the size fee, we don't need to execute the verification.