### PR TITLE
Small StorageKey optimization

### DIFF
--- a/src/neo/SmartContract/StorageKey.cs
+++ b/src/neo/SmartContract/StorageKey.cs
@@ -84,7 +84,7 @@ namespace Neo.SmartContract
 
         public override int GetHashCode()
         {
-            return Id.GetHashCode() + (int)Key.Span.Murmur32(0);
+            return Id + (int)Key.Span.Murmur32(0);
         }
 
         void ISerializable.Serialize(BinaryWriter writer)

--- a/src/neo/SmartContract/StorageKey.cs
+++ b/src/neo/SmartContract/StorageKey.cs
@@ -17,7 +17,7 @@ namespace Neo.SmartContract
     /// <summary>
     /// Represents the keys in contract storage.
     /// </summary>
-    public class StorageKey : IEquatable<StorageKey>
+    public sealed record StorageKey
     {
         /// <summary>
         /// The id of the contract.
@@ -32,12 +32,6 @@ namespace Neo.SmartContract
         private byte[] cache = null;
 
         public StorageKey() { }
-
-        public StorageKey(int id, ReadOnlyMemory<byte> key)
-        {
-            Id = id;
-            Key = key;
-        }
 
         internal StorageKey(byte[] cache)
         {
@@ -67,12 +61,6 @@ namespace Neo.SmartContract
             if (ReferenceEquals(this, other))
                 return true;
             return Id == other.Id && Key.Span.SequenceEqual(other.Key.Span);
-        }
-
-        public override bool Equals(object obj)
-        {
-            if (obj is not StorageKey other) return false;
-            return Equals(other);
         }
 
         public override int GetHashCode()

--- a/tests/neo.UnitTests/IO/Caching/UT_CloneCache.cs
+++ b/tests/neo.UnitTests/IO/Caching/UT_CloneCache.cs
@@ -15,6 +15,11 @@ namespace Neo.UnitTests.IO.Caching
         ClonedCache clonedCache;
         MyDataCache myDataCache;
 
+        private static readonly StorageKey key1 = new() { Id = 0, Key = Encoding.UTF8.GetBytes("key1") };
+        private static readonly StorageKey key2 = new() { Id = 0, Key = Encoding.UTF8.GetBytes("key2") };
+        private static readonly StorageKey key3 = new() { Id = 0, Key = Encoding.UTF8.GetBytes("key3") };
+        private static readonly StorageKey key4 = new() { Id = 0, Key = Encoding.UTF8.GetBytes("key4") };
+
         [TestInitialize]
         public void Init()
         {
@@ -31,64 +36,64 @@ namespace Neo.UnitTests.IO.Caching
         [TestMethod]
         public void TestAddInternal()
         {
-            clonedCache.Add(new MyKey("key1"), new MyValue("value1"));
-            clonedCache[new MyKey("key1")].Should().Be(new MyValue("value1"));
+            clonedCache.Add(key1, new MyValue("value1"));
+            clonedCache[key1].Should().Be(new MyValue("value1"));
 
             clonedCache.Commit();
-            Assert.IsTrue(myDataCache[new MyKey("key1")].Value.Span.SequenceEqual(new MyValue("value1").Value.Span));
+            Assert.IsTrue(myDataCache[key1].Value.Span.SequenceEqual(new MyValue("value1").Value.Span));
         }
 
         [TestMethod]
         public void TestDeleteInternal()
         {
-            myDataCache.Add(new MyKey("key1"), new MyValue("value1"));
-            clonedCache.Delete(new MyKey("key1"));   //  trackable.State = TrackState.Deleted
+            myDataCache.Add(key1, new MyValue("value1"));
+            clonedCache.Delete(key1);   //  trackable.State = TrackState.Deleted
             clonedCache.Commit();
 
-            clonedCache.TryGet(new MyKey("key1")).Should().BeNull();
-            myDataCache.TryGet(new MyKey("key1")).Should().BeNull();
+            clonedCache.TryGet(key1).Should().BeNull();
+            myDataCache.TryGet(key1).Should().BeNull();
         }
 
         [TestMethod]
         public void TestFindInternal()
         {
-            clonedCache.Add(new MyKey("key1"), new MyValue("value1"));
-            myDataCache.Add(new MyKey("key2"), new MyValue("value2"));
-            myDataCache.InnerDict.Add(new MyKey("key3"), new MyValue("value3"));
+            clonedCache.Add(key1, new MyValue("value1"));
+            myDataCache.Add(key2, new MyValue("value2"));
+            myDataCache.InnerDict.Add(key3, new MyValue("value3"));
 
-            var items = clonedCache.Find(new MyKey("key1").ToArray());
-            items.ElementAt(0).Key.Should().Be(new MyKey("key1"));
+            var items = clonedCache.Find(key1.ToArray());
+            items.ElementAt(0).Key.Should().Be(key1);
             items.ElementAt(0).Value.Should().Be(new MyValue("value1"));
             items.Count().Should().Be(1);
 
-            items = clonedCache.Find(new MyKey("key2").ToArray());
-            items.ElementAt(0).Key.Should().Be(new MyKey("key2"));
+            items = clonedCache.Find(key2.ToArray());
+            items.ElementAt(0).Key.Should().Be(key2);
             new MyValue("value2").Should().Be(items.ElementAt(0).Value);
             items.Count().Should().Be(1);
 
-            items = clonedCache.Find(new MyKey("key3").ToArray());
-            items.ElementAt(0).Key.Should().Be(new MyKey("key3"));
+            items = clonedCache.Find(key3.ToArray());
+            items.ElementAt(0).Key.Should().Be(key3);
             new MyValue("value3").Should().Be(items.ElementAt(0).Value);
             items.Count().Should().Be(1);
 
-            items = clonedCache.Find(new MyKey("key4").ToArray());
+            items = clonedCache.Find(key4.ToArray());
             items.Count().Should().Be(0);
         }
 
         [TestMethod]
         public void TestGetInternal()
         {
-            clonedCache.Add(new MyKey("key1"), new MyValue("value1"));
-            myDataCache.Add(new MyKey("key2"), new MyValue("value2"));
-            myDataCache.InnerDict.Add(new MyKey("key3"), new MyValue("value3"));
+            clonedCache.Add(key1, new MyValue("value1"));
+            myDataCache.Add(key2, new MyValue("value2"));
+            myDataCache.InnerDict.Add(key3, new MyValue("value3"));
 
-            new MyValue("value1").Should().Be(clonedCache[new MyKey("key1")]);
-            new MyValue("value2").Should().Be(clonedCache[new MyKey("key2")]);
-            new MyValue("value3").Should().Be(clonedCache[new MyKey("key3")]);
+            new MyValue("value1").Should().Be(clonedCache[key1]);
+            new MyValue("value2").Should().Be(clonedCache[key2]);
+            new MyValue("value3").Should().Be(clonedCache[key3]);
 
             Action action = () =>
             {
-                var item = clonedCache[new MyKey("key4")];
+                var item = clonedCache[key4];
             };
             action.Should().Throw<KeyNotFoundException>();
         }
@@ -96,33 +101,33 @@ namespace Neo.UnitTests.IO.Caching
         [TestMethod]
         public void TestTryGetInternal()
         {
-            clonedCache.Add(new MyKey("key1"), new MyValue("value1"));
-            myDataCache.Add(new MyKey("key2"), new MyValue("value2"));
-            myDataCache.InnerDict.Add(new MyKey("key3"), new MyValue("value3"));
+            clonedCache.Add(key1, new MyValue("value1"));
+            myDataCache.Add(key2, new MyValue("value2"));
+            myDataCache.InnerDict.Add(key3, new MyValue("value3"));
 
-            new MyValue("value1").Should().Be(clonedCache.TryGet(new MyKey("key1")));
-            new MyValue("value2").Should().Be(clonedCache.TryGet(new MyKey("key2")));
-            new MyValue("value3").Should().Be(clonedCache.TryGet(new MyKey("key3")));
-            clonedCache.TryGet(new MyKey("key4")).Should().BeNull();
+            new MyValue("value1").Should().Be(clonedCache.TryGet(key1));
+            new MyValue("value2").Should().Be(clonedCache.TryGet(key2));
+            new MyValue("value3").Should().Be(clonedCache.TryGet(key3));
+            clonedCache.TryGet(key4).Should().BeNull();
         }
 
         [TestMethod]
         public void TestUpdateInternal()
         {
-            clonedCache.Add(new MyKey("key1"), new MyValue("value1"));
-            myDataCache.Add(new MyKey("key2"), new MyValue("value2"));
-            myDataCache.InnerDict.Add(new MyKey("key3"), new MyValue("value3"));
+            clonedCache.Add(key1, new MyValue("value1"));
+            myDataCache.Add(key2, new MyValue("value2"));
+            myDataCache.InnerDict.Add(key3, new MyValue("value3"));
 
-            clonedCache.GetAndChange(new MyKey("key1")).Value = Encoding.Default.GetBytes("value_new_1");
-            clonedCache.GetAndChange(new MyKey("key2")).Value = Encoding.Default.GetBytes("value_new_2");
-            clonedCache.GetAndChange(new MyKey("key3")).Value = Encoding.Default.GetBytes("value_new_3");
+            clonedCache.GetAndChange(key1).Value = Encoding.Default.GetBytes("value_new_1");
+            clonedCache.GetAndChange(key2).Value = Encoding.Default.GetBytes("value_new_2");
+            clonedCache.GetAndChange(key3).Value = Encoding.Default.GetBytes("value_new_3");
 
             clonedCache.Commit();
 
-            new MyValue("value_new_1").Should().Be(clonedCache[new MyKey("key1")]);
-            new MyValue("value_new_2").Should().Be(clonedCache[new MyKey("key2")]);
-            new MyValue("value_new_3").Should().Be(clonedCache[new MyKey("key3")]);
-            new MyValue("value_new_2").Should().Be(clonedCache[new MyKey("key2")]);
+            new MyValue("value_new_1").Should().Be(clonedCache[key1]);
+            new MyValue("value_new_2").Should().Be(clonedCache[key2]);
+            new MyValue("value_new_3").Should().Be(clonedCache[key3]);
+            new MyValue("value_new_2").Should().Be(clonedCache[key2]);
         }
 
         [TestMethod]

--- a/tests/neo.UnitTests/IO/Caching/UT_DataCache.cs
+++ b/tests/neo.UnitTests/IO/Caching/UT_DataCache.cs
@@ -5,7 +5,6 @@ using Neo.Persistence;
 using Neo.SmartContract;
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Text;
 
@@ -31,15 +30,6 @@ namespace Neo.UnitTests.IO.Caching
             Key = Encoding.UTF8.GetBytes(val);
         }
 
-        public void Deserialize(BinaryReader reader)
-        {
-            Key = Encoding.UTF8.GetBytes(reader.ReadString());
-        }
-
-        public void Serialize(BinaryWriter writer)
-        {
-            writer.Write(Key.Span);
-        }
         public bool Equals(MyKey other)
         {
             if (other == null) return false;

--- a/tests/neo.UnitTests/Ledger/UT_MemoryPool.cs
+++ b/tests/neo.UnitTests/Ledger/UT_MemoryPool.cs
@@ -516,10 +516,8 @@ namespace Neo.UnitTests.Ledger
             {
                 Value = feePerByte
             };
-            var key1 = CreateStorageKey(Prefix_MaxTransactionsPerBlock);
-            var key2 = CreateStorageKey(Prefix_FeePerByte);
-            key1.Id = NativeContract.Policy.Id;
-            key2.Id = NativeContract.Policy.Id;
+            var key1 = CreateStorageKey(NativeContract.Policy.Id, Prefix_MaxTransactionsPerBlock);
+            var key2 = CreateStorageKey(NativeContract.Policy.Id, Prefix_FeePerByte);
             snapshot.Add(key1, item1);
             snapshot.Add(key2, item2);
 
@@ -543,14 +541,14 @@ namespace Neo.UnitTests.Ledger
             _unit.VerifiedCount.Should().Be(0);
         }
 
-        public static StorageKey CreateStorageKey(byte prefix, byte[] key = null)
+        public static StorageKey CreateStorageKey(int id, byte prefix, byte[] key = null)
         {
             byte[] buffer = GC.AllocateUninitializedArray<byte>(sizeof(byte) + (key?.Length ?? 0));
             buffer[0] = prefix;
             key?.CopyTo(buffer.AsSpan(1));
             return new()
             {
-                Id = 0,
+                Id = id,
                 Key = buffer
             };
         }

--- a/tests/neo.UnitTests/Ledger/UT_StorageKey.cs
+++ b/tests/neo.UnitTests/Ledger/UT_StorageKey.cs
@@ -1,9 +1,6 @@
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Neo.IO;
 using Neo.SmartContract;
-using System;
-using System.IO;
 
 namespace Neo.UnitTests.Ledger
 {
@@ -13,21 +10,8 @@ namespace Neo.UnitTests.Ledger
         [TestMethod]
         public void Id_Get()
         {
-            var uut = new StorageKey(1, new byte[] { 0x01 });
+            var uut = new StorageKey { Id = 1, Key = new byte[] { 0x01 } };
             uut.Id.Should().Be(1);
-        }
-
-        [TestMethod]
-        public void Size()
-        {
-            var ut = new StorageKey() { Key = new byte[17], Id = 0 };
-            ut.ToArray().Length.Should().Be(((ISerializable)ut).Size);
-
-            ut = new StorageKey() { Key = Array.Empty<byte>(), Id = 0 };
-            ut.ToArray().Length.Should().Be(((ISerializable)ut).Size);
-
-            ut = new StorageKey() { Key = new byte[16], Id = 0 };
-            ut.ToArray().Length.Should().Be(((ISerializable)ut).Size);
         }
 
         [TestMethod]
@@ -78,7 +62,7 @@ namespace Neo.UnitTests.Ledger
                 Id = val,
                 Key = keyVal
             };
-            StorageKey uut = new(val, keyVal);
+            StorageKey uut = new() { Id = val, Key = keyVal };
             uut.Equals(newSk).Should().BeTrue();
         }
 
