### PR TITLE
fix plugin configwatcher

### DIFF
--- a/src/neo/Plugins/Plugin.cs
+++ b/src/neo/Plugins/Plugin.cs
@@ -65,7 +65,7 @@ namespace Neo.Plugins
                 {
                     EnableRaisingEvents = true,
                     IncludeSubdirectories = true,
-                    NotifyFilter = NotifyFilters.CreationTime | NotifyFilters.LastWrite | NotifyFilters.Size,
+                    NotifyFilter = NotifyFilters.FileName | NotifyFilters.DirectoryName | NotifyFilters.CreationTime | NotifyFilters.LastWrite | NotifyFilters.Size,
                 };
                 configWatcher.Changed += ConfigWatcher_Changed;
                 configWatcher.Created += ConfigWatcher_Changed;

--- a/src/neo/Plugins/Plugin.cs
+++ b/src/neo/Plugins/Plugin.cs
@@ -78,13 +78,13 @@ namespace Neo.Plugins
         /// </summary>
         protected Plugin()
         {
-            Plugins.Add(this);
+            if (!Plugins.Contains(this))Plugins.Add(this);
 
-            if (this is ILogPlugin logger) Loggers.Add(logger);
-            if (this is IStorageProvider storage) Storages.Add(Name, storage);
-            if (this is IP2PPlugin p2p) P2PPlugins.Add(p2p);
-            if (this is IPersistencePlugin persistence) PersistencePlugins.Add(persistence);
-            if (this is IMemoryPoolTxObserverPlugin txObserver) TxObserverPlugins.Add(txObserver);
+            if (this is ILogPlugin logger && !Loggers.Contains(logger)) Loggers.Add(logger);
+            if (this is IStorageProvider storage && !Storages.ContainsKey(Name)) Storages.Add(Name, storage);
+            if (this is IP2PPlugin p2p && !P2PPlugins.Contains(p2p)) P2PPlugins.Add(p2p);
+            if (this is IPersistencePlugin persistence && !PersistencePlugins.Contains(persistence)) PersistencePlugins.Add(persistence);
+            if (this is IMemoryPoolTxObserverPlugin txObserver && !TxObserverPlugins.Contains(txObserver)) TxObserverPlugins.Add(txObserver);
             if (this is IApplicationEngineProvider provider) ApplicationEngine.SetApplicationEngineProvider(provider);
 
             Configure();

--- a/src/neo/Plugins/Plugin.cs
+++ b/src/neo/Plugins/Plugin.cs
@@ -78,7 +78,7 @@ namespace Neo.Plugins
         /// </summary>
         protected Plugin()
         {
-            if (!Plugins.Contains(this))Plugins.Add(this);
+            if (!Plugins.Contains(this)) Plugins.Add(this);
 
             if (this is ILogPlugin logger && !Loggers.Contains(logger)) Loggers.Add(logger);
             if (this is IStorageProvider storage && !Storages.ContainsKey(Name)) Storages.Add(Name, storage);


### PR DESCRIPTION
I'm not sure whether this is by design, but apparently 

https://github.com/neo-project/neo/blob/a4d2eddbee049bbe3d5d9552e11181d294af929e/src/neo/Plugins/Plugin.cs#L71

will not take effect when a new file or folder for a plugin created. File modification does take effect, though.