### PR TITLE
Fix hardfork checking logic

### DIFF
--- a/src/Neo/SmartContract/ApplicationEngine.cs
+++ b/src/Neo/SmartContract/ApplicationEngine.cs
@@ -635,26 +635,8 @@ namespace Neo.SmartContract
                 // If the hardfork has a specific height in the configuration, check the block height.
                 return PersistingBlock.Index >= height;
             }
-
-            // Check for continuity in configured hardforks
-            var sortedHardforks = ProtocolSettings.Hardforks.Keys
-                .OrderBy(h => allHardforks.IndexOf(h))
-                .ToList();
-
-            for (int i = 0; i < sortedHardforks.Count - 1; i++)
-            {
-                int currentIndex = allHardforks.IndexOf(sortedHardforks[i]);
-                int nextIndex = allHardforks.IndexOf(sortedHardforks[i + 1]);
-
-                // If they aren't consecutive, return false.
-                if (nextIndex - currentIndex > 1)
-                    return false;
-            }
-
             // If no specific conditions are met, return true.
             return true;
         }
-
-
     }
 }

--- a/src/Neo/SmartContract/ApplicationEngine.cs
+++ b/src/Neo/SmartContract/ApplicationEngine.cs
@@ -46,6 +46,7 @@ namespace Neo.SmartContract
         /// </summary>
         public static event EventHandler<LogEventArgs> Log;
 
+        private static readonly IList<Hardfork> AllHardforks = Enum.GetValues(typeof(Hardfork)).Cast<Hardfork>().ToArray();
         private static Dictionary<uint, InteropDescriptor> services;
         private readonly long gas_amount;
         private Dictionary<Type, object> states;
