### PR TITLE
fix VerifyStateIndependent

### DIFF
--- a/src/neo/Network/P2P/Payloads/Transaction.cs
+++ b/src/neo/Network/P2P/Payloads/Transaction.cs
@@ -407,7 +407,7 @@ namespace Neo.Network.P2P.Payloads
                         if (!Crypto.VerifySignature(this.GetSignData(settings.Network), witnesses[i].InvocationScript.AsSpan(2), pubkey, ECCurve.Secp256r1))
                             return VerifyResult.Invalid;
                     }
-                    catch (Exception)
+                    catch
                     {
                         return VerifyResult.Invalid;
                     }

--- a/src/neo/Network/P2P/Payloads/Transaction.cs
+++ b/src/neo/Network/P2P/Payloads/Transaction.cs
@@ -407,7 +407,7 @@ namespace Neo.Network.P2P.Payloads
                         if (!Crypto.VerifySignature(this.GetSignData(settings.Network), witnesses[i].InvocationScript.AsSpan(2), pubkey, ECCurve.Secp256r1))
                             return VerifyResult.Invalid;
                     }
-                    catch (ArgumentException)
+                    catch (Exception)
                     {
                         return VerifyResult.Invalid;
                     }
@@ -430,7 +430,7 @@ namespace Neo.Network.P2P.Payloads
                                 return VerifyResult.Invalid;
                         }
                     }
-                    catch (ArgumentException)
+                    catch (Exception)
                     {
                         return VerifyResult.Invalid;
                     }

--- a/src/neo/Network/P2P/Payloads/Transaction.cs
+++ b/src/neo/Network/P2P/Payloads/Transaction.cs
@@ -430,7 +430,7 @@ namespace Neo.Network.P2P.Payloads
                                 return VerifyResult.Invalid;
                         }
                     }
-                    catch (Exception)
+                    catch
                     {
                         return VerifyResult.Invalid;
                     }


### PR DESCRIPTION
Func VerifySignature is able to throw exceptions other than ArgumentException, i.e. due to invalid VerificationScript

https://github.com/neo-project/neo/blob/3d19dd897fae8258ce971cf05f4d30660499d8c0/src/neo/Network/P2P/Payloads/Transaction.cs#L407

https://github.com/neo-project/neo/blob/3d19dd897fae8258ce971cf05f4d30660499d8c0/src/neo/Cryptography/Crypto.cs#L114

https://github.com/neo-project/neo/blob/3d19dd897fae8258ce971cf05f4d30660499d8c0/src/neo/Cryptography/ECC/ECPoint.cs#L86