@@ -92,7 +76,7 @@ namespace Neo.UnitTests.Ledger
                 Id = val,
                 Key = keyVal
             };
-            StorageKey uut = new(0x78000000, keyVal);
+            StorageKey uut = new() { Id = 0x78000000, Key = keyVal };
             uut.Equals(newSk).Should().BeFalse();
         }
 
@@ -106,14 +90,14 @@ namespace Neo.UnitTests.Ledger
                 Id = val,
                 Key = keyVal
             };
-            StorageKey uut = new(val, TestUtils.GetByteArray(10, 0x88));
+            StorageKey uut = new() { Id = val, Key = TestUtils.GetByteArray(10, 0x88) };
             uut.Equals(newSk).Should().BeFalse();
         }
 
         [TestMethod]
         public void GetHashCode_Get()
         {
-            StorageKey uut = new(0x42000000, TestUtils.GetByteArray(10, 0x42));
+            StorageKey uut = new() { Id = 0x42000000, Key = TestUtils.GetByteArray(10, 0x42) };
             uut.GetHashCode().Should().Be(1374529787);
         }
 
@@ -123,22 +107,6 @@ namespace Neo.UnitTests.Ledger
             StorageKey uut = new();
             uut.Equals(1u).Should().BeFalse();
             uut.Equals((object)uut).Should().BeTrue();
