### PR TITLE
fix contract trust FromStackItem `ContractPermissionDescriptor.Create(StackItem item)`

### DIFF
--- a/src/Neo/SmartContract/Manifest/ContractManifest.cs
+++ b/src/Neo/SmartContract/Manifest/ContractManifest.cs
@@ -81,7 +81,7 @@ namespace Neo.SmartContract.Manifest
             {
                 Null _ => WildcardContainer<ContractPermissionDescriptor>.CreateWildcard(),
                 // Array array when array.Any(p => ((ByteString)p).Size == 0) => WildcardContainer<ContractPermissionDescriptor>.CreateWildcard(),
-                Array array => WildcardContainer<ContractPermissionDescriptor>.Create(array.Select(p => new ContractPermissionDescriptor(p.GetSpan())).ToArray()),
+                Array array => WildcardContainer<ContractPermissionDescriptor>.Create(array.Select(ContractPermissionDescriptor.Create).ToArray()),
                 _ => throw new ArgumentException(null, nameof(stackItem))
             };
             Extra = (JObject)JToken.Parse(@struct[7].GetSpan());

--- a/src/Neo/SmartContract/Manifest/ContractPermissionDescriptor.cs
+++ b/src/Neo/SmartContract/Manifest/ContractPermissionDescriptor.cs
@@ -69,9 +69,7 @@ namespace Neo.SmartContract.Manifest
 
         public static ContractPermissionDescriptor Create(StackItem item)
         {
-            if (item == StackItem.Null)
-                return CreateWildcard();
-            return new ContractPermissionDescriptor(item.GetSpan());
+            return item.Equals(StackItem.Null) ? CreateWildcard() : new ContractPermissionDescriptor(item.GetSpan());
         }
 
         /// <summary>

--- a/src/Neo/SmartContract/Manifest/ContractPermissionDescriptor.cs
+++ b/src/Neo/SmartContract/Manifest/ContractPermissionDescriptor.cs
@@ -11,6 +11,7 @@
 using Neo.Cryptography.ECC;
 using Neo.IO;
 using Neo.Json;
+using Neo.VM.Types;
 using System;
 
 namespace Neo.SmartContract.Manifest
@@ -64,6 +65,13 @@ namespace Neo.SmartContract.Manifest
                 default:
                     throw new ArgumentException(null, nameof(span));
             }
+        }
+
+        public static ContractPermissionDescriptor Create(StackItem item)
+        {
+            if (item == StackItem.Null)
+                return CreateWildcard();
+            return new ContractPermissionDescriptor(item.GetSpan());
         }
 
         /// <summary>


### PR DESCRIPTION
https://github.com/neo-project/neo/issues/2899
https://github.com/nspcc-dev/neo-go/issues/3105
https://github.com/neo-project/neo/issues/2890
**NOT EXPECTED TO BE MERGED DIRECTLY.** Just to make `ListContracts` and `GetContract(0x12fbec62fb765ce3f55845106ccf3717716723ad)` work on Testnet T5 for now
https://github.com/Hecate2/neo/releases/tag/fix-contract-trust