### PR TITLE
Optimize wallet factories

### DIFF
--- a/src/Neo/Wallets/IWalletFactory.cs
+++ b/src/Neo/Wallets/IWalletFactory.cs
@@ -12,7 +12,7 @@ namespace Neo.Wallets
 {
     public interface IWalletFactory
     {
-        public bool Handle(string filename);
+        public bool Handle(string path);
 
         public Wallet CreateWallet(string name, string path, string password, ProtocolSettings settings);
 

--- a/src/Neo/Wallets/NEP6/NEP6WalletFactory.cs
+++ b/src/Neo/Wallets/NEP6/NEP6WalletFactory.cs
@@ -8,7 +8,6 @@
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
-using Neo.Plugins;
 using System;
 using System.IO;
 
@@ -18,9 +17,9 @@ namespace Neo.Wallets.NEP6
     {
         public static readonly NEP6WalletFactory Instance = new();
 
-        public bool Handle(string filename)
+        public bool Handle(string path)
         {
-            return Path.GetExtension(filename).ToLowerInvariant() == ".json";
+            return Path.GetExtension(path).ToLowerInvariant() == ".json";
         }
 
         public Wallet CreateWallet(string name, string path, string password, ProtocolSettings settings)

--- a/src/Neo/Wallets/SQLite/SQLiteWalletFactory.cs
+++ b/src/Neo/Wallets/SQLite/SQLiteWalletFactory.cs
@@ -8,7 +8,6 @@
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
-using Neo.Plugins;
 using System.IO;
 
 namespace Neo.Wallets.SQLite
@@ -17,9 +16,9 @@ namespace Neo.Wallets.SQLite
     {
         public static readonly SQLiteWalletFactory Instance = new();
 
-        public bool Handle(string filename)
+        public bool Handle(string path)
         {
-            return Path.GetExtension(filename).ToLowerInvariant() == ".db3";
+            return Path.GetExtension(path).ToLowerInvariant() == ".db3";
         }
 
         public Wallet CreateWallet(string name, string path, string password, ProtocolSettings settings)

--- a/src/Neo/Wallets/Wallet.cs
+++ b/src/Neo/Wallets/Wallet.cs
@@ -779,8 +779,7 @@ namespace Neo.Wallets
 
         private static IWalletFactory GetFactory(string path)
         {
-            string filename = System.IO.Path.GetFileName(path);
-            return factories.FirstOrDefault(p => p.Handle(filename));
+            return factories.FirstOrDefault(p => p.Handle(path));
         }
 
         public static void RegisterFactory(IWalletFactory factory)


### PR DESCRIPTION
Pass full path to wallet factories so that they can check the file (instead of the file name only) to decide whether to handle it.