### PR TITLE
Refund extra GAS

### DIFF
--- a/src/Neo/Ledger/Blockchain.cs
+++ b/src/Neo/Ledger/Blockchain.cs
@@ -401,26 +401,16 @@ namespace Neo.Ledger
             using (SnapshotCache snapshot = system.GetSnapshot())
             {
                 List<ApplicationExecuted> all_application_executed = new();
-                TransactionState[] transactionStates;
-                using (ApplicationEngine engine = ApplicationEngine.Create(TriggerType.OnPersist, null, snapshot, block, system.Settings, 0))
-                {
-                    engine.LoadScript(onPersistScript);
-                    if (engine.Execute() != VMState.HALT) throw new InvalidOperationException();
-                    ApplicationExecuted application_executed = new(engine);
-                    Context.System.EventStream.Publish(application_executed);
-                    all_application_executed.Add(application_executed);
-                    transactionStates = engine.GetState<TransactionState[]>();
-                }
+                ApplicationExecuted persist_application_executed;
                 DataCache clonedSnapshot = snapshot.CreateSnapshot();
 
                 // Warning: Do not write into variable snapshot directly. Write into variable clonedSnapshot and commit instead.
-                foreach (TransactionState transactionState in transactionStates)
+                foreach (var tx in block.Transactions)
                 {
-                    Transaction tx = transactionState.Transaction;
+                    // Transaction tx = transactionState.Transaction;
                     using ApplicationEngine engine = ApplicationEngine.Create(TriggerType.Application, tx, clonedSnapshot, block, system.Settings, tx.SystemFee);
                     engine.LoadScript(tx.Script);
-                    transactionState.State = engine.Execute();
-                    if (transactionState.State == VMState.HALT)
+                    if (engine.Execute() == VMState.HALT)
                     {
                         clonedSnapshot.Commit();
                     }
@@ -433,6 +423,16 @@ namespace Neo.Ledger
                     Context.System.EventStream.Publish(application_executed);
                     all_application_executed.Add(application_executed);
                 }
+
+                using (ApplicationEngine engine = ApplicationEngine.Create(TriggerType.OnPersist, null, snapshot, block, system.Settings, 0))
+                {
+                    engine.LoadScript(onPersistScript);
+                    if (engine.Execute() != VMState.HALT) throw new InvalidOperationException();
+                    persist_application_executed = new(engine);
+                    Context.System.EventStream.Publish(persist_application_executed);
+                    all_application_executed.Insert(0, persist_application_executed);
+                }
+
                 using (ApplicationEngine engine = ApplicationEngine.Create(TriggerType.PostPersist, null, snapshot, block, system.Settings, 0))
                 {
                     engine.LoadScript(postPersistScript);

--- a/src/Neo/Ledger/Blockchain.cs
+++ b/src/Neo/Ledger/Blockchain.cs
@@ -22,6 +22,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 
 namespace Neo.Ledger
@@ -411,6 +412,7 @@ namespace Neo.Ledger
                     transactionStates = engine.GetState<TransactionState[]>();
                 }
                 DataCache clonedSnapshot = snapshot.CreateSnapshot();
+
                 // Warning: Do not write into variable snapshot directly. Write into variable clonedSnapshot and commit instead.
                 foreach (TransactionState transactionState in transactionStates)
                 {
@@ -426,6 +428,7 @@ namespace Neo.Ledger
                     {
                         clonedSnapshot = snapshot.CreateSnapshot();
                     }
+                    block._gasConsumed.Add(tx.Hash, engine.GasConsumed);
                     ApplicationExecuted application_executed = new(engine);
                     Context.System.EventStream.Publish(application_executed);
                     all_application_executed.Add(application_executed);

--- a/src/Neo/Network/P2P/Payloads/Block.cs
+++ b/src/Neo/Network/P2P/Payloads/Block.cs
@@ -14,6 +14,7 @@ using Neo.Json;
 using Neo.Ledger;
 using Neo.Persistence;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 
@@ -80,6 +81,8 @@ namespace Neo.Network.P2P.Payloads
         /// The witness of the block.
         /// </summary>
         public Witness Witness => Header.Witness;
+
+        protected internal Dictionary<UInt256, long> _gasConsumed = new();
 
         InventoryType IInventory.InventoryType => InventoryType.Block;
         public int Size => Header.Size + Transactions.GetVarSize();

--- a/src/Neo/SmartContract/ApplicationEngine.cs
+++ b/src/Neo/SmartContract/ApplicationEngine.cs
@@ -316,7 +316,13 @@ namespace Neo.SmartContract
         /// <param name="gas">The maximum gas used in this execution. The execution will fail when the gas is exhausted.</param>
         /// <param name="diagnostic">The diagnostic to be used by the <see cref="ApplicationEngine"/>.</param>
         /// <returns>The engine instance created.</returns>
-        public static ApplicationEngine Create(TriggerType trigger, IVerifiable container, DataCache snapshot, Block persistingBlock = null, ProtocolSettings settings = null, long gas = TestModeGas, IDiagnostic diagnostic = null)
+        public static ApplicationEngine Create(TriggerType trigger,
+            IVerifiable container,
+            DataCache snapshot,
+            Block persistingBlock = null,
+            ProtocolSettings settings = null,
+            long gas = TestModeGas,
+            IDiagnostic diagnostic = null)
         {
             return Provider?.Create(trigger, container, snapshot, persistingBlock, settings, gas, diagnostic)
                   ?? new ApplicationEngine(trigger, container, snapshot, persistingBlock, settings, gas, diagnostic);

--- a/src/Neo/SmartContract/Native/GasToken.cs
+++ b/src/Neo/SmartContract/Native/GasToken.cs
@@ -36,9 +36,11 @@ namespace Neo.SmartContract.Native
             long totalNetworkFee = 0;
             foreach (Transaction tx in engine.PersistingBlock.Transactions)
             {
-                await Burn(engine, tx.Sender, tx.SystemFee + tx.NetworkFee);
+                var gasConsumed = engine.PersistingBlock._gasConsumed[tx.Hash];
+                await Burn(engine, tx.Sender, gasConsumed + tx.NetworkFee);
                 totalNetworkFee += tx.NetworkFee;
             }
+
             ECPoint[] validators = NEO.GetNextBlockValidators(engine.Snapshot, engine.ProtocolSettings.ValidatorsCount);
             UInt160 primary = Contract.CreateSignatureRedeemScript(validators[engine.PersistingBlock.PrimaryIndex]).ToScriptHash();
             await Mint(engine, primary, totalNetworkFee, false);


### PR DESCRIPTION
This is an experimental work trying to study the possiblity of refunding extra system fee user pays.

Solution here is only burn the amount of consumed system fee instead.

Open to comments and suggestations.

Gas consume table after analysing `1,291,140` transactions in neo N3:

| 10%   | 20%   | 30%   | 40%   | 50%   | 60%   | 70%   | 80%   | 90%    | 100%   |
|-------|-------|-------|-------|-------|-------|-------|-------|--------|--------|
| 32211 | 37606 | 49009 | 12775 | 27212 | 9822  | 4861  | 15839 | 257764 | 844041 |
| 2.49% | 2.91% | 3.8%  | 0.99% | 2.11% | 0.79% | 0.38% | 1.23% | 19.96% | 65.37% |


![Figure_1](https://user-images.githubusercontent.com/10189511/192068485-44f1f05e-104e-4002-9f31-a0406160a23f.png)

From the table we can see that around 35% transactions pay more GAS fee than needed, and 2.49% transaction even pay 10 times more transaction fee than needed.
