### PR TITLE
Decimal compare

### DIFF
--- a/src/neo/BigDecimal.cs
+++ b/src/neo/BigDecimal.cs
@@ -188,7 +188,9 @@ namespace Neo
 
         public override int GetHashCode()
         {
-            return HashCode.Combine(value, decimals);
+            BigInteger divisor = BigInteger.Pow(10, decimals);
+            BigInteger result = BigInteger.DivRem(value, divisor, out BigInteger remainder);
+            return HashCode.Combine(result, remainder);
         }
     }
 }

--- a/src/neo/BigDecimal.cs
+++ b/src/neo/BigDecimal.cs
@@ -167,27 +167,28 @@ namespace Neo
 
         public int CompareTo(BigDecimal other)
         {
-            var left = BigInteger.Multiply((int)Math.Pow(10, other.decimals), value);
-            var right = BigInteger.Multiply((int)Math.Pow(10, decimals), other.value);
+            BigInteger left = value, right = other.value;
+            if (decimals < other.decimals)
+                left *= BigInteger.Pow(10, other.decimals - decimals);
+            else if (decimals > other.decimals)
+                right *= BigInteger.Pow(10, decimals - other.decimals);
             return left.CompareTo(right);
         }
 
         public override bool Equals(object obj)
         {
-            return Equals(obj is BigDecimal @decimal ? @decimal : default);
+            if (obj is not BigDecimal @decimal) return false;
+            return Equals(@decimal);
+        }
+
+        public bool Equals(BigDecimal other)
+        {
+            return CompareTo(other) == 0;
         }
 
         public override int GetHashCode()
         {
             return HashCode.Combine(value, decimals);
-        }
-
-        public bool Equals(BigDecimal other)
-        {
-            if (Sign != other.Sign) return false;
-            var left = BigInteger.Multiply((int)Math.Pow(10, other.decimals), value);
-            var right = BigInteger.Multiply((int)Math.Pow(10, decimals), other.value);
-            return left == right;
         }
     }
 }

--- a/src/neo/BigDecimal.cs
+++ b/src/neo/BigDecimal.cs
@@ -192,5 +192,35 @@ namespace Neo
             BigInteger result = BigInteger.DivRem(value, divisor, out BigInteger remainder);
             return HashCode.Combine(result, remainder);
         }
+
+        public static bool operator ==(BigDecimal left, BigDecimal right)
+        {
+            return left.CompareTo(right) == 0;
+        }
+
+        public static bool operator !=(BigDecimal left, BigDecimal right)
+        {
+            return left.CompareTo(right) != 0;
+        }
+
+        public static bool operator <(BigDecimal left, BigDecimal right)
+        {
+            return left.CompareTo(right) < 0;
+        }
+
+        public static bool operator <=(BigDecimal left, BigDecimal right)
+        {
+            return left.CompareTo(right) <= 0;
+        }
+
+        public static bool operator >(BigDecimal left, BigDecimal right)
+        {
+            return left.CompareTo(right) > 0;
+        }
+
+        public static bool operator >=(BigDecimal left, BigDecimal right)
+        {
+            return left.CompareTo(right) >= 0;
+        }
     }
 }

--- a/src/neo/BigDecimal.cs
+++ b/src/neo/BigDecimal.cs
@@ -16,7 +16,7 @@ namespace Neo
     /// <summary>
     /// Represents a fixed-point number of arbitrary precision.
     /// </summary>
-    public struct BigDecimal
+    public struct BigDecimal : IComparable<BigDecimal>, IEquatable<BigDecimal>
     {
         private readonly BigInteger value;
         private readonly byte decimals;
@@ -163,6 +163,31 @@ namespace Neo
             }
             result = new BigDecimal(value, decimals);
             return true;
+        }
+
+        public int CompareTo(BigDecimal other)
+        {
+            var left = BigInteger.Multiply((int)Math.Pow(10, other.decimals), value);
+            var right = BigInteger.Multiply((int)Math.Pow(10, decimals), other.value);
+            return left.CompareTo(right);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj is BigDecimal @decimal ? @decimal : default);
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(value, decimals);
+        }
+
+        public bool Equals(BigDecimal other)
+        {
+            if (Sign != other.Sign) return false;
+            var left = BigInteger.Multiply((int)Math.Pow(10, other.decimals), value);
+            var right = BigInteger.Multiply((int)Math.Pow(10, decimals), other.value);
+            return left == right;
         }
     }
 }

--- a/src/neo/BigDecimal.cs
+++ b/src/neo/BigDecimal.cs
@@ -59,6 +59,7 @@ namespace Neo
             {
                 ReadOnlySpan<byte> buffer = new(p, 16);
                 this.value = new BigInteger(buffer[..12], isUnsigned: true);
+                if (buffer[15] != 0) this.value = -this.value;
                 this.decimals = buffer[14];
             }
         }
@@ -80,6 +81,8 @@ namespace Neo
                     throw new ArgumentException(null, nameof(value));
                 else if (buffer[14] < decimals)
                     this.value *= BigInteger.Pow(10, decimals - buffer[14]);
+                if (buffer[15] != 0)
+                    this.value = -this.value;
             }
             this.decimals = decimals;
         }

--- a/tests/neo.UnitTests/UT_BigDecimal.cs
+++ b/tests/neo.UnitTests/UT_BigDecimal.cs
@@ -58,6 +58,10 @@ namespace Neo.UnitTests
             value = new BigDecimal(0M, 0);
             value.Value.Should().Be(new BigInteger(0));
             value.Decimals.Should().Be(0);
+
+            value = new BigDecimal(5.5M, 1);
+            var b = new BigDecimal(55M);
+            value.Value.Should().Be(b.Value);
         }
 
         [TestMethod]
@@ -69,6 +73,20 @@ namespace Neo.UnitTests
             value.Sign.Should().Be(0);
             value = new BigDecimal(new BigInteger(-10), 0);
             value.Sign.Should().Be(-1);
+        }
+
+        [TestMethod]
+        public void TestCompareDecimals()
+        {
+            BigDecimal a = new(5.5M, 1);
+            BigDecimal b = new(55M);
+            BigDecimal c = new(55M, 1);
+            a.Equals(b).Should().Be(false);
+            a.Equals(c).Should().Be(false);
+            b.Equals(c).Should().Be(true);
+            a.CompareTo(b).Should().Be(-1);
+            a.CompareTo(c).Should().Be(-1);
+            b.CompareTo(c).Should().Be(0);
         }
 
         [TestMethod]


### PR DESCRIPTION
refer to https://github.com/neo-project/neo/issues/2640#issuecomment-985096362

Add the `compare` and `equal` methods to `BigDecimal`

```C#
            BigDecimal a = new(5.5M, 1);
            BigDecimal b = new(55M);
            BigDecimal c = new(55M, 1);
            a.Equals(b).Should().Be(false);
            a.Equals(c).Should().Be(false);
            b.Equals(c).Should().Be(true);
            a.CompareTo(b).Should().Be(-1);
            a.CompareTo(c).Should().Be(-1);
            b.CompareTo(c).Should().Be(0);
```