### PR TITLE
Updated `Neo.Cryptography.BLS12_381`  Package

### DIFF
--- a/src/Neo/Neo.csproj
+++ b/src/Neo/Neo.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
-    <PackageReference Include="Neo.Cryptography.BLS12_381" Version="0.2.0" />
+    <PackageReference Include="Neo.Cryptography.BLS12_381" Version="0.3.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Update `nuget` package `Neo.Cryptography.BLS12_381` that supports `dotnet` standard now.