### PR TITLE
Fix typo when throwing an exception for negative GAS

### DIFF
--- a/src/neo/SmartContract/ApplicationEngine.Runtime.cs
+++ b/src/neo/SmartContract/ApplicationEngine.Runtime.cs
@@ -293,7 +293,7 @@ namespace Neo.SmartContract
         protected internal void BurnGas(long gas)
         {
             if (gas <= 0)
-                throw new InvalidOperationException("GAS must be possitive.");
+                throw new InvalidOperationException("GAS must be positive.");
             AddGas(gas);
         }
     }


### PR DESCRIPTION
Fixes a typo introduced in PR #2421