### PR TITLE
SmartContract: rename hex in ContractParametersContext

### DIFF
--- a/src/neo/SmartContract/ContractParametersContext.cs
+++ b/src/neo/SmartContract/ContractParametersContext.cs
@@ -170,7 +170,7 @@ namespace Neo.SmartContract
             if (!typeof(IVerifiable).IsAssignableFrom(type)) throw new FormatException();
 
             var verifiable = (IVerifiable)Activator.CreateInstance(type);
-            using (MemoryStream ms = new MemoryStream(Convert.FromBase64String(json["hex"].AsString()), false))
+            using (MemoryStream ms = new MemoryStream(Convert.FromBase64String(json["document"].AsString()), false))
             using (BinaryReader reader = new BinaryReader(ms, Utility.StrictUTF8))
             {
                 verifiable.DeserializeUnsigned(reader);
@@ -246,7 +246,7 @@ namespace Neo.SmartContract
             {
                 Verifiable.SerializeUnsigned(writer);
                 writer.Flush();
-                json["hex"] = Convert.ToBase64String(ms.ToArray());
+                json["document"] = Convert.ToBase64String(ms.ToArray());
             }
             json["items"] = new JObject();
             foreach (var item in ContextItems)

--- a/src/neo/SmartContract/ContractParametersContext.cs
+++ b/src/neo/SmartContract/ContractParametersContext.cs
@@ -170,7 +170,7 @@ namespace Neo.SmartContract
             if (!typeof(IVerifiable).IsAssignableFrom(type)) throw new FormatException();
 
             var verifiable = (IVerifiable)Activator.CreateInstance(type);
-            using (MemoryStream ms = new MemoryStream(Convert.FromBase64String(json["document"].AsString()), false))
+            using (MemoryStream ms = new MemoryStream(Convert.FromBase64String(json["data"].AsString()), false))
             using (BinaryReader reader = new BinaryReader(ms, Utility.StrictUTF8))
             {
                 verifiable.DeserializeUnsigned(reader);
@@ -246,7 +246,7 @@ namespace Neo.SmartContract
             {
                 Verifiable.SerializeUnsigned(writer);
                 writer.Flush();
-                json["document"] = Convert.ToBase64String(ms.ToArray());
+                json["data"] = Convert.ToBase64String(ms.ToArray());
             }
             json["items"] = new JObject();
             foreach (var item in ContextItems)

--- a/tests/neo.UnitTests/SmartContract/UT_ContractParameterContext.cs
+++ b/tests/neo.UnitTests/SmartContract/UT_ContractParameterContext.cs
@@ -46,14 +46,14 @@ namespace Neo.UnitTests.SmartContract
             var context = new ContractParametersContext(snapshot, tx);
             context.Add(contract, 0, new byte[] { 0x01 });
             string str = context.ToString();
-            str.Should().Be(@"{""type"":""Neo.Network.P2P.Payloads.Transaction"",""document"":""AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFmUJDLobcPtqo9vZKIdjXsd8fVGwEAARI="",""items"":{}}");
+            str.Should().Be(@"{""type"":""Neo.Network.P2P.Payloads.Transaction"",""data"":""AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFmUJDLobcPtqo9vZKIdjXsd8fVGwEAARI="",""items"":{}}");
         }
 
         [TestMethod]
         public void TestParse()
         {
             var snapshot = TestBlockchain.GetTestSnapshot();
-            var ret = ContractParametersContext.Parse("{\"type\":\"Neo.Network.P2P.Payloads.Transaction\",\"document\":\"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFmUJDLobcPtqo9vZKIdjXsd8fVGwEAARI=\",\"items\":{\"0xbecaad15c0ea585211faf99738a4354014f177f2\":{\"script\":\"IQJv8DuUkkHOHa3UNRnmlg4KhbQaaaBcMoEDqivOFZTKFmh0dHaq\",\"parameters\":[{\"type\":\"Signature\",\"value\":\"AQ==\"}],\"signatures\":{\"03b209fd4f53a7170ea4444e0cb0a6bb6a53c2bd016926989cf85f9b0fba17a70c\":\"AQ==\"}}}}", snapshot);
+            var ret = ContractParametersContext.Parse("{\"type\":\"Neo.Network.P2P.Payloads.Transaction\",\"data\":\"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFmUJDLobcPtqo9vZKIdjXsd8fVGwEAARI=\",\"items\":{\"0xbecaad15c0ea585211faf99738a4354014f177f2\":{\"script\":\"IQJv8DuUkkHOHa3UNRnmlg4KhbQaaaBcMoEDqivOFZTKFmh0dHaq\",\"parameters\":[{\"type\":\"Signature\",\"value\":\"AQ==\"}],\"signatures\":{\"03b209fd4f53a7170ea4444e0cb0a6bb6a53c2bd016926989cf85f9b0fba17a70c\":\"AQ==\"}}}}", snapshot);
             ret.ScriptHashes[0].ToString().Should().Be("0x1bd5c777ec35768892bd3daab60fb7a1cb905066");
             ((Transaction)ret.Verifiable).Script.ToHexString().Should().Be(new byte[] { 18 }.ToHexString());
         }
@@ -62,7 +62,7 @@ namespace Neo.UnitTests.SmartContract
         public void TestFromJson()
         {
             var snapshot = TestBlockchain.GetTestSnapshot();
-            Action action = () => ContractParametersContext.Parse("{\"type\":\"wrongType\",\"document\":\"00000000007c97764845172d827d3c863743293931a691271a0000000000000000000000000000000000000000000100\",\"items\":{\"0x1bd5c777ec35768892bd3daab60fb7a1cb905066\":{\"script\":\"21026ff03b949241ce1dadd43519e6960e0a85b41a69a05c328103aa2bce1594ca1650680a906ad4\",\"parameters\":[{\"type\":\"Signature\",\"value\":\"01\"}]}}}", snapshot);
+            Action action = () => ContractParametersContext.Parse("{\"type\":\"wrongType\",\"data\":\"00000000007c97764845172d827d3c863743293931a691271a0000000000000000000000000000000000000000000100\",\"items\":{\"0x1bd5c777ec35768892bd3daab60fb7a1cb905066\":{\"script\":\"21026ff03b949241ce1dadd43519e6960e0a85b41a69a05c328103aa2bce1594ca1650680a906ad4\",\"parameters\":[{\"type\":\"Signature\",\"value\":\"01\"}]}}}", snapshot);
             action.Should().Throw<FormatException>();
         }
 

--- a/tests/neo.UnitTests/SmartContract/UT_ContractParameterContext.cs
+++ b/tests/neo.UnitTests/SmartContract/UT_ContractParameterContext.cs
@@ -46,14 +46,14 @@ namespace Neo.UnitTests.SmartContract
             var context = new ContractParametersContext(snapshot, tx);
             context.Add(contract, 0, new byte[] { 0x01 });
             string str = context.ToString();
-            str.Should().Be(@"{""type"":""Neo.Network.P2P.Payloads.Transaction"",""hex"":""AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFmUJDLobcPtqo9vZKIdjXsd8fVGwEAARI="",""items"":{}}");
+            str.Should().Be(@"{""type"":""Neo.Network.P2P.Payloads.Transaction"",""document"":""AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFmUJDLobcPtqo9vZKIdjXsd8fVGwEAARI="",""items"":{}}");
         }
 
         [TestMethod]
         public void TestParse()
         {
             var snapshot = TestBlockchain.GetTestSnapshot();
-            var ret = ContractParametersContext.Parse("{\"type\":\"Neo.Network.P2P.Payloads.Transaction\",\"hex\":\"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFmUJDLobcPtqo9vZKIdjXsd8fVGwEAARI=\",\"items\":{\"0xbecaad15c0ea585211faf99738a4354014f177f2\":{\"script\":\"IQJv8DuUkkHOHa3UNRnmlg4KhbQaaaBcMoEDqivOFZTKFmh0dHaq\",\"parameters\":[{\"type\":\"Signature\",\"value\":\"AQ==\"}],\"signatures\":{\"03b209fd4f53a7170ea4444e0cb0a6bb6a53c2bd016926989cf85f9b0fba17a70c\":\"AQ==\"}}}}", snapshot);
+            var ret = ContractParametersContext.Parse("{\"type\":\"Neo.Network.P2P.Payloads.Transaction\",\"document\":\"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFmUJDLobcPtqo9vZKIdjXsd8fVGwEAARI=\",\"items\":{\"0xbecaad15c0ea585211faf99738a4354014f177f2\":{\"script\":\"IQJv8DuUkkHOHa3UNRnmlg4KhbQaaaBcMoEDqivOFZTKFmh0dHaq\",\"parameters\":[{\"type\":\"Signature\",\"value\":\"AQ==\"}],\"signatures\":{\"03b209fd4f53a7170ea4444e0cb0a6bb6a53c2bd016926989cf85f9b0fba17a70c\":\"AQ==\"}}}}", snapshot);
             ret.ScriptHashes[0].ToString().Should().Be("0x1bd5c777ec35768892bd3daab60fb7a1cb905066");
             ((Transaction)ret.Verifiable).Script.ToHexString().Should().Be(new byte[] { 18 }.ToHexString());
         }
