### PR TITLE
Fixed workflow  timeout-minutes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ env:
 jobs:
 
   Test:
-    timeout-minutes: 10
+    timeout-minutes: 15
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]


### PR DESCRIPTION
10 minutes isn't a enough. We should of looked at the avg time for an action.