### PR TITLE
Added README to packages

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -9,6 +9,7 @@
     <PackageIcon>neo.png</PackageIcon>
     <PackageProjectUrl>https://github.com/neo-project/neo</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/neo-project/neo.git</RepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
@@ -19,5 +20,6 @@
 
   <ItemGroup>
     <None Include="../neo.png" Pack="true" Visible="false" PackagePath=""/>
+    <None Include="../README.md" Pack="true" Visible="false" PackagePath=""/>
   </ItemGroup>
 </Project>

--- a/src/README.md
+++ b/src/README.md
@@ -1,0 +1,25 @@
+## Overview
+This repository contain main classes of the [Neo](https://www.neo.org) blockchain.
+Visit the [documentation](https://docs.neo.org/docs/en-us/index.html) to get started.
+
+## Related projects
+Code references are provided for all platform building blocks. That includes the base library, the VM, a command line application and the compiler. 
+
+- [neo:](https://github.com/neo-project/neo/) Neo core library, contains base classes, including ledger, p2p and IO modules.
+- [neo-modules:](https://github.com/neo-project/neo-modules/) Neo modules include additional tools and plugins to be used with Neo.
+- [neo-devpack-dotnet:](https://github.com/neo-project/neo-devpack-dotnet/) These are the official tools used to convert a C# smart-contract into a *neo executable file*.
+
+## Opening a new issue
+Please feel free to create new issues to suggest features or ask questions.
+
+- [Feature request](https://github.com/neo-project/neo/issues/new?assignees=&labels=discussion&template=feature-or-enhancement-request.md&title=)
+- [Bug report](https://github.com/neo-project/neo/issues/new?assignees=&labels=&template=bug_report.md&title=)
+- [Questions](https://github.com/neo-project/neo/issues/new?assignees=&labels=question&template=questions.md&title=)
+
+If you found a security issue, please refer to our [security policy](https://github.com/neo-project/neo/security/policy).
+
+## Bounty program
+You can be rewarded by finding security issues. Please refer to our [bounty program page](https://neo.org/bounty) for more information.
+
+## License
+The NEO project is licensed under the [MIT license](http://www.opensource.org/licenses/mit-license.php).


### PR DESCRIPTION
This gets rid of the warning when packing nuget packages, and helps users on nuget as well. So they know what the package is and does.

**Change Log**
- Added `README.md`
- Updated `Directory.Build.props`

**Removes**
```
The package Neo.3.6.2-CI01441 is missing a readme. Go to https://aka.ms/nuget/authoring-best-practices/readme to learn why package readmes are important.
```
