### PR TITLE
Check amount > 0 to avoid adding undesired (Account, Value)

### DIFF
--- a/src/neo/Wallets/Wallet.cs
+++ b/src/neo/Wallets/Wallet.cs
@@ -188,7 +188,7 @@ namespace Neo.Wallets
                         orderedAccounts.RemoveAt(i);
                         i--;
                     }
-                    for (i = 0; i < orderedAccounts.Count; i++)
+                    for (i = 0; amount > 0 && i < orderedAccounts.Count; i++)
                     {
                         if (orderedAccounts[i].Value < amount)
                             continue;

--- a/src/neo/Wallets/Wallet.cs
+++ b/src/neo/Wallets/Wallet.cs
@@ -188,21 +188,24 @@ namespace Neo.Wallets
                         orderedAccounts.RemoveAt(i);
                         i--;
                     }
-                    for (i = 0; amount > 0 && i < orderedAccounts.Count; i++)
+                    if (amount > 0)
                     {
-                        if (orderedAccounts[i].Value < amount)
-                            continue;
-                        if (orderedAccounts[i].Value == amount)
+                        for (i = 0; i < orderedAccounts.Count; i++)
                         {
-                            result.Add(orderedAccounts[i]);
-                            orderedAccounts.RemoveAt(i);
+                            if (orderedAccounts[i].Value < amount)
+                                continue;
+                            if (orderedAccounts[i].Value == amount)
+                            {
+                                result.Add(orderedAccounts[i]);
+                                orderedAccounts.RemoveAt(i);
+                            }
+                            else
+                            {
+                                result.Add((orderedAccounts[i].Account, amount));
+                                orderedAccounts[i] = (orderedAccounts[i].Account, orderedAccounts[i].Value - amount);
+                            }
+                            break;
                         }
-                        else
-                        {
-                            result.Add((orderedAccounts[i].Account, amount));
-                            orderedAccounts[i] = (orderedAccounts[i].Account, orderedAccounts[i].Value - amount);
-                        }
-                        break;
                     }
                 }
             }


### PR DESCRIPTION
When `amount` equals 0 in the second `for` loop, if there are remaining `orderedAccounts`, `result` will add an extra `(orderedAccounts[i].Account, 0)` into it and thus this account will be added into the `cosignerList` which is unnecessary.