### PR TITLE
VM Fix: Increase the performance of neo by 20%.

### DIFF
--- a/src/Neo.VM/ReferenceCounter.cs
+++ b/src/Neo.VM/ReferenceCounter.cs
@@ -82,6 +82,7 @@ namespace Neo.VM
             if (zero_referred.Count > 0)
             {
                 // Overhead: 16.5%
+                zero_referred = null; // tell GC to collect
                 zero_referred = new(ReferenceEqualityComparer.Instance);//.Clear();
                 if (cached_components is null)
                 {

--- a/src/Neo.VM/ReferenceCounter.cs
+++ b/src/Neo.VM/ReferenceCounter.cs
@@ -82,8 +82,10 @@ namespace Neo.VM
             if (zero_referred.Count > 0)
             {
                 // Overhead: 16.5%
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
                 zero_referred = null; // tell GC to collect
-                zero_referred = new(ReferenceEqualityComparer.Instance);//.Clear();
+                zero_referred = new(ReferenceEqualityComparer.Instance); // .Clear();
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
                 if (cached_components is null)
                 {
                     //Tarjan<StackItem> tarjan = new(tracked_items.Where(p => p.StackReferences == 0));

--- a/src/Neo.VM/ReferenceCounter.cs
+++ b/src/Neo.VM/ReferenceCounter.cs
@@ -25,7 +25,7 @@ namespace Neo.VM
         private const bool TrackAllItems = false;
 
         private readonly HashSet<StackItem> tracked_items = new(ReferenceEqualityComparer.Instance);
-        private readonly HashSet<StackItem> zero_referred = new(ReferenceEqualityComparer.Instance);
+        private HashSet<StackItem> zero_referred = new(ReferenceEqualityComparer.Instance);
         private LinkedList<HashSet<StackItem>>? cached_components;
         private int references_count = 0;
 
@@ -81,7 +81,8 @@ namespace Neo.VM
         {
             if (zero_referred.Count > 0)
             {
-                zero_referred.Clear();
+                // Overhead: 16.5%
+                zero_referred = new(ReferenceEqualityComparer.Instance);//.Clear();
                 if (cached_components is null)
                 {
                     //Tarjan<StackItem> tarjan = new(tracked_items.Where(p => p.StackReferences == 0));


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
This pr focuses on optimize the vm performance. After sampling the overhead of syncing the whole blockchain, i noticed that the clear operation on the zero_reference hash set consumes 16.5% of the general time. So I replace it by generate a new hash set object, leave the old object to the C# GC to clear.

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
