### PR TITLE
Native: store ID->hash mapping for native contracts too

### DIFF
--- a/src/Neo/SmartContract/Native/ContractManagement.cs
+++ b/src/Neo/SmartContract/Native/ContractManagement.cs
@@ -116,6 +116,7 @@ namespace Neo.SmartContract.Native
                     Hash = contract.Hash,
                     Manifest = contract.Manifest
                 }));
+                engine.Snapshot.Add(CreateStorageKey(Prefix_ContractHash).AddBigEndian(contract.Id), new StorageItem(contract.Hash.ToArray()));
                 await contract.Initialize(engine);
             }
         }


### PR DESCRIPTION
This is an omission of #2807, even though native hashes are well-known GetContractById better be symmetric for all contracts. Related to nspcc-dev/neo-go#2837.