### PR TITLE
replace `Buffer.BlockCopy` to `Array.Copy`

### DIFF
--- a/src/neo/Helper.cs
+++ b/src/neo/Helper.cs
@@ -51,7 +51,7 @@ namespace Neo
             int p = 0;
             foreach (byte[] src in buffers)
             {
-                Buffer.BlockCopy(src, 0, dst, p, src.Length);
+                Array.Copy(src, 0, dst, p, src.Length);
                 p += src.Length;
             }
             return dst;

--- a/tests/neo.UnitTests/UT_Helper.cs
+++ b/tests/neo.UnitTests/UT_Helper.cs
@@ -222,5 +222,16 @@ namespace Neo.UnitTests
             var endPoint2 = new IPEndPoint(addr2, 8888);
             endPoint2.Unmap().Should().Be(endPoint);
         }
+
+        [TestMethod]
+        public void TestConcat()
+        {
+            var a = "2d3b96ae1bcc5a585e075e3b81920210dec16302".HexToBytes();
+            var b = "4e454f0050b51da6bb366be3ea50140cda45ba7df575287c0371000b2037ed3898ff8bf5".HexToBytes();
+            var c = "2d3b96ae1bcc5a585e075e3b81920210dec16302".HexToBytes();
+            var d = Helper.Concat(a, b, c).ToHexString().ToString();
+
+            Assert.AreEqual(d, "2d3b96ae1bcc5a585e075e3b81920210dec163024e454f0050b51da6bb366be3ea50140cda45ba7df575287c0371000b2037ed3898ff8bf52d3b96ae1bcc5a585e075e3b81920210dec16302");
+        }
     }
 }


### PR DESCRIPTION
Intel Core i7-9750H CPU 2.60GHz, 1 CPU, 12 logical and 6 physical cores
.NET SDK=5.0.302
  [Host]     : .NET 5.0.8 (5.0.821.31504), X64 RyuJIT  [AttachedDebugger]
  DefaultJob : .NET 5.0.8 (5.0.821.31504), X64 RyuJIT

`new`
| Method |     Mean |    Error |   StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated | Completed Work Items | Lock Contentions |
|------- |---------:|---------:|---------:|-------:|------:|------:|----------:|---------------------:|-----------------:|
| ConCat | 39.19 ns | 0.608 ns | 0.475 ns | 0.0242 |     - |     - |     152 B |               0.0000 |                - |

`old`
| Method |     Mean |    Error |   StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated | Completed Work Items | Lock Contentions |
|------- |---------:|---------:|---------:|-------:|------:|------:|----------:|---------------------:|-----------------:|
| ConCat | 47.16 ns | 0.826 ns | 0.773 ns | 0.0242 |     - |     - |     152 B |               0.0000 |                - |
