### PR TITLE
Murmur128: process data in Little-Endian fashion

### DIFF
--- a/src/neo/Cryptography/Murmur128.cs
+++ b/src/neo/Cryptography/Murmur128.cs
@@ -43,7 +43,7 @@ namespace Neo.Cryptography
             int alignedLength = ibStart + (cbSize - remainder);
             for (int i = ibStart; i < alignedLength; i += 16)
             {
-                ulong k1 = BinaryPrimitives.ReadUInt64BigEndian(array.AsSpan(i));
+                ulong k1 = BinaryPrimitives.ReadUInt64LittleEndian(array.AsSpan(i));
                 k1 *= c1;
                 k1 = RotateLeft(k1, r1);
                 k1 *= c2;
@@ -52,7 +52,7 @@ namespace Neo.Cryptography
                 H1 += H2;
                 H1 = H1 * m + n1;
 
-                ulong k2 = BinaryPrimitives.ReadUInt64BigEndian(array.AsSpan(i + 8));
+                ulong k2 = BinaryPrimitives.ReadUInt64LittleEndian(array.AsSpan(i + 8));
                 k2 *= c2;
                 k2 = RotateLeft(k2, r2);
                 k2 *= c1;

--- a/tests/neo.UnitTests/Cryptography/UT_Murmur128.cs
+++ b/tests/neo.UnitTests/Cryptography/UT_Murmur128.cs
@@ -26,6 +26,9 @@ namespace Neo.UnitTests.Cryptography
 
             array = Encoding.ASCII.GetBytes("hello world");
             array.Murmur128(123u).ToHexString().ToString().Should().Be("e0a0632d4f51302c55e3b3e48d28795d");
+
+            array = "718f952132679baa9c5c2aa0d329fd2a".HexToBytes();
+            array.Murmur128(123u).ToHexString().ToString().Should().Be("9b4aa747ff0cf4e41b3d96251551c8ae");
         }
     }
 }

--- a/tests/neo.UnitTests/SmartContract/UT_ApplicationEngine.Runtime.cs
+++ b/tests/neo.UnitTests/SmartContract/UT_ApplicationEngine.Runtime.cs
@@ -32,11 +32,11 @@ namespace Neo.UnitTests.SmartContract
             var rand_9 = engine_2.GetRandom();
             var rand_10 = engine_2.GetRandom();
 
-            rand_1.Should().Be(BigInteger.Parse("318788182164858154199132431451757857059"));
-            rand_2.Should().Be(BigInteger.Parse("282447758760362720671055450131457608779"));
-            rand_3.Should().Be(BigInteger.Parse("135807514681881442643162663784616300855"));
-            rand_4.Should().Be(BigInteger.Parse("312803243085521724655455828201034417069"));
-            rand_5.Should().Be(BigInteger.Parse("188525996996387253649513686803230761335"));
+            rand_1.Should().Be(BigInteger.Parse("225932872514876835587448704843370203748"));
+            rand_2.Should().Be(BigInteger.Parse("190129535548110356450238097068474508661"));
+            rand_3.Should().Be(BigInteger.Parse("48930406787011198493485648810190184269"));
+            rand_4.Should().Be(BigInteger.Parse("66199389469641263539889463157823839112"));
+            rand_5.Should().Be(BigInteger.Parse("217172703763162599519098299724476526911"));
 
             rand_1.Should().Be(rand_6);
             rand_2.Should().Be(rand_7);
@@ -79,11 +79,11 @@ namespace Neo.UnitTests.SmartContract
             var rand_9 = engine_2.GetRandom();
             var rand_10 = engine_2.GetRandom();
 
-            rand_1.Should().Be(BigInteger.Parse("318788182164858154199132431451757857059"));
-            rand_2.Should().Be(BigInteger.Parse("282447758760362720671055450131457608779"));
-            rand_3.Should().Be(BigInteger.Parse("135807514681881442643162663784616300855"));
-            rand_4.Should().Be(BigInteger.Parse("312803243085521724655455828201034417069"));
-            rand_5.Should().Be(BigInteger.Parse("188525996996387253649513686803230761335"));
+            rand_1.Should().Be(BigInteger.Parse("225932872514876835587448704843370203748"));
+            rand_2.Should().Be(BigInteger.Parse("190129535548110356450238097068474508661"));
+            rand_3.Should().Be(BigInteger.Parse("48930406787011198493485648810190184269"));
+            rand_4.Should().Be(BigInteger.Parse("66199389469641263539889463157823839112"));
+            rand_5.Should().Be(BigInteger.Parse("217172703763162599519098299724476526911"));
 
             rand_1.Should().NotBe(rand_6);
             rand_2.Should().NotBe(rand_7);


### PR DESCRIPTION
The reference implementation make an explicit comment about endianness.
https://github.com/aappleby/smhasher/blob/master/src/MurmurHash3.cpp#L5

Also wikipedia entry on MurmurHash has some rationale behind little-endianness https://en.wikipedia.org/wiki/MurmurHash#Algorithm :
```
Note: Endian swapping is only necessary on big-endian machines.
       The purpose is to place the meaningful digits towards the low end of the value,
       so that these digits have the greatest potential to affect the low range digits
       in the subsequent multiplication.  Consider that locating the meaningful digits
       in the high range would produce a greater effect upon the high digits of the
       multiplication, and notably, that such high digits are likely to be discarded
       by the modulo arithmetic under overflow.  We don't want that.
```

On blockchain we _must_ fix the endianness in case, though.
Given that dominating architecrures nowadays are x86_64 (LE) and ARM (LE _by default_) I think it makes sense to use LE here.