### PR TITLE
Restrict maximum number of conflicting transactions per Ledger's conflict record

### DIFF
--- a/src/Neo/Ledger/MemoryPool.cs
+++ b/src/Neo/Ledger/MemoryPool.cs
@@ -367,6 +367,12 @@ namespace Neo.Ledger
             // Step 2: check if unsorted transactions were in `tx`'s Conflicts attributes.
             foreach (var hash in tx.GetAttributes<Conflicts>().Select(p => p.Hash))
             {
+                // Firstly, check whether there's a free space in the list of transactions that has the same
+                // conflicts as `tx` has (in case of successfull verification, `tx` has to be added to this list).
+                if (_conflicts.TryGetValue(hash, out var pooled))
+                    if (pooled.Count() >= Neo.SmartContract.Native.LedgerContract.MaxAllowedConflictingTransactions) return false;
+
+                // After that, check if unsorted transactions are in the `tx`'s Conflicts attributes.
                 if (_unsortedTransactions.TryGetValue(hash, out PoolItem unsortedTx))
                 {
                     if (!tx.Signers.Select(p => p.Account).Intersect(unsortedTx.Tx.Signers.Select(p => p.Account)).Any()) return false;

--- a/src/Neo/SmartContract/Native/LedgerContract.cs
+++ b/src/Neo/SmartContract/Native/LedgerContract.cs
@@ -54,8 +54,7 @@ namespace Neo.SmartContract.Native
                 {
                     var conflictRecord = engine.Snapshot.GetAndChange(CreateStorageKey(Prefix_Transaction).Add(attr.Hash),
                         () => new StorageItem(new TransactionState { ConflictingSigners = Array.Empty<UInt160>() })).GetInteroperable<TransactionState>();
-                    conflictRecord.ConflictingSigners = conflictRecord.ConflictingSigners.Concat(conflictingSigners)
-                        .Distinct().OrderBy(s => s).Take(MaxAllowedConflictingSigners).ToArray();
+                    conflictRecord.ConflictingSigners = conflictRecord.ConflictingSigners.Concat(conflictingSigners).Distinct().ToArray();
                 }
             }
             engine.SetState(transactions);

--- a/src/Neo/SmartContract/Native/LedgerContract.cs
+++ b/src/Neo/SmartContract/Native/LedgerContract.cs
@@ -38,7 +38,7 @@ namespace Neo.SmartContract.Native
         // conflicting records in mempool is limited by the same constant. Thus, the overall maximum
         // number of transactions per a single conflict record that can ever exist in the Ledger's
         // storage is 2*MaxAllowedConflictingTransactions.
-        private const int MaxAllowedConflictingTransactions = 16;
+        internal const int MaxAllowedConflictingTransactions = 16;
 
         internal LedgerContract()
         {

--- a/src/Neo/SmartContract/Native/TransactionState.cs
+++ b/src/Neo/SmartContract/Native/TransactionState.cs
@@ -32,6 +32,8 @@ namespace Neo.SmartContract.Native
         /// </summary>
         public Transaction Transaction;
 
+        public uint ConflictingTransactionsCount;
+
         public UInt160[] ConflictingSigners;
 
         /// <summary>
@@ -47,6 +49,7 @@ namespace Neo.SmartContract.Native
             {
                 BlockIndex = BlockIndex,
                 Transaction = Transaction,
+                ConflictingTransactionsCount = ConflictingTransactionsCount,
                 ConflictingSigners = ConflictingSigners,
                 State = State,
                 _rawTransaction = _rawTransaction
@@ -59,6 +62,7 @@ namespace Neo.SmartContract.Native
             BlockIndex = from.BlockIndex;
             Transaction = from.Transaction;
             ConflictingSigners = from.ConflictingSigners;
+            ConflictingTransactionsCount = from.ConflictingTransactionsCount;
             State = from.State;
             if (_rawTransaction.IsEmpty)
                 _rawTransaction = from._rawTransaction;
@@ -67,9 +71,10 @@ namespace Neo.SmartContract.Native
         void IInteroperable.FromStackItem(StackItem stackItem)
         {
             Struct @struct = (Struct)stackItem;
-            if (@struct.Count == 1)
+            if (@struct.Count == 2)
             {
-                ConflictingSigners = ((VM.Types.Array)@struct[0]).Select(u => new UInt160(u.GetSpan())).ToArray();
+                ConflictingTransactionsCount = (uint)@struct[0].GetInteger();
+                ConflictingSigners = ((VM.Types.Array)@struct[1]).Select(u => new UInt160(u.GetSpan())).ToArray();
                 return;
             }
             BlockIndex = (uint)@struct[0].GetInteger();
@@ -80,7 +85,7 @@ namespace Neo.SmartContract.Native
 
         StackItem IInteroperable.ToStackItem(ReferenceCounter referenceCounter)
         {
-            if (Transaction is null) return new Struct(referenceCounter) { new VM.Types.Array(referenceCounter, ConflictingSigners.Select(u => new ByteString(u.ToArray())).ToArray()) };
+            if (Transaction is null) return new Struct(referenceCounter) { ConflictingTransactionsCount, new VM.Types.Array(referenceCounter, ConflictingSigners.Select(u => new ByteString(u.ToArray())).ToArray()) };
             if (_rawTransaction.IsEmpty)
                 _rawTransaction = Transaction.ToArray();
             return new Struct(referenceCounter) { BlockIndex, _rawTransaction, (byte)State };


### PR DESCRIPTION
### TL;DR
Please, pay attention that **the target branch of this PR is not `master`, it's `max-conflicts` (#2908)**. This PR contains a minor improvement for the native Ledger conflict records fix originally implemented in the #2908. It also contains related memory pool fix (the memory pool problem is described in https://github.com/neo-project/neo/pull/2908#discussion_r1327302012).

### To core devs
This PR is ready to be reviewed and aimed (after its merge into #2908) to fix #2907. However, we have another approach that should fix the #2907 and that is even better than approach presented in the current PR and in #2908. I will publish the new approach and motivation in a separate commit for further discussions. We (Roman and me) are kindly asking the core devs to carefully consider the new approach before merging this PR and before merging #2908 (it won't take a lot of time).

**Update:** the new approach is described in https://github.com/neo-project/neo/issues/2907#issuecomment-1722506014.

### Full PR description

The minor improvement this PR contributes to #2908 is: Instead of restricting the maximum number of conflicting signers per conflict record we can restrict the number of transactions that make their contribution to this conflict record. The constraint nature is the same, it doesn't allow to spam the chain with a large set of transactions that have identical Conflicts attribute. This approach has several benefits over restricting the number of signers for these conflicting transactions:
1. It significantly simplifies and accelerates a newly-pooled transaction verification. We don't need to perform this `Concat(signers).Distinct().Count()` operation anymore on new transaction addition to check on-chain conflicts.
2. It has a space for improvement which is not presented in this commit, but has to be implemented if the current solution will be accepted by the core developers. A space for improvement is the following: during Conflicts attribute verification we don't actually need to retrieve the whole list of conflicting signers for the conflict record. What we need instead is to check the `ConflictingTransactionsCount` field only. Thus, we may safely omit the `ConflictingSigners` deserialisation from stack item.
3. It allows to easily port the same constraint to the mempool (see the further commit) which, in turn, roughly restricts the overall possible number of transactions per conflict record in Ledger contract up to 2x`MaxAllowedConflictingTransactions`. It means that the maximum number of signers per conflict record in the worst case equals to 2x`MaxAllowedConflictingTransactions`x(`MaxTransactionAttributes`-1)=480.

At the same time, the overhead the presented approach brings in the `TransactionState` and overall DB size is quite insignificant (it's only a single additional Integer field per one conflict record that should be serialized).

The mempool fix that is presented in this PR solves the problem described in https://github.com/neo-project/neo/pull/2908#discussion_r1327302012. The memory pool fix itself is a port of the Ledger conflicting tx restriction logic to the MemoryPool: the maximum number of mempooled transactions that has the same Conflicts attribute (i.e. those transactions that conflict with the same transaction) is restricted by the LedgerContract.MaxAllowedConflictingTransactions constant. This restriction, combined with the existing Ledger's storage restriction, roughly restricts the overall possible number of transactions per conflict record in Ledger contract up to 2*MaxAllowedConflictingTransactions at max. It means that the maximum number of signers per conflict record in the worst case equals to 2x`MaxAllowedConflictingTransactions`x(`MaxTransactionAttributes`-1)=480 (with the current values of these constants).

### Caveats 
Note 1: this PR changes the native Ledger scheme, thus, requires the DB resync on upgrade. States will differ from the current 3.6.0 T5.

Note 2: this PR (as far as #2908) doesn't help with those transactions that already were included into blocks 2690038-2690040 of the current T5 due to the https://github.com/neo-project/neo/issues/2907#issue-1898320065. We need to have a separate discussion on these "malicious" blocks and decide how to handle them. However, this PR doesn't ever prevent the node from the proper processing of these blocks on resync, the blocks will be processed successfully (with HALT state, i.e. the same way as they were processed by the 3.6.0 release).