### PR TITLE
[Neo VM: FIX] the GetString() methods of bytestring requires strictUTF8

### DIFF
--- a/src/Neo.VM/EvaluationStack.cs
+++ b/src/Neo.VM/EvaluationStack.cs
@@ -45,7 +45,7 @@ namespace Neo.VM
                             StackItemType.Pointer => $"({((Pointer)p).Position})",
                             StackItemType.Boolean => $"({p.GetBoolean()})",
                             StackItemType.Integer => $"({p.GetInteger()})",
-                            StackItemType.ByteString => $"(\"{p.GetString()}\")",
+                            StackItemType.ByteString => p.GetSpan().ToArray().TryGetString(out var str) ? $"(\"{str}\")" : $"(\"{Convert.ToBase64String(p.GetSpan())}\")",
                             StackItemType.Array
                                 or StackItemType.Map
                                 or StackItemType.Struct => $"({((CompoundType)p).Count})",

--- a/src/Neo.VM/Utility.cs
+++ b/src/Neo.VM/Utility.cs
@@ -31,7 +31,7 @@ namespace Neo.VM
         {
             try
             {
-                value = Encoding.UTF8.GetString(byteArray);
+                value = StrictUTF8.GetString(byteArray);
                 return true;
             }
             catch (DecoderFallbackException)

--- a/src/Neo.VM/Utility.cs
+++ b/src/Neo.VM/Utility.cs
@@ -27,6 +27,25 @@ namespace Neo.VM
             StrictUTF8.EncoderFallback = EncoderFallback.ExceptionFallback;
         }
 
+        public static bool TryGetString(this byte[] byteArray, out string? value)
+        {
+            try
+            {
+                value = Encoding.UTF8.GetString(byteArray);
+                return true;
+            }
+            catch (DecoderFallbackException)
+            {
+                value = default;
+                return false;
+            }
+            catch (ArgumentException)
+            {
+                value = default;
+                return false;
+            }
+        }
+
         public static BigInteger ModInverse(this BigInteger value, BigInteger modulus)
         {
             if (value <= 0) throw new ArgumentOutOfRangeException(nameof(value));

--- a/tests/Neo.VM.Tests/UtEvaluationStack.cs
+++ b/tests/Neo.VM.Tests/UtEvaluationStack.cs
@@ -10,6 +10,7 @@
 // modifications are permitted.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.Test.Extensions;
 using Neo.VM;
 using Neo.VM.Types;
 using System;
@@ -210,6 +211,14 @@ namespace Neo.Test
             stack.Insert(3, true);
 
             Assert.AreEqual("[Boolean(True), ByteString(\"test\"), Integer(1), Integer(3)]", stack.ToString());
+        }
+
+        [TestMethod]
+        public void TestToStringInvalidUTF8()
+        {
+            var stack = new EvaluationStack(new ReferenceCounter());
+            stack.Insert(0, "4CC95219999D421243C8161E3FC0F4290C067845".FromHexString());
+            Assert.AreEqual("[ByteString(\"TMlSGZmdQhJDyBYeP8D0KQwGeEU=\")]", stack.ToString());
         }
     }
 }


### PR DESCRIPTION

# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

The GetString methods of StackItem requires strick UTF8.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] TestToStringInvalidUTF8

**Test Configuration**:
dotnet test 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
