### PR TITLE
CalculateNetworkFee: throw an exception when contract for a contract-based witness is not found

### DIFF
--- a/src/neo/Wallets/Wallet.cs
+++ b/src/neo/Wallets/Wallet.cs
@@ -549,7 +549,7 @@ namespace Neo.Wallets
                 {
                     var contract = NativeContract.ContractManagement.GetContract(snapshot, hash);
                     if (contract is null)
-                        throw new ArgumentException($"The smart contract {hash} is not found");
+                        throw new ArgumentException($"The smart contract or address {hash} is not found");
                     var md = contract.Manifest.Abi.GetMethod("verify", 0);
                     if (md is null)
                         throw new ArgumentException($"The smart contract {contract.Hash} haven't got verify method without arguments");

--- a/src/neo/Wallets/Wallet.cs
+++ b/src/neo/Wallets/Wallet.cs
@@ -548,7 +548,8 @@ namespace Neo.Wallets
                 if (witness_script is null)
                 {
                     var contract = NativeContract.ContractManagement.GetContract(snapshot, hash);
-                    if (contract is null) continue;
+                    if (contract is null)
+                        throw new ArgumentException($"The smart contract {hash} is not found");
                     var md = contract.Manifest.Abi.GetMethod("verify", 0);
                     if (md is null)
                         throw new ArgumentException($"The smart contract {contract.Hash} haven't got verify method without arguments");

--- a/tests/neo.UnitTests/Network/P2P/Payloads/UT_Transaction.cs
+++ b/tests/neo.UnitTests/Network/P2P/Payloads/UT_Transaction.cs
@@ -718,6 +718,59 @@ namespace Neo.UnitTests.Network.P2P.Payloads
         }
 
         [TestMethod]
+        public void FeeIsSignatureContract_UnexistingVerificationContractFAULT()
+        {
+            var wallet = TestUtils.GenerateTestWallet();
+            var snapshot = TestBlockchain.GetTestSnapshot();
+
+            // no password on this wallet
+            using var unlock = wallet.Unlock("");
+            var acc = wallet.CreateAccount();
+
+            // Fake balance
+
+            var key = NativeContract.GAS.CreateStorageKey(20, acc.ScriptHash);
+
+            var entry = snapshot.GetAndChange(key, () => new StorageItem(new AccountState()));
+
+            entry.GetInteroperable<AccountState>().Balance = 10000 * NativeContract.GAS.Factor;
+
+            snapshot.Commit();
+
+            // Make transaction
+            // Manually creating script
+
+            byte[] script;
+            using (ScriptBuilder sb = new())
+            {
+                // self-transfer of 1e-8 GAS
+                BigInteger value = new BigDecimal(BigInteger.One, 8).Value;
+                sb.EmitDynamicCall(NativeContract.GAS.Hash, "transfer", acc.ScriptHash, acc.ScriptHash, value, null);
+                sb.Emit(OpCode.ASSERT);
+                script = sb.ToArray();
+            }
+
+            // trying global scope
+            var signers = new Signer[]{ new Signer
+                {
+                    Account = acc.ScriptHash,
+                    Scopes = WitnessScope.Global
+                } };
+
+            // creating new wallet with missing account for test
+            var walletWithoutAcc = TestUtils.GenerateTestWallet();
+
+            // using this...
+
+            Transaction tx = null;
+            // expects ArgumentException on execution of 'CalculateNetworkFee' due to
+            // null witness_script (no account in the wallet, no corresponding witness
+            // and no verification contract for the signer)
+            Assert.ThrowsException<ArgumentException>(() => walletWithoutAcc.MakeTransaction(snapshot, script, acc.ScriptHash, signers));
+            Assert.IsNull(tx);
+        }
+
+        [TestMethod]
         public void Transaction_Reverify_Hashes_Length_Unequal_To_Witnesses_Length()
         {
             var snapshot = TestBlockchain.GetTestSnapshot();


### PR DESCRIPTION
We do search for a contract only when `witness_script is null`. And
`witness_script is null` situation can happen in three cases:
1) when it's a contract-based verification => we need a contract
2) when it's a standard verification, but there's no such account
   in the wallet => it's a user error, he should open the wallet with
   the proper account to calculate netFee
3) when it's a standard verification, no account was found in the wallet
   and no suitable witness was found in the provided transaction's
   witnesses => it's a user error (or he might just forget about it),
   but still, the user should provide transaction with suitable
   witnesses to calculate network fee

As a result, cases 2) and 3) are the user's errors, so we need to notify
the user about it (by throwing an exception). And it's impossible to
calculate netFee without a contract in case 1), so we throw an exception.

Otherwise, if the contract is not found and we are continuing, then
calculated network fee is smaller than the real one required for
transaction verification (but the user don't know about it).