### PR TITLE
Prevent cross throw

### DIFF
--- a/src/neo/SmartContract/ApplicationEngine.cs
+++ b/src/neo/SmartContract/ApplicationEngine.cs
@@ -264,7 +264,8 @@ namespace Neo.SmartContract
                 currentNodeOfInvocationTree = currentNodeOfInvocationTree.Parent;
             if (UncaughtException is not null && CurrentContext is not null && context.Script != CurrentContext.Script)
             {
-                throw new VMUnhandledException(UncaughtException);
+                ExecutionContextState state = CurrentContext.GetState<ExecutionContextState>();
+                if (!state.AllowCrossThrows) throw new VMUnhandledException(UncaughtException);
             }
             if (contractTasks.Remove(context, out var awaiter))
             {
@@ -325,6 +326,7 @@ namespace Neo.SmartContract
                 {
                     p.CallFlags = callFlags;
                     p.ScriptHash = contract.Hash;
+                    p.AllowCrossThrows = method.AllowCrossThrows;
                     p.Contract = new ContractState
                     {
                         Id = contract.Id,

--- a/src/neo/SmartContract/ApplicationEngine.cs
+++ b/src/neo/SmartContract/ApplicationEngine.cs
@@ -262,10 +262,16 @@ namespace Neo.SmartContract
             base.ContextUnloaded(context);
             if (Diagnostic is not null)
                 currentNodeOfInvocationTree = currentNodeOfInvocationTree.Parent;
-            if (!contractTasks.Remove(context, out var awaiter)) return;
-            if (UncaughtException is not null)
+            if (UncaughtException is not null && CurrentContext is not null && context.Script != CurrentContext.Script)
+            {
                 throw new VMUnhandledException(UncaughtException);
-            awaiter.SetResult(this);
+            }
+            if (contractTasks.Remove(context, out var awaiter))
+            {
+                if (UncaughtException is not null)
+                    throw new VMUnhandledException(UncaughtException);
+                awaiter.SetResult(this);
+            }
         }
 
         /// <summary>

--- a/src/neo/SmartContract/ExecutionContextState.cs
+++ b/src/neo/SmartContract/ExecutionContextState.cs
@@ -36,5 +36,11 @@ namespace Neo.SmartContract
         /// The <see cref="SmartContract.CallFlags"/> of the current context.
         /// </summary>
         public CallFlags CallFlags { get; set; } = CallFlags.All;
+
+        /// <summary>
+        /// Indicates whether the method allow to throw exceptions from external contract.
+        /// False by default
+        /// </summary>
+        public bool AllowCrossThrows { get; set; } = false;
     }
 }

--- a/src/neo/SmartContract/Manifest/ContractMethodDescriptor.cs
+++ b/src/neo/SmartContract/Manifest/ContractMethodDescriptor.cs
@@ -96,6 +96,7 @@ namespace Neo.SmartContract.Manifest
             json["returntype"] = ReturnType.ToString();
             json["offset"] = Offset;
             json["safe"] = Safe;
+            json["allowCrossThrows"] = AllowCrossThrows;
             return json;
         }
     }

--- a/src/neo/SmartContract/Manifest/ContractMethodDescriptor.cs
+++ b/src/neo/SmartContract/Manifest/ContractMethodDescriptor.cs
@@ -37,6 +37,12 @@ namespace Neo.SmartContract.Manifest
         /// </summary>
         public bool Safe { get; set; }
 
+        /// <summary>
+        /// Indicates whether the method allow to throw exceptions from external contract.
+        /// False by default
+        /// </summary>
+        public bool AllowCrossThrows { get; set; }
+
         public override void FromStackItem(StackItem stackItem)
         {
             base.FromStackItem(stackItem);
@@ -44,6 +50,7 @@ namespace Neo.SmartContract.Manifest
             ReturnType = (ContractParameterType)(byte)@struct[2].GetInteger();
             Offset = (int)@struct[3].GetInteger();
             Safe = @struct[4].GetBoolean();
+            AllowCrossThrows = @struct.Count > 5 && @struct[5].GetBoolean();
         }
 
         public override StackItem ToStackItem(ReferenceCounter referenceCounter)
@@ -52,6 +59,7 @@ namespace Neo.SmartContract.Manifest
             @struct.Add((byte)ReturnType);
             @struct.Add(Offset);
             @struct.Add(Safe);
+            @struct.Add(AllowCrossThrows);
             return @struct;
         }
 
@@ -68,7 +76,8 @@ namespace Neo.SmartContract.Manifest
                 Parameters = ((JArray)json["parameters"]).Select(u => ContractParameterDefinition.FromJson(u)).ToArray(),
                 ReturnType = Enum.Parse<ContractParameterType>(json["returntype"].GetString()),
                 Offset = json["offset"].GetInt32(),
-                Safe = json["safe"].GetBoolean()
+                Safe = json["safe"].GetBoolean(),
+                AllowCrossThrows = json["allowCrossThrows"]?.GetBoolean() == true
             };
             if (string.IsNullOrEmpty(descriptor.Name)) throw new FormatException();
             _ = descriptor.Parameters.ToDictionary(p => p.Name);


### PR DESCRIPTION
Any contract can return error codes or error messages without a `throw`, I think that we have two possible good solutions:

1- This one, prevent cross-throws (we don't really need them).
2- Isolate storage changes between contract calls (like ethereum does).
