### PR TITLE
Fix: specify log exception.

### DIFF
--- a/src/Neo.CLI/Settings.cs
+++ b/src/Neo.CLI/Settings.cs
@@ -11,6 +11,7 @@
 
 using Microsoft.Extensions.Configuration;
 using Neo.Network.P2P;
+using Neo.Persistence;
 using System;
 using System.Threading;
 
@@ -77,13 +78,13 @@ namespace Neo
 
     public class StorageSettings
     {
-        public string Engine { get; } = string.Empty;
+        public string Engine { get; } = nameof(MemoryStore);
         public string Path { get; } = string.Empty;
 
         public StorageSettings(IConfigurationSection section)
         {
-            Engine = section.GetValue(nameof(Engine), "LevelDBStore")!;
-            Path = section.GetValue(nameof(Path), "Data_LevelDB_{0}")!;
+            Engine = section.GetValue(nameof(Engine), nameof(MemoryStore))!;
+            Path = section.GetValue(nameof(Path), string.Empty)!;
         }
     }
 

--- a/src/Neo/Network/P2P/Payloads/Transaction.cs
+++ b/src/Neo/Network/P2P/Payloads/Transaction.cs
@@ -458,7 +458,7 @@ namespace Neo.Network.P2P.Payloads
 
         public StackItem ToStackItem(ReferenceCounter referenceCounter)
         {
-            if (Sender == null) throw new ArgumentException("Sender is not specified in the transaction.");
+            if (_signers == null || _signers.Length == 0) throw new ArgumentException("Sender is not specified in the transaction.");
             return new Array(referenceCounter, new StackItem[]
             {
                 // Computed properties

--- a/src/Neo/Network/P2P/Payloads/Transaction.cs
+++ b/src/Neo/Network/P2P/Payloads/Transaction.cs
@@ -458,7 +458,7 @@ namespace Neo.Network.P2P.Payloads
 
         public StackItem ToStackItem(ReferenceCounter referenceCounter)
         {
-            if(Sender == null) throw new ArgumentException("Sender is not specified in the transaction.");
+            if (Sender == null) throw new ArgumentException("Sender is not specified in the transaction.");
             return new Array(referenceCounter, new StackItem[]
             {
                 // Computed properties

--- a/src/Neo/Network/P2P/Payloads/Transaction.cs
+++ b/src/Neo/Network/P2P/Payloads/Transaction.cs
@@ -458,6 +458,7 @@ namespace Neo.Network.P2P.Payloads
 
         public StackItem ToStackItem(ReferenceCounter referenceCounter)
         {
+            if(Sender == null) throw new ArgumentException("Sender is not specified in the transaction.");
             return new Array(referenceCounter, new StackItem[]
             {
                 // Computed properties

--- a/src/Neo/SmartContract/ApplicationEngine.Runtime.cs
+++ b/src/Neo/SmartContract/ApplicationEngine.Runtime.cs
@@ -327,9 +327,16 @@ namespace Neo.SmartContract
         /// <param name="state">The message of the log.</param>
         protected internal void RuntimeLog(byte[] state)
         {
-            if (state.Length > MaxNotificationSize) throw new ArgumentException(null, nameof(state));
-            string message = Utility.StrictUTF8.GetString(state);
-            Log?.Invoke(this, new LogEventArgs(ScriptContainer, CurrentScriptHash, message));
+            if (state.Length > MaxNotificationSize) throw new ArgumentException("Message is too long.", nameof(state));
+            try
+            {
+                string message = Utility.StrictUTF8.GetString(state);
+                Log?.Invoke(this, new LogEventArgs(ScriptContainer, CurrentScriptHash, message));
+            }
+            catch
+            {
+                throw new ArgumentException("Failed to convert byte array to string: Invalid or non-printable UTF-8 sequence detected.", nameof(state));
+            }
         }
 
         /// <summary>

--- a/tests/Neo.UnitTests/SmartContract/UT_ApplicationEngine.Runtime.cs
+++ b/tests/Neo.UnitTests/SmartContract/UT_ApplicationEngine.Runtime.cs
@@ -175,5 +175,17 @@ namespace Neo.UnitTests.SmartContract
             rand_4.Should().NotBe(rand_9);
             rand_5.Should().NotBe(rand_10);
         }
+
+        [TestMethod]
+        public void TestInvalidUtf8LogMessage()
+        {
+            var tx_1 = TestUtils.GetTransaction(UInt160.Zero);
+            using var engine = ApplicationEngine.Create(TriggerType.Application, tx_1, null, TestBlockchain.TheNeoSystem.GenesisBlock, settings: TestBlockchain.TheNeoSystem.Settings, gas: 1100_00000000);
+            var msg = new byte[]
+            {
+                68, 216, 160, 6, 89, 102, 86, 72, 37, 15, 132, 45, 76, 221, 170, 21, 128, 51, 34, 168, 205, 56, 10, 228, 51, 114, 4, 218, 245, 155, 172, 132
+            };
+            Assert.ThrowsException<ArgumentException>(() => engine.RuntimeLog(msg));
+        }
     }
 }


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

The RuntimeLog interface failed to speficy the exception message, though it takes arbitrary byte array as parameter, it only accept UTF8 sequence.

Fixes # (issue) https://github.com/neo-project/neo/issues/3088

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Test TestInvalidUtf8LogMessage()

**Test Configuration**:
Run TestInvalidUtf8LogMessage in UT_ApplicationEngine.Runtime.cs

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
