### PR TITLE
fix dead lock with state service

### DIFF
--- a/src/neo/NeoSystem.cs
+++ b/src/neo/NeoSystem.cs
@@ -81,9 +81,9 @@ namespace Neo
             this.Blockchain = ActorSystem.ActorOf(Ledger.Blockchain.Props(this));
             this.LocalNode = ActorSystem.ActorOf(Network.P2P.LocalNode.Props(this));
             this.TaskManager = ActorSystem.ActorOf(Network.P2P.TaskManager.Props(this));
-            Blockchain.Ask<FillCompleted>(new FillMemoryPool { Transactions = Enumerable.Empty<Transaction>() }).Wait();
             foreach (var plugin in Plugin.Plugins)
                 plugin.OnSystemLoaded(this);
+            Blockchain.Ask<FillCompleted>(new FillMemoryPool { Transactions = Enumerable.Empty<Transaction>() }).Wait();
         }
 
         private static void CurrentDomain_UnhandledException(object sender, UnhandledExceptionEventArgs e)


### PR DESCRIPTION
Fix dead lock between main thread and blockchain thread.

**Problem**
* `Blockchain` will persist genesis block in constructor, this will call `Plugin.OnPersist`. Because store of `StateService` is only initialized when `OnSystemLoaded` and it is used in `StateService.OnPersist`, so this thread will be blocked util `StateService.OnSystemLoaded` called.
* `Blockchain.Ask` is blocked until there is response. This makes we won't move to `Plugin.OnSystemLoaded`, which will initialize store of `StateService`.