-        }
-
-        [TestMethod]
-        public void TestDeserialize()
-        {
-            using MemoryStream ms = new(1024);
-            using BinaryWriter writer = new(ms);
-
-            StorageKey uut = new(0x42000000, TestUtils.GetByteArray(10, 0x42));
-            ((ISerializable)uut).Serialize(writer);
-
-            MemoryReader reader = new(ms.ToArray());
-            StorageKey dest = new StorageKey();
-            ((ISerializable)dest).Deserialize(ref reader);
-            dest.Id.Should().Be(uut.Id);
-            dest.Key.Span.SequenceEqual(uut.Key.Span).Should().BeTrue();
         }
     }
 }

--- a/tests/neo.UnitTests/Ledger/UT_StorageKey.cs
+++ b/tests/neo.UnitTests/Ledger/UT_StorageKey.cs
@@ -18,10 +18,7 @@ namespace Neo.UnitTests.Ledger
         public void Id_Set()
         {
             int val = 1;
-            StorageKey uut = new()
-            {
-                Id = val
-            };
+            StorageKey uut = new() { Id = val };
             uut.Id.Should().Be(val);
         }
 
@@ -29,10 +26,7 @@ namespace Neo.UnitTests.Ledger
         public void Key_Set()
         {
             byte[] val = new byte[] { 0x42, 0x32 };
-            StorageKey uut = new()
-            {
-                Key = val
-            };
+            StorageKey uut = new() { Key = val };
             uut.Key.Length.Should().Be(2);
             uut.Key.Span[0].Should().Be(val[0]);
             uut.Key.Span[1].Should().Be(val[1]);

--- a/tests/neo.UnitTests/Ledger/UT_StorageKey.cs
+++ b/tests/neo.UnitTests/Ledger/UT_StorageKey.cs
@@ -1,6 +1,9 @@
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.IO;
 using Neo.SmartContract;
+using System;
+using System.IO;
 
 namespace Neo.UnitTests.Ledger
 {
@@ -31,7 +34,10 @@ namespace Neo.UnitTests.Ledger
         public void Id_Set()
         {
             int val = 1;
-            uut.Id = val;
+            StorageKey uut = new()
+            {
+                Id = val
+            };
             uut.Id.Should().Be(val);
         }
 
@@ -39,7 +45,10 @@ namespace Neo.UnitTests.Ledger
         public void Key_Set()
         {
             byte[] val = new byte[] { 0x42, 0x32 };
-            uut.Key = val;
+            StorageKey uut = new()
+            {
+                Key = val
+            };
             uut.Key.Length.Should().Be(2);
             uut.Key.Span[0].Should().Be(val[0]);
             uut.Key.Span[1].Should().Be(val[1]);
@@ -121,13 +130,13 @@ namespace Neo.UnitTests.Ledger
         {
             using MemoryStream ms = new(1024);
             using BinaryWriter writer = new(ms);
-            using BinaryReader reader = new(ms);
 
             StorageKey uut = new(0x42000000, TestUtils.GetByteArray(10, 0x42));
             ((ISerializable)uut).Serialize(writer);
-            ms.Seek(0, SeekOrigin.Begin);
+
+            MemoryReader reader = new(ms.ToArray());
             StorageKey dest = new StorageKey();
-            ((ISerializable)dest).Deserialize(reader);
+            ((ISerializable)dest).Deserialize(ref reader);
             dest.Id.Should().Be(uut.Id);
             dest.Key.Span.SequenceEqual(uut.Key.Span).Should().BeTrue();
         }

--- a/tests/neo.UnitTests/Ledger/UT_StorageKey.cs
+++ b/tests/neo.UnitTests/Ledger/UT_StorageKey.cs
@@ -10,18 +10,11 @@ namespace Neo.UnitTests.Ledger
     [TestClass]
     public class UT_StorageKey
     {
-        StorageKey uut;
-
-        [TestInitialize]
-        public void TestSetup()
-        {
-            uut = new StorageKey();
-        }
-
         [TestMethod]
         public void Id_Get()
         {
-            uut.Id.Should().Be(0);
+            var uut = new StorageKey(1, new byte[] { 0x01 });
+            uut.Id.Should().Be(1);
         }
 
         [TestMethod]
@@ -30,7 +23,7 @@ namespace Neo.UnitTests.Ledger
             var ut = new StorageKey() { Key = new byte[17], Id = 0 };
             ut.ToArray().Length.Should().Be(((ISerializable)ut).Size);
 
-            ut = new StorageKey() { Key = new byte[0], Id = 0 };
+            ut = new StorageKey() { Key = Array.Empty<byte>(), Id = 0 };
             ut.ToArray().Length.Should().Be(((ISerializable)ut).Size);
 
             ut = new StorageKey() { Key = new byte[16], Id = 0 };
@@ -38,32 +31,16 @@ namespace Neo.UnitTests.Ledger
         }
 
         [TestMethod]
-        public void Id_Set()
-        {
-            int val = 1;
-            uut.Id = val;
-            uut.Id.Should().Be(val);
-        }
-
-        [TestMethod]
-        public void Key_Set()
-        {
-            byte[] val = new byte[] { 0x42, 0x32 };
-            uut.Key = val;
-            uut.Key.Length.Should().Be(2);
-            uut.Key.Span[0].Should().Be(val[0]);
-            uut.Key.Span[1].Should().Be(val[1]);
-        }
-
-        [TestMethod]
         public void Equals_SameObj()
         {
+            StorageKey uut = new();
             uut.Equals(uut).Should().BeTrue();
         }
 
         [TestMethod]
         public void Equals_Null()
         {
+            StorageKey uut = new();
             uut.Equals(null).Should().BeFalse();
         }
 
@@ -77,9 +54,7 @@ namespace Neo.UnitTests.Ledger
                 Id = val,
                 Key = keyVal
             };
-            uut.Id = val;
-            uut.Key = keyVal;
-
+            StorageKey uut = new(val, keyVal);
             uut.Equals(newSk).Should().BeTrue();
         }
 
@@ -93,12 +68,9 @@ namespace Neo.UnitTests.Ledger
                 Id = val,
                 Key = keyVal
             };
