### PR TITLE
StorageItem: optimize binary representation

### DIFF
--- a/src/neo/SmartContract/StorageItem.cs
+++ b/src/neo/SmartContract/StorageItem.cs
@@ -66,7 +66,7 @@ namespace Neo.SmartContract
 
         public void Deserialize(BinaryReader reader)
         {
-            Value = reader.ReadVarBytes();
+            Value = reader.ReadBytes((int)(reader.BaseStream.Length - reader.BaseStream.Position));
         }
 
         public void FromReplica(StorageItem replica)
@@ -95,7 +95,7 @@ namespace Neo.SmartContract
 
         public void Serialize(BinaryWriter writer)
         {
-            writer.WriteVarBytes(Value);
+            writer.Write(Value);
         }
 
         public void Set(BigInteger integer)

--- a/src/neo/SmartContract/StorageItem.cs
+++ b/src/neo/SmartContract/StorageItem.cs
@@ -66,7 +66,7 @@ namespace Neo.SmartContract
 
         public void Deserialize(BinaryReader reader)
         {
-            Value = reader.ReadBytes((int)(reader.BaseStream.Length - reader.BaseStream.Position));
+            Value = reader.ReadBytes((int)(reader.BaseStream.Length));
         }
 
         public void FromReplica(StorageItem replica)

--- a/tests/neo.UnitTests/Ledger/UT_StorageItem.cs
+++ b/tests/neo.UnitTests/Ledger/UT_StorageItem.cs
@@ -64,7 +64,7 @@ namespace Neo.UnitTests.Ledger
         [TestMethod]
         public void Deserialize()
         {
-            byte[] data = new byte[] { 10, 66, 32, 32, 32, 32, 32, 32, 32, 32, 32, 0 };
+            byte[] data = new byte[] { 66, 32, 32, 32, 32, 32, 32, 32, 32, 32 };
             int index = 0;
             using (MemoryStream ms = new MemoryStream(data, index, data.Length - index, false))
             {
@@ -96,7 +96,7 @@ namespace Neo.UnitTests.Ledger
                 }
             }
 
-            byte[] requiredData = new byte[] { 10, 66, 32, 32, 32, 32, 32, 32, 32, 32, 32 };
+            byte[] requiredData = new byte[] { 66, 32, 32, 32, 32, 32, 32, 32, 32, 32 };
 
             data.Length.Should().Be(requiredData.Length);
             for (int i = 0; i < requiredData.Length; i++)


### PR DESCRIPTION
After #2351 StorageItem is just a thin wrapper for some byte array in its
essence so we can Use the same trick as was used for storage keys in #1566 and
avoid additional wrapping/unwrapping with VarBytes encoding.