### PR TITLE
Limit notifications

### DIFF
--- a/src/neo/SmartContract/ApplicationEngine.Runtime.cs
+++ b/src/neo/SmartContract/ApplicationEngine.Runtime.cs
@@ -308,11 +308,8 @@ namespace Neo.SmartContract
                     case Map map:
                         if (!compounds.Add(map))
                             throw new InvalidOperationException();
-                        foreach (var (k, v) in map)
-                        {
-                            queue.Enqueue(k);
+                        foreach (var (_, v) in map)
                             queue.Enqueue(v);
-                        }
                         break;
                     case VM.Types.Buffer:
                     case InteropInterface:

--- a/src/neo/SmartContract/NotifyEventArgs.cs
+++ b/src/neo/SmartContract/NotifyEventArgs.cs
@@ -68,7 +68,7 @@ namespace Neo.SmartContract
             {
                 ScriptHash.ToArray(),
                 EventName,
-                State.DeepCopy()
+                State
             };
         }
     }

--- a/src/neo/neo.csproj
+++ b/src/neo/neo.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="BouncyCastle.NetCore" Version="1.8.10" />
     <PackageReference Include="K4os.Compression.LZ4" Version="1.2.16" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.4" />
-    <PackageReference Include="Neo.VM" Version="3.2.0-CI00307" />
+    <PackageReference Include="Neo.VM" Version="3.2.0-CI00312" />
   </ItemGroup>
 
 </Project>

--- a/tests/neo.UnitTests/SmartContract/UT_ApplicationEngine.Runtime.cs
+++ b/tests/neo.UnitTests/SmartContract/UT_ApplicationEngine.Runtime.cs
@@ -23,6 +23,7 @@ namespace Neo.UnitTests.SmartContract
         public void TestNotSupportedNotification()
         {
             using var engine = ApplicationEngine.Create(TriggerType.Application, null, null, TestBlockchain.TheNeoSystem.GenesisBlock, settings: TestBlockchain.TheNeoSystem.Settings, gas: 1100_00000000);
+            engine.LoadScript(Array.Empty<byte>());
 
             // circular
 
@@ -36,7 +37,8 @@ namespace Neo.UnitTests.SmartContract
             array.Clear();
             array.Add(new VM.Types.Buffer(1));
 
-            Assert.ThrowsException<InvalidOperationException>(() => engine.RuntimeNotify(new byte[] { 0x01 }, array));
+            engine.RuntimeNotify(new byte[] { 0x01 }, array);
+            engine.Notifications[0].State[0].Type.Should().Be(VM.Types.StackItemType.ByteString);
 
             // Pointer
 

--- a/tests/neo.UnitTests/SmartContract/UT_ApplicationEngine.Runtime.cs
+++ b/tests/neo.UnitTests/SmartContract/UT_ApplicationEngine.Runtime.cs
@@ -20,6 +20,40 @@ namespace Neo.UnitTests.SmartContract
         }
 
         [TestMethod]
+        public void TestNotSupportedNotification()
+        {
+            using var engine = ApplicationEngine.Create(TriggerType.Application, null, null, TestBlockchain.TheNeoSystem.GenesisBlock, settings: TestBlockchain.TheNeoSystem.Settings, gas: 1100_00000000);
+
+            // circular
+
+            VM.Types.Array array = new();
+            array.Add(array);
+
+            Assert.ThrowsException<NotSupportedException>(() => engine.RuntimeNotify(new byte[] { 0x01 }, array));
+
+            // Buffer
+
+            array.Clear();
+            array.Add(new VM.Types.Buffer(1));
+
+            Assert.ThrowsException<InvalidOperationException>(() => engine.RuntimeNotify(new byte[] { 0x01 }, array));
+
+            // Pointer
+
+            array.Clear();
+            array.Add(new VM.Types.Pointer(Array.Empty<byte>(), 1));
+
+            Assert.ThrowsException<NotSupportedException>(() => engine.RuntimeNotify(new byte[] { 0x01 }, array));
+
+            // InteropInterface
+
+            array.Clear();
+            array.Add(new VM.Types.InteropInterface(new object()));
+
+            Assert.ThrowsException<NotSupportedException>(() => engine.RuntimeNotify(new byte[] { 0x01 }, array));
+        }
+
+        [TestMethod]
         public void TestGetRandomSameBlock()
         {
             var tx = TestUtils.GetTransaction(UInt160.Zero);


### PR DESCRIPTION
~Added some restrictions to `System.Runtime.Notify`.~

~1. Recursive references in notifications are not allowed.
2. Sending `Buffer`, `InteropInterface` and `Pointer` in notifications is not allowed.~

Notifications are deep copied as immutable.