### PR TITLE
Fix plugins to make single file assemblies possible

### DIFF
--- a/src/Neo/Plugins/Plugin.cs
+++ b/src/Neo/Plugins/Plugin.cs
@@ -32,7 +32,7 @@ namespace Neo.Plugins
         /// <summary>
         /// The directory containing the plugin folders. Files can be contained in any subdirectory.
         /// </summary>
-        public static readonly string PluginsDirectory = Combine(GetDirectoryName(Assembly.GetEntryAssembly().Location), "Plugins");
+        public static readonly string PluginsDirectory = Combine(GetDirectoryName(System.AppContext.BaseDirectory), "Plugins");
 
         private static readonly FileSystemWatcher configWatcher;
 
@@ -123,7 +123,7 @@ namespace Neo.Plugins
 
             string filename = an.Name + ".dll";
             string path = filename;
-            if (!File.Exists(path)) path = Combine(GetDirectoryName(Assembly.GetEntryAssembly().Location), filename);
+            if (!File.Exists(path)) path = Combine(GetDirectoryName(System.AppContext.BaseDirectory), filename);
             if (!File.Exists(path)) path = Combine(PluginsDirectory, filename);
             if (!File.Exists(path)) path = Combine(PluginsDirectory, args.RequestingAssembly.GetName().Name, filename);
             if (!File.Exists(path)) return null;


### PR DESCRIPTION
I just changed `Assembly.GetEntryAssembly().Location` to `System.AppContext.BaseDirectory` (read more [here](https://learn.microsoft.com/en-us/dotnet/api/system.appcontext.basedirectory?view=net-7.0)). This will make possible single file assemblies for Neo Nodes.

Actually, the problem with `Assembly.GetEntryAssembly().Location` is that it doesn't support single file assemblies introduced in .net 6.

Let me know if you have a better way to do it, please. IMHO, this is already the best way (it was even recommended [in this issue](https://github.com/dotnet/corert/issues/6947)).