### PR TITLE
Mutex

### DIFF
--- a/src/neo/SmartContract/ApplicationEngine.Runtime.cs
+++ b/src/neo/SmartContract/ApplicationEngine.Runtime.cs
@@ -139,6 +139,18 @@ namespace Neo.SmartContract
         public static readonly InteropDescriptor System_Runtime_BurnGas = Register("System.Runtime.BurnGas", nameof(BurnGas), 1 << 4, CallFlags.None);
 
         /// <summary>
+        /// The <see cref="InteropDescriptor"/> of System.Runtime.MutexRemove.
+        /// Remove a mutex.
+        /// </summary>
+        public static readonly InteropDescriptor System_Runtime_Remove = Register("System.Runtime.MutexRemove", nameof(MutexRemove), 1 << 4, CallFlags.None);
+
+        /// <summary>
+        /// The <see cref="InteropDescriptor"/> of System.Runtime.MutexCreate.
+        /// Create a mutex.
+        /// </summary>
+        public static readonly InteropDescriptor System_Runtime_Mutex = Register("System.Runtime.MutexCreate", nameof(MutexCreate), 1 << 4, CallFlags.None);
+
+        /// <summary>
         /// The implementation of System.Runtime.Platform.
         /// Gets the name of the current platform.
         /// </summary>
@@ -353,6 +365,36 @@ namespace Neo.SmartContract
             if (gas <= 0)
                 throw new InvalidOperationException("GAS must be positive.");
             AddGas(gas);
+        }
+
+        /// <summary>
+        /// Create mutex
+        /// </summary>
+        /// <param name="name">Mutex name</param>
+        protected internal bool MutexCreate(string name)
+        {
+            if (!_mutex.TryGetValue(CurrentScriptHash, out var set))
+            {
+                set = _mutex[CurrentScriptHash] = new HashSet<string>();
+            }
+
+            return set.Add(name);
+        }
+
+        /// <summary>
+        /// Remove mutex
+        /// </summary>
+        /// <param name="name">Mutex name</param>
+        protected internal bool MutexRemove(string name)
+        {
+            if (_mutex.TryGetValue(CurrentScriptHash, out var set))
+            {
+                return set.Remove(name);
+            }
+            else
+            {
+                return false;
+            }
         }
     }
 }

--- a/src/neo/SmartContract/ApplicationEngine.cs
+++ b/src/neo/SmartContract/ApplicationEngine.cs
@@ -57,6 +57,7 @@ namespace Neo.SmartContract
         internal readonly uint ExecFeeFactor;
         internal readonly uint StoragePrice;
         private byte[] nonceData;
+        private readonly Dictionary<UInt160, HashSet<string>> _mutex = new();
 
         /// <summary>
         /// Gets or sets the provider used to create the <see cref="ApplicationEngine"/>.


### PR DESCRIPTION
Alternative to https://github.com/neo-project/neo/pull/2774 and https://github.com/neo-project/neo/pull/2776

- The mutex are shared between different context of the same Contract.
- It is possible to create a non-reentrant modifier in the compiler that adds create and delete to the beginning and end of methods.