@@ -612,8 +613,6 @@ namespace Neo.SmartContract
 
         public bool IsHardforkEnabled(Hardfork hardfork)
         {
-            var allHardforks = Enum.GetValues(typeof(Hardfork)).Cast<Hardfork>().ToList();
-
             // Return true if there's no specific configuration or PersistingBlock is null
             if (PersistingBlock is null || ProtocolSettings.Hardforks.Count == 0)
                 return true;
@@ -621,8 +620,8 @@ namespace Neo.SmartContract
             // If the hardfork isn't specified in the configuration, check if it's a new one.
             if (!ProtocolSettings.Hardforks.ContainsKey(hardfork))
             {
-                int currentHardforkIndex = allHardforks.IndexOf(hardfork);
-                int lastConfiguredHardforkIndex = allHardforks.IndexOf(ProtocolSettings.Hardforks.Keys.Last());
+                int currentHardforkIndex = AllHardforks.IndexOf(hardfork);
+                int lastConfiguredHardforkIndex = AllHardforks.IndexOf(ProtocolSettings.Hardforks.Keys.Last());
 
                 // If it's a newer hardfork compared to the ones in the configuration, disable it.
                 if (currentHardforkIndex > lastConfiguredHardforkIndex)

--- a/src/Neo/SmartContract/ApplicationEngine.cs
+++ b/src/Neo/SmartContract/ApplicationEngine.cs
@@ -628,8 +628,7 @@ namespace Neo.SmartContract
                     return false;
             }
 
-            uint height;
-            if (ProtocolSettings.Hardforks.TryGetValue(hardfork, out height))
+            if (ProtocolSettings.Hardforks.TryGetValue(hardfork, out uint height))
             {
                 // If the hardfork has a specific height in the configuration, check the block height.
                 return PersistingBlock.Index >= height;

--- a/src/Neo/SmartContract/ApplicationEngine.cs
+++ b/src/Neo/SmartContract/ApplicationEngine.cs
@@ -614,8 +614,20 @@ namespace Neo.SmartContract
         {
             if (PersistingBlock is null)
                 return true;
+
             if (!ProtocolSettings.Hardforks.TryGetValue(hardfork, out uint height))
-                return true;
+                return false;
+
+            // Pre-computed previous hardforks
+            var allHardforks = Enum.GetValues(typeof(Hardfork)).Cast<Hardfork>().ToList();
+            foreach (var hf in allHardforks)
+            {
+                if (hf >= hardfork)
+                    break;
+                if (!ProtocolSettings.Hardforks.ContainsKey(hf))
+                    return false;
+            }
+
             return PersistingBlock.Index >= height;
         }
     }

--- a/src/Neo/SmartContract/ApplicationEngine.cs
+++ b/src/Neo/SmartContract/ApplicationEngine.cs
@@ -612,7 +612,7 @@ namespace Neo.SmartContract
 
         public bool IsHardforkEnabled(Hardfork hardfork)
         {
-            if (PersistingBlock is null)
+            if (PersistingBlock is null || ProtocolSettings.Hardforks.Count == 0)
                 return true;
 
             if (!ProtocolSettings.Hardforks.TryGetValue(hardfork, out uint height))

--- a/tests/Neo.UnitTests/SmartContract/UT_ApplicationEngine.Runtime.cs
+++ b/tests/Neo.UnitTests/SmartContract/UT_ApplicationEngine.Runtime.cs
@@ -80,10 +80,10 @@ namespace Neo.UnitTests.SmartContract
             var rand_10 = engine_2.GetRandom();
 
             rand_1.Should().Be(BigInteger.Parse("271339657438512451304577787170704246350"));
-            rand_2.Should().Be(BigInteger.Parse("98548189559099075644778613728143131367"));
-            rand_3.Should().Be(BigInteger.Parse("247654688993873392544380234598471205121"));
-            rand_4.Should().Be(BigInteger.Parse("291082758879475329976578097236212073607"));
-            rand_5.Should().Be(BigInteger.Parse("247152297361212656635216876565962360375"));
+            rand_2.Should().Be(BigInteger.Parse("3519468259280385525954723453894821326"));
+            rand_3.Should().Be(BigInteger.Parse("109167038153789065876532298231776118857"));
+            rand_4.Should().Be(BigInteger.Parse("278188388582393629262399165075733096984"));
+            rand_5.Should().Be(BigInteger.Parse("252973537848551880583287107760169066816"));
 
             rand_1.Should().Be(rand_6);
             rand_2.Should().Be(rand_7);
@@ -127,10 +127,10 @@ namespace Neo.UnitTests.SmartContract
             var rand_10 = engine_2.GetRandom();
 
             rand_1.Should().Be(BigInteger.Parse("271339657438512451304577787170704246350"));
-            rand_2.Should().Be(BigInteger.Parse("98548189559099075644778613728143131367"));
-            rand_3.Should().Be(BigInteger.Parse("247654688993873392544380234598471205121"));
-            rand_4.Should().Be(BigInteger.Parse("291082758879475329976578097236212073607"));
-            rand_5.Should().Be(BigInteger.Parse("247152297361212656635216876565962360375"));
+            rand_2.Should().Be(BigInteger.Parse("3519468259280385525954723453894821326"));
+            rand_3.Should().Be(BigInteger.Parse("109167038153789065876532298231776118857"));
+            rand_4.Should().Be(BigInteger.Parse("278188388582393629262399165075733096984"));
+            rand_5.Should().Be(BigInteger.Parse("252973537848551880583287107760169066816"));
 
             rand_1.Should().NotBe(rand_6);
             rand_2.Should().NotBe(rand_7);

--- a/tests/Neo.UnitTests/SmartContract/UT_ApplicationEngine.Runtime.cs
+++ b/tests/Neo.UnitTests/SmartContract/UT_ApplicationEngine.Runtime.cs
@@ -80,10 +80,10 @@ namespace Neo.UnitTests.SmartContract
             var rand_10 = engine_2.GetRandom();
 
             rand_1.Should().Be(BigInteger.Parse("271339657438512451304577787170704246350"));
-            rand_2.Should().Be(BigInteger.Parse("3519468259280385525954723453894821326"));
-            rand_3.Should().Be(BigInteger.Parse("109167038153789065876532298231776118857"));
-            rand_4.Should().Be(BigInteger.Parse("278188388582393629262399165075733096984"));
-            rand_5.Should().Be(BigInteger.Parse("252973537848551880583287107760169066816"));
+            rand_2.Should().Be(BigInteger.Parse("98548189559099075644778613728143131367"));
+            rand_3.Should().Be(BigInteger.Parse("247654688993873392544380234598471205121"));
+            rand_4.Should().Be(BigInteger.Parse("291082758879475329976578097236212073607"));
+            rand_5.Should().Be(BigInteger.Parse("247152297361212656635216876565962360375"));
 
             rand_1.Should().Be(rand_6);
             rand_2.Should().Be(rand_7);
@@ -127,10 +127,10 @@ namespace Neo.UnitTests.SmartContract
             var rand_10 = engine_2.GetRandom();
 
             rand_1.Should().Be(BigInteger.Parse("271339657438512451304577787170704246350"));
-            rand_2.Should().Be(BigInteger.Parse("3519468259280385525954723453894821326"));
-            rand_3.Should().Be(BigInteger.Parse("109167038153789065876532298231776118857"));
-            rand_4.Should().Be(BigInteger.Parse("278188388582393629262399165075733096984"));
-            rand_5.Should().Be(BigInteger.Parse("252973537848551880583287107760169066816"));
+            rand_2.Should().Be(BigInteger.Parse("98548189559099075644778613728143131367"));
+            rand_3.Should().Be(BigInteger.Parse("247654688993873392544380234598471205121"));
+            rand_4.Should().Be(BigInteger.Parse("291082758879475329976578097236212073607"));
+            rand_5.Should().Be(BigInteger.Parse("247152297361212656635216876565962360375"));
 
             rand_1.Should().NotBe(rand_6);
             rand_2.Should().NotBe(rand_7);

--- a/tests/Neo.UnitTests/SmartContract/UT_ApplicationEngine.cs
+++ b/tests/Neo.UnitTests/SmartContract/UT_ApplicationEngine.cs
@@ -85,12 +85,12 @@ namespace Neo.UnitTests.SmartContract
                 var inc = nextIndex - currentIndex;
                 inc.Should().Be(1);
             }
+
             // Check that block numbers are not higher in earlier hardforks than in later ones
             for (int i = 0; i < sortedHardforks.Count - 1; i++)
             {
                 (setting[sortedHardforks[i]] > setting[sortedHardforks[i + 1]]).Should().Be(false);
             }
-
         }
     }
 }


### PR DESCRIPTION
trying to address https://github.com/neo-project/neo/issues/2885

 * enable everything if there is nothing specified in the config (to avoid `A: 0, B: 0` for new networks)
 * enable _old_ hardforks at 0 if some newer one is specified, but these old ones are omitted (`C: 100500` means `A: 0, B: 0` as well if there are no explicit configurations for `A` and `B`)
 * disable new hardforks if they're not specified in the config (`A: 100500` in the config, but we know there is also `B`, but it's not configured, so it's disabled)

This should reasonably cover all cases. For old networks with `A` configured one would need to specify `B`, `C`, etc. to enable them. For new networks old hardforks could be omitted initially and only new ones specified when needed.

This behavior doesn't match neither C#, nor NeoGo at the moment, so we'd need some fixes. But I'd also like to have some consistent handling of this configuration across different node implementations. 