### PR TITLE
`Bug Fix`| Signers not being set in `neo-cli` with Invoke Command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -256,3 +256,4 @@ paket-files/
 
 PublishProfiles
 /.vscode
+launchSettings.json

--- a/src/Neo.CLI/CLI/MainService.Contracts.cs
+++ b/src/Neo.CLI/CLI/MainService.Contracts.cs
@@ -135,9 +135,8 @@ namespace Neo.CLI
             Signer[] signers = Array.Empty<Signer>();
             if (!NoWallet())
             {
-                var defaultAccount = CurrentWallet!.GetDefaultAccount();
-                if (sender == null && defaultAccount != null)
-                    sender = defaultAccount.ScriptHash;
+                if (sender == null)
+                    sender = CurrentWallet!.GetDefaultAccount()?.ScriptHash;
 
                 if (sender != null)
                 {


### PR DESCRIPTION
# Description
Closes #3088

Basically signers are not being set in `neo-cli` when no sender or signers are specified. When command `invoke` is run. Set to use `DefaultAccount` of `wallet`.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

![image](https://github.com/neo-project/neo/assets/8141309/d7bc1cf7-ed0a-4881-a0c0-d10c5752339c)

**Test Configuration**:
On TestNet
`neo-cli`: `neo> invoke 0x70b53ba105de41678d0ffe57d62aa4cfd6e4e2db test`

You need contract that calls `syscall` `GetScriptContainer`.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
