### PR TITLE
Add Scopes into Transaction

### DIFF
--- a/src/neo/Network/P2P/Payloads/Transaction.cs
+++ b/src/neo/Network/P2P/Payloads/Transaction.cs
@@ -464,6 +464,7 @@ namespace Neo.Network.P2P.Payloads
                 NetworkFee,
                 ValidUntilBlock,
                 Script,
+                new Array(referenceCounter, Signers.Select(u => new ByteString(u.ToArray())))
             });
         }
 

--- a/src/neo/Network/P2P/Payloads/Transaction.cs
+++ b/src/neo/Network/P2P/Payloads/Transaction.cs
@@ -464,7 +464,7 @@ namespace Neo.Network.P2P.Payloads
                 NetworkFee,
                 ValidUntilBlock,
                 Script,
-                new Array(referenceCounter, Signers.Select(u => new ByteString(u.ToArray())))
+                new Array(referenceCounter, Signers.Where(u => u.Scopes != WitnessScope.None).Select(u => new ByteString(u.ToArray())))
             });
         }
 

--- a/src/neo/Network/P2P/Payloads/Transaction.cs
+++ b/src/neo/Network/P2P/Payloads/Transaction.cs
@@ -451,6 +451,11 @@ namespace Neo.Network.P2P.Payloads
 
         public StackItem ToStackItem(ReferenceCounter referenceCounter)
         {
+            // Compute signers
+            var signers = new Map(referenceCounter);
+            foreach (var signer in Signers)
+                signers[signer.Account.ToArray()] = signer.ToArray();
+
             return new Array(referenceCounter, new StackItem[]
             {
                 // Computed properties
@@ -464,7 +469,7 @@ namespace Neo.Network.P2P.Payloads
                 NetworkFee,
                 ValidUntilBlock,
                 Script,
-                new Array(referenceCounter, Signers.Select(u => new ByteString(u.ToArray())))
+                signers
             });
         }
 

--- a/src/neo/Network/P2P/Payloads/Transaction.cs
+++ b/src/neo/Network/P2P/Payloads/Transaction.cs
@@ -464,7 +464,7 @@ namespace Neo.Network.P2P.Payloads
                 NetworkFee,
                 ValidUntilBlock,
                 Script,
-                new Array(referenceCounter, Signers.Where(u => u.Scopes != WitnessScope.None).Select(u => new ByteString(u.ToArray())))
+                new Array(referenceCounter, Signers.Select(u => new ByteString(u.ToArray())))
             });
         }
 


### PR DESCRIPTION
It's required to have access to the transaction's scopes inside the smart contract in certain cases, I thought about create a new syscall, check if a witness it will be valid, but it depend of the callingscript, executionscript, in fact the whole ExecutionEngine...
I want to check inside my verify if the transaction was signed by the user.