### PR TITLE
Reduce json max depth default value

### DIFF
--- a/src/Neo.Json/JToken.cs
+++ b/src/Neo.Json/JToken.cs
@@ -127,7 +127,7 @@ public abstract class JToken
     /// <param name="value">The byte array that contains the JSON token.</param>
     /// <param name="max_nest">The maximum nesting depth when parsing the JSON token.</param>
     /// <returns>The parsed JSON token.</returns>
-    public static JToken? Parse(ReadOnlySpan<byte> value, int max_nest = 100)
+    public static JToken? Parse(ReadOnlySpan<byte> value, int max_nest = 64)
     {
         Utf8JsonReader reader = new(value, new JsonReaderOptions
         {
@@ -153,7 +153,7 @@ public abstract class JToken
     /// <param name="value">The <see cref="string"/> that contains the JSON token.</param>
     /// <param name="max_nest">The maximum nesting depth when parsing the JSON token.</param>
     /// <returns>The parsed JSON token.</returns>
-    public static JToken? Parse(string value, int max_nest = 100)
+    public static JToken? Parse(string value, int max_nest = 64)
     {
         return Parse(StrictUTF8.GetBytes(value), max_nest);
     }


### PR DESCRIPTION
Related to: https://github.com/neo-project/neo-modules/issues/820

The default value of `JsonReaderOptions.MaxDepth` is 64 as mentioned in:

```
Gets or sets the maximum depth allowed when reading JSON, with the default (i.e. 0) indicating a max depth of 64.
```

We shouldn't have more than that