### PR TITLE
fix NeoSystem shutdown order

### DIFF
--- a/src/Neo/NeoSystem.cs
+++ b/src/Neo/NeoSystem.cs
@@ -163,12 +163,12 @@ namespace Neo
 
         public void Dispose()
         {
-            foreach (var p in Plugin.Plugins)
-                p.Dispose();
             EnsureStopped(LocalNode);
             // Dispose will call ActorSystem.Terminate()
             ActorSystem.Dispose();
             ActorSystem.WhenTerminated.Wait();
+            foreach (var p in Plugin.Plugins)
+                p.Dispose();
             HeaderCache.Dispose();
             store.Dispose();
         }

--- a/src/Neo/NeoSystem.cs
+++ b/src/Neo/NeoSystem.cs
@@ -164,11 +164,12 @@ namespace Neo
         public void Dispose()
         {
             EnsureStopped(LocalNode);
+            EnsureStopped(Blockchain);
+            foreach (var p in Plugin.Plugins)
+                p.Dispose();
             // Dispose will call ActorSystem.Terminate()
             ActorSystem.Dispose();
             ActorSystem.WhenTerminated.Wait();
-            foreach (var p in Plugin.Plugins)
-                p.Dispose();
             HeaderCache.Dispose();
             store.Dispose();
         }


### PR DESCRIPTION
fix https://github.com/neo-project/neo-modules/issues/786

What I theorize is happening is that while the plugins are disposed (and they remove their `Committing`/`Committed` handlers) in the background the main persist loop continues to add blocks and transactions. The plugins (like app log) no longer process these blocks hence we lose data. By first shutting down the "main loop" we ensure plugins don't miss anything. 