### PR TITLE
MyGet Fix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,10 +67,8 @@ jobs:
       run: |
         for filename in *.nupkg; do
             dotnet nuget push "${filename}" \
-            --source https://www.myget.org/F/neo/api/v2/package \
-            --api-key "${{ secrets.MYGET_TOKEN }}" \
-            --symbol-source https://www.myget.org/F/neo/symbols/api/v2/package \
-            --symbol-api-key "${{ secrets.MYGET_TOKEN }}";
+            --source https://www.myget.org/F/neo/api/v3/index.json \
+            --api-key "${{ secrets.MYGET_TOKEN }}";
         done;
       shell: bash
 


### PR DESCRIPTION
This is my fault. Has to do with not updating to the new `v3` API of myget. Because we are using new nuget format for symbols. The error is misleading.

Read more about it here
https://docs.myget.org/docs/reference/symbols#Pushing_symbols_packages_to_MyGet