### PR TITLE
Add Has Method

### DIFF
--- a/src/neo/SmartContract/Native/ContractManagement.cs
+++ b/src/neo/SmartContract/Native/ContractManagement.cs
@@ -154,7 +154,7 @@ namespace Neo.SmartContract.Native
         [ContractMethod(CpuFee = 1 << 15, RequiredCallFlags = CallFlags.ReadStates)]
         public bool HasMethod(DataCache snapshot, UInt160 hash, string method, int pcount)
         {
-            var contract = snapshot.TryGet(CreateStorageKey(Prefix_Contract).Add(hash))?.GetInteroperable<ContractState>();
+            var contract = GetContract(snapshot, hash);
             if (contract is null) return false;
             var methodDescriptor = contract.Manifest.Abi.GetMethod(method, pcount);
             return methodDescriptor is not null;

--- a/src/neo/SmartContract/Native/ContractManagement.cs
+++ b/src/neo/SmartContract/Native/ContractManagement.cs
@@ -155,6 +155,7 @@ namespace Neo.SmartContract.Native
         public bool HasMethod(DataCache snapshot, UInt160 hash, string method, int pcount)
         {
             var contract = snapshot.TryGet(CreateStorageKey(Prefix_Contract).Add(hash))?.GetInteroperable<ContractState>();
+            if (contract is null) return false;
             var methodDescriptor = contract.Manifest.Abi.GetMethod(method, pcount);
             return methodDescriptor is not null;
         }

--- a/src/neo/SmartContract/Native/ContractManagement.cs
+++ b/src/neo/SmartContract/Native/ContractManagement.cs
@@ -144,6 +144,22 @@ namespace Neo.SmartContract.Native
         }
 
         /// <summary>
+        /// Check if a method exists in a contract.
+        /// </summary>
+        /// <param name="snapshot">The snapshot used to read data.</param>
+        /// <param name="hash">The hash of the deployed contract.</param>
+        /// <param name="method">The name of the method</param>
+        /// <param name="pcount">The number of parameters</param>
+        /// <returns>True if the method exists.</returns>
+        [ContractMethod(CpuFee = 1 << 15, RequiredCallFlags = CallFlags.ReadStates)]
+        public bool HasMethod(DataCache snapshot, UInt160 hash, string method, int pcount)
+        {
+            var contract = snapshot.TryGet(CreateStorageKey(Prefix_Contract).Add(hash))?.GetInteroperable<ContractState>();
+            var methodDescriptor = contract.Manifest.Abi.GetMethod(method, pcount);
+            return methodDescriptor is not null;
+        }
+
+        /// <summary>
         /// Gets all deployed contracts.
         /// </summary>
         /// <param name="snapshot">The snapshot used to read data.</param>


### PR DESCRIPTION
It can be useful in order to avoid parsing the entire abi by contract, something that becomes tedious and expensive to do with the VM