### PR TITLE
optimise `secp256k1` on osx

### DIFF
--- a/src/neo/Cryptography/Crypto.cs
+++ b/src/neo/Cryptography/Crypto.cs
@@ -73,14 +73,13 @@ namespace Neo.Cryptography
                     new Org.BouncyCastle.Math.BigInteger(pubkey.Y.Value.ToString()));
                 var pubKey = new Org.BouncyCastle.Crypto.Parameters.ECPublicKeyParameters("ECDSA", point, domain);
                 var signer = new Org.BouncyCastle.Crypto.Signers.ECDsaSigner();
+                signer.Init(false, pubKey);
 
                 var sig = signature.ToArray();
                 var r = new Org.BouncyCastle.Math.BigInteger(1, sig, 0, 32);
                 var s = new Org.BouncyCastle.Math.BigInteger(1, sig, 32, 32);
 
-                signer.Init(false, pubKey);
-                var hash = Helper.Sha256(message.ToArray());
-                return signer.VerifySignature(hash, r, s);
+                return signer.VerifySignature(message.Sha256(), r, s);
             }
             else
             {

--- a/src/neo/Cryptography/Crypto.cs
+++ b/src/neo/Cryptography/Crypto.cs
@@ -72,17 +72,15 @@ namespace Neo.Cryptography
                     new Org.BouncyCastle.Math.BigInteger(pubkey.X.Value.ToString()),
                     new Org.BouncyCastle.Math.BigInteger(pubkey.Y.Value.ToString()));
                 var pubKey = new Org.BouncyCastle.Crypto.Parameters.ECPublicKeyParameters("ECDSA", point, domain);
-                var signer = Org.BouncyCastle.Security.SignerUtilities.GetSigner("SHA-256withECDSA");
-
-                signer.Init(false, pubKey);
-                signer.BlockUpdate(message.ToArray(), 0, message.Length);
+                var signer = new Org.BouncyCastle.Crypto.Signers.ECDsaSigner();
 
                 var sig = signature.ToArray();
                 var r = new Org.BouncyCastle.Math.BigInteger(1, sig, 0, 32);
                 var s = new Org.BouncyCastle.Math.BigInteger(1, sig, 32, 32);
-                sig = new Org.BouncyCastle.Asn1.DerSequence(new Org.BouncyCastle.Asn1.DerInteger(r), new Org.BouncyCastle.Asn1.DerInteger(s)).GetDerEncoded();
 
-                return signer.VerifySignature(sig);
+                signer.Init(false, pubKey);
+                var hash = Helper.Sha256(message.ToArray());
+                return signer.VerifySignature(hash, r, s);
             }
             else
             {


### PR DESCRIPTION
`new`
|            Method |      Mean |     Error |    StdDev |
|------------------ |----------:|----------:|----------:|
|   VerifySignature |  1.553 ms | 0.0138 ms | 0.0129 ms |

`old`
|            Method |      Mean |     Error |    StdDev |
|------------------ |----------:|----------:|----------:|
|   VerifySignature |  1.649 ms | 0.0327 ms | 0.0726 ms |