### PR TITLE
Avoid isexternal init

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -22,4 +22,9 @@
     <None Include="../neo.png" Pack="true" Visible="false" PackagePath=""/>
     <None Include="../README.md" Pack="true" Visible="false" PackagePath=""/>
   </ItemGroup>
+
+  <ItemGroup>
+    <!--<Compile Remove="C:\Red4Sec\neo\neo\src\IsExternalInit.cs" />-->
+    <Compile Include="$(MSBuildThisFileDirectory)IsExternalInit.cs" Visible="false" />
+  </ItemGroup>
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -24,7 +24,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!--<Compile Remove="C:\Red4Sec\neo\neo\src\IsExternalInit.cs" />-->
     <Compile Include="$(MSBuildThisFileDirectory)IsExternalInit.cs" Visible="false" />
   </ItemGroup>
 </Project>

--- a/src/IsExternalInit.cs
+++ b/src/IsExternalInit.cs
@@ -9,7 +9,6 @@
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
-#if !NET5_0_OR_GREATER
 
 using System.ComponentModel;
 
@@ -24,5 +23,7 @@ namespace System.Runtime.CompilerServices
     {
     }
 }
+
+#if !NET5_0_OR_GREATER
 
 #endif

--- a/src/IsExternalInit.cs
+++ b/src/IsExternalInit.cs
@@ -9,6 +9,7 @@
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
+#if !NET5_0_OR_GREATER
 
 using System.ComponentModel;
 
@@ -23,7 +24,5 @@ namespace System.Runtime.CompilerServices
     {
     }
 }
-
-#if !NET5_0_OR_GREATER
 
 #endif


### PR DESCRIPTION
Avoid to create `IsExternalInit` in all dotnet standard projects