### PR TITLE
Allow access TestingEngine to internal

### DIFF
--- a/src/Neo/Neo.csproj
+++ b/src/Neo/Neo.csproj
@@ -22,4 +22,8 @@
     <ProjectReference Include="..\Neo.VM\Neo.VM.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="Neo.SmartContract.Testing" />
+  </ItemGroup>
+
 </Project>

--- a/src/Neo/SmartContract/StorageKey.cs
+++ b/src/Neo/SmartContract/StorageKey.cs
@@ -34,7 +34,7 @@ namespace Neo.SmartContract
 
         public StorageKey() { }
 
-        public StorageKey(byte[] cache)
+        internal StorageKey(byte[] cache)
         {
             this.cache = cache;
             Id = BinaryPrimitives.ReadInt32LittleEndian(cache);

--- a/src/Neo/SmartContract/StorageKey.cs
+++ b/src/Neo/SmartContract/StorageKey.cs
@@ -34,7 +34,7 @@ namespace Neo.SmartContract
 
         public StorageKey() { }
 
-        internal StorageKey(byte[] cache)
+        public StorageKey(byte[] cache)
         {
             this.cache = cache;
             Id = BinaryPrimitives.ReadInt32LittleEndian(cache);


### PR DESCRIPTION
I need this change if I want to import from json using `SnapshotCache` in https://github.com/neo-project/neo-devpack-dotnet/pull/890