-            uut.Id = 0x78000000;
-            uut.Key = keyVal;
-
+            StorageKey uut = new(0x78000000, keyVal);
             uut.Equals(newSk).Should().BeFalse();
         }
-
 
         [TestMethod]
         public void Equals_SameHash_DiffKey()
@@ -110,23 +82,21 @@ namespace Neo.UnitTests.Ledger
                 Id = val,
                 Key = keyVal
             };
-            uut.Id = val;
-            uut.Key = TestUtils.GetByteArray(10, 0x88);
-
+            StorageKey uut = new(val, TestUtils.GetByteArray(10, 0x88));
             uut.Equals(newSk).Should().BeFalse();
         }
 
         [TestMethod]
         public void GetHashCode_Get()
         {
-            uut.Id = 0x42000000;
-            uut.Key = TestUtils.GetByteArray(10, 0x42);
+            StorageKey uut = new(0x42000000, TestUtils.GetByteArray(10, 0x42));
             uut.GetHashCode().Should().Be(1374529787);
         }
 
         [TestMethod]
         public void Equals_Obj()
         {
+            StorageKey uut = new();
             uut.Equals(1u).Should().BeFalse();
             uut.Equals((object)uut).Should().BeTrue();
         }
@@ -134,19 +104,17 @@ namespace Neo.UnitTests.Ledger
         [TestMethod]
         public void TestDeserialize()
         {
-            using (MemoryStream ms = new MemoryStream(1024))
-            using (BinaryWriter writer = new BinaryWriter(ms))
-            using (BinaryReader reader = new BinaryReader(ms))
-            {
-                uut.Id = 0x42000000;
-                uut.Key = TestUtils.GetByteArray(10, 0x42);
-                ((ISerializable)uut).Serialize(writer);
-                ms.Seek(0, SeekOrigin.Begin);
-                StorageKey dest = new StorageKey();
-                ((ISerializable)dest).Deserialize(reader);
-                dest.Id.Should().Be(uut.Id);
-                dest.Key.Span.SequenceEqual(uut.Key.Span).Should().BeTrue();
-            }
+            using MemoryStream ms = new(1024);
+            using BinaryWriter writer = new(ms);
+            using BinaryReader reader = new(ms);
+
+            StorageKey uut = new(0x42000000, TestUtils.GetByteArray(10, 0x42));
+            ((ISerializable)uut).Serialize(writer);
+            ms.Seek(0, SeekOrigin.Begin);
+            StorageKey dest = new StorageKey();
+            ((ISerializable)dest).Deserialize(reader);
+            dest.Id.Should().Be(uut.Id);
+            dest.Key.Span.SequenceEqual(uut.Key.Span).Should().BeTrue();
         }
     }
 }

--- a/tests/neo.UnitTests/TestUtils.cs
+++ b/tests/neo.UnitTests/TestUtils.cs
@@ -245,5 +245,10 @@ namespace Neo.UnitTests
             newObj.Deserialize(ref reader);
             return newObj;
         }
+
+        public static bool EqualsTo(this StorageItem item, StorageItem other)
+        {
+            return item.Value.Span.SequenceEqual(other.Value.Span);
+        }
     }
 }


### PR DESCRIPTION
- `GetHashCode` returns the same integer value, so it could be removed
- Properties must be immutable