@@ -62,7 +62,7 @@ namespace Neo.UnitTests.SmartContract
         public void TestFromJson()
         {
             var snapshot = TestBlockchain.GetTestSnapshot();
-            Action action = () => ContractParametersContext.Parse("{\"type\":\"wrongType\",\"hex\":\"00000000007c97764845172d827d3c863743293931a691271a0000000000000000000000000000000000000000000100\",\"items\":{\"0x1bd5c777ec35768892bd3daab60fb7a1cb905066\":{\"script\":\"21026ff03b949241ce1dadd43519e6960e0a85b41a69a05c328103aa2bce1594ca1650680a906ad4\",\"parameters\":[{\"type\":\"Signature\",\"value\":\"01\"}]}}}", snapshot);
+            Action action = () => ContractParametersContext.Parse("{\"type\":\"wrongType\",\"document\":\"00000000007c97764845172d827d3c863743293931a691271a0000000000000000000000000000000000000000000100\",\"items\":{\"0x1bd5c777ec35768892bd3daab60fb7a1cb905066\":{\"script\":\"21026ff03b949241ce1dadd43519e6960e0a85b41a69a05c328103aa2bce1594ca1650680a906ad4\",\"parameters\":[{\"type\":\"Signature\",\"value\":\"01\"}]}}}", snapshot);
             action.Should().Throw<FormatException>();
         }
 


### PR DESCRIPTION
It's not really hex since #1199 and even before that it could've been named a
bit differently. `item` is not an option because we already have `items`
there, but we're signing things so probably it's OK to call this signed thing
a `document`.