### PR TITLE
Lightweight blockstate

### DIFF
--- a/src/neo/Helper.cs
+++ b/src/neo/Helper.cs
@@ -298,5 +298,16 @@ namespace Neo
                 return endPoint;
             return new IPEndPoint(endPoint.Address.Unmap(), endPoint.Port);
         }
+
+        internal static byte[] XOR(this byte[] value, byte[] other)
+        {
+            if (value.Length != other.Length) return null;
+
+            for (int i = 0; i < value.Length; i++)
+            {
+                value[i] ^= other[i];
+            }
+            return value;
+        }
     }
 }

--- a/src/neo/Persistence/SnapshotCache.cs
+++ b/src/neo/Persistence/SnapshotCache.cs
@@ -34,10 +34,11 @@ namespace Neo.Persistence
             snapshot?.Delete(key.ToArray());
         }
 
-        public override void Commit()
+        public override byte[] Commit()
         {
             base.Commit();
             snapshot.Commit();
+            return null;
         }
 
         protected override bool ContainsInternal(StorageKey key)


### PR DESCRIPTION
Transactions in the block can not ensure that all nodes are in the same state, we still need a state synchronization mechanism to ensure that all nodes are at the same pace.

This is a lightweight block state, it uses the hash of every storage operation as the current block state.
