### PR TITLE
Fix Neo VM target frameworks

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,7 +5,7 @@
     <Copyright>2015-2023 The Neo Project</Copyright>
     <VersionPrefix>3.6.2</VersionPrefix>
     <Authors>The Neo Project</Authors>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFrameworks>net7.0</TargetFrameworks>
     <PackageProjectUrl>https://github.com/neo-project/neo</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryType>git</RepositoryType>

--- a/src/Neo.VM/Neo.VM.csproj
+++ b/src/Neo.VM/Neo.VM.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.1;net7.0</TargetFrameworks>
+    <LangVersion>9.0</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>enable</Nullable>
   </PropertyGroup>


### PR DESCRIPTION
There were two problems that had to be fixed.

1 - The property 'TargetFramework' was replacing the 'TargetFramework**s**' property on the Neo.VM project. 
2 - The Neo.VM project is using the Lang 9.0 property that wasn't ported from the other repository.


How to reproduce the error:
On `master`, use `dotnet pack -c Debug -o out --include-source`. It will throw an error

How to verify:
Using this branch, try the same command again: `dotnet pack -c Debug -o out --include-source`. It should generate the files without errors (but a few warnings about 'package readmes')
