### PR TITLE
[Crypto Add] add secp256K1 Sign

### DIFF
--- a/src/Neo.GUI/GUI/SigningDialog.cs
+++ b/src/Neo.GUI/GUI/SigningDialog.cs
@@ -87,7 +87,7 @@ namespace Neo.GUI
 
             try
             {
-                signedData = Crypto.Sign(raw, keys.PrivateKey, keys.PublicKey.EncodePoint(false).Skip(1).ToArray());
+                signedData = Crypto.Sign(raw, keys.PrivateKey);
             }
             catch (Exception err)
             {

--- a/src/Neo/Cryptography/Crypto.cs
+++ b/src/Neo/Cryptography/Crypto.cs
@@ -76,7 +76,7 @@ namespace Neo.Cryptography
             }
 
             var curve =
-                 ecCurve == null || ecCurve == ECC.ECCurve.Secp256r1 ? ECCurve.NamedCurves.nistP256 :
+                ecCurve == null || ecCurve == ECC.ECCurve.Secp256r1 ? ECCurve.NamedCurves.nistP256 :
                 ecCurve == ECC.ECCurve.Secp256k1 ? ECCurve.CreateFromFriendlyName("secP256k1") :
                 throw new NotSupportedException();
 

--- a/src/Neo/Cryptography/Crypto.cs
+++ b/src/Neo/Cryptography/Crypto.cs
@@ -13,7 +13,6 @@ using Neo.IO.Caching;
 using Org.BouncyCastle.Crypto.Parameters;
 using Org.BouncyCastle.Math;
 using System;
-using System.Linq;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 
@@ -26,7 +25,6 @@ namespace Neo.Cryptography
     {
         private static readonly ECDsaCache CacheECDsa = new();
         private static readonly bool IsOSX = RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
-        private static readonly bool IsLinux = RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
 
         /// <summary>
         /// Calculates the 160-bit hash value of the specified message.
@@ -58,7 +56,7 @@ namespace Neo.Cryptography
         /// <returns>The ECDSA signature for the specified message.</returns>
         public static byte[] Sign(byte[] message, byte[] priKey, byte[] pubKey, ECC.ECCurve ecCurve = null)
         {
-            if ((IsOSX || IsLinux) && ecCurve == ECC.ECCurve.Secp256k1)
+            if (IsOSX && ecCurve == ECC.ECCurve.Secp256k1)
             {
                 var curveParameters = Org.BouncyCastle.Asn1.Sec.SecNamedCurves.GetByName("secp256k1");
                 var domain = new ECDomainParameters(curveParameters.Curve, curveParameters.G, curveParameters.N, curveParameters.H);

--- a/src/Neo/Cryptography/Crypto.cs
+++ b/src/Neo/Cryptography/Crypto.cs
@@ -79,8 +79,7 @@ namespace Neo.Cryptography
             }
 
             var curve =
-                // Default curve is SECP256R1
-                ecCurve == null ? ECCurve.NamedCurves.nistP256 :
+                 ecCurve == null || ecCurve == ECC.ECCurve.Secp256r1 ? ECCurve.NamedCurves.nistP256 :
                 ecCurve == ECC.ECCurve.Secp256k1 ? ECCurve.CreateFromFriendlyName("secP256k1") :
                 throw new NotSupportedException();
 
@@ -88,11 +87,6 @@ namespace Neo.Cryptography
             {
                 Curve = curve,
                 D = priKey,
-                Q = new ECPoint
-                {
-                    X = pubKey.Take(32).ToArray(),
-                    Y = pubKey.Skip(32).Take(32).ToArray()
-                }
             });
             return ecdsa.SignData(message, HashAlgorithmName.SHA256);
         }
@@ -125,11 +119,9 @@ namespace Neo.Cryptography
 
                 return signer.VerifySignature(message.Sha256(), r, s);
             }
-            else
-            {
-                var ecdsa = CreateECDsa(pubkey);
-                return ecdsa.VerifyData(message, signature, HashAlgorithmName.SHA256);
-            }
+
+            var ecdsa = CreateECDsa(pubkey);
+            return ecdsa.VerifyData(message, signature, HashAlgorithmName.SHA256);
         }
 
         /// <summary>

--- a/src/Neo/Cryptography/Crypto.cs
+++ b/src/Neo/Cryptography/Crypto.cs
@@ -51,10 +51,9 @@ namespace Neo.Cryptography
         /// </summary>
         /// <param name="message">The message to be signed.</param>
         /// <param name="priKey">The private key to be used.</param>
-        /// <param name="pubKey">The public key to be used (uncommpressed, 65 bytes).</param>
         /// <param name="ecCurve">The <see cref="ECC.ECCurve"/> curve of the signature, default is <see cref="ECC.ECCurve.Secp256k1"/>.</param>
         /// <returns>The ECDSA signature for the specified message.</returns>
-        public static byte[] Sign(byte[] message, byte[] priKey, byte[] pubKey, ECC.ECCurve ecCurve = null)
+        public static byte[] Sign(byte[] message, byte[] priKey, ECC.ECCurve ecCurve = null)
         {
             if (IsOSX && ecCurve == ECC.ECCurve.Secp256k1)
             {

--- a/src/Neo/Cryptography/Crypto.cs
+++ b/src/Neo/Cryptography/Crypto.cs
@@ -25,6 +25,7 @@ namespace Neo.Cryptography
     {
         private static readonly ECDsaCache CacheECDsa = new();
         private static readonly bool IsOSX = RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
+        private static readonly bool IsLinux = RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
 
         /// <summary>
         /// Calculates the 160-bit hash value of the specified message.
@@ -56,7 +57,7 @@ namespace Neo.Cryptography
         /// <returns>The ECDSA signature for the specified message.</returns>
         public static byte[] Sign(byte[] message, byte[] priKey, byte[] pubKey, ECC.ECCurve ecCurve = null)
         {
-            if (IsOSX && ecCurve == ECC.ECCurve.Secp256k1)
+            if ((IsOSX || IsLinux) && ecCurve == ECC.ECCurve.Secp256k1)
             {
                 var curveParameters = Org.BouncyCastle.Asn1.Sec.SecNamedCurves.GetByName("secp256k1");
                 var domain = new ECDomainParameters(curveParameters.Curve, curveParameters.G, curveParameters.N, curveParameters.H);

--- a/src/Neo/Cryptography/Crypto.cs
+++ b/src/Neo/Cryptography/Crypto.cs
@@ -51,7 +51,7 @@ namespace Neo.Cryptography
         /// </summary>
         /// <param name="message">The message to be signed.</param>
         /// <param name="priKey">The private key to be used.</param>
-        /// <param name="ecCurve">The <see cref="ECC.ECCurve"/> curve of the signature, default is <see cref="ECC.ECCurve.Secp256k1"/>.</param>
+        /// <param name="ecCurve">The <see cref="ECC.ECCurve"/> curve of the signature, default is <see cref="ECC.ECCurve.Secp256r1"/>.</param>
         /// <returns>The ECDSA signature for the specified message.</returns>
         public static byte[] Sign(byte[] message, byte[] priKey, ECC.ECCurve ecCurve = null)
         {

--- a/src/Neo/Cryptography/Crypto.cs
+++ b/src/Neo/Cryptography/Crypto.cs
@@ -10,6 +10,8 @@
 // modifications are permitted.
 
 using Neo.IO.Caching;
+using Org.BouncyCastle.Crypto.Parameters;
+using Org.BouncyCastle.Math;
 using System;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
@@ -48,19 +50,46 @@ namespace Neo.Cryptography
         /// Signs the specified message using the ECDSA algorithm.
         /// </summary>
         /// <param name="message">The message to be signed.</param>
-        /// <param name="prikey">The private key to be used.</param>
-        /// <param name="pubkey">The public key to be used.</param>
+        /// <param name="priKey">The private key to be used.</param>
+        /// <param name="pubKey">The public key to be used (uncommpressed, 65 bytes).</param>
+        /// <param name="ecCurve">The <see cref="ECC.ECCurve"/> curve of the signature, default is <see cref="ECC.ECCurve.Secp256k1"/>.</param>
         /// <returns>The ECDSA signature for the specified message.</returns>
-        public static byte[] Sign(byte[] message, byte[] prikey, byte[] pubkey)
+        public static byte[] Sign(byte[] message, byte[] priKey, byte[] pubKey, ECC.ECCurve ecCurve = null)
         {
+            if (IsOSX && ecCurve == ECC.ECCurve.Secp256k1)
+            {
+                var curveParameters = Org.BouncyCastle.Asn1.Sec.SecNamedCurves.GetByName("secp256k1");
+                var domain = new ECDomainParameters(curveParameters.Curve, curveParameters.G, curveParameters.N, curveParameters.H);
+                var signer = new Org.BouncyCastle.Crypto.Signers.ECDsaSigner();
+                var privateKey = new BigInteger(1, priKey);
+                var priKeyParameters = new ECPrivateKeyParameters(privateKey, domain);
+                signer.Init(true, priKeyParameters);
+                var signature = signer.GenerateSignature(message.Sha256());
+
+                var signatureBytes = new byte[64];
+                var rBytes = signature[0].ToByteArrayUnsigned();
+                var sBytes = signature[1].ToByteArrayUnsigned();
+
+                // Copy r and s into their respective parts of the signatureBytes array, aligning them to the right.
+                Buffer.BlockCopy(rBytes, 0, signatureBytes, 32 - rBytes.Length, rBytes.Length);
+                Buffer.BlockCopy(sBytes, 0, signatureBytes, 64 - sBytes.Length, sBytes.Length);
+                return signatureBytes;
+            }
+
+            var curve =
+                // Default curve is SECP256R1
+                ecCurve == null ? ECCurve.NamedCurves.nistP256 :
+                ecCurve == ECC.ECCurve.Secp256k1 ? ECCurve.CreateFromFriendlyName("secP256k1") :
+                throw new NotSupportedException();
+
             using var ecdsa = ECDsa.Create(new ECParameters
             {
-                Curve = ECCurve.NamedCurves.nistP256,
-                D = prikey,
+                Curve = curve,
+                D = priKey,
                 Q = new ECPoint
                 {
-                    X = pubkey[..32],
-                    Y = pubkey[32..]
+                    X = pubKey[..32],
+                    Y = pubKey[32..]
                 }
             });
             return ecdsa.SignData(message, HashAlgorithmName.SHA256);
@@ -80,17 +109,17 @@ namespace Neo.Cryptography
             if (IsOSX && pubkey.Curve == ECC.ECCurve.Secp256k1)
             {
                 var curve = Org.BouncyCastle.Asn1.Sec.SecNamedCurves.GetByName("secp256k1");
-                var domain = new Org.BouncyCastle.Crypto.Parameters.ECDomainParameters(curve.Curve, curve.G, curve.N, curve.H);
+                var domain = new ECDomainParameters(curve.Curve, curve.G, curve.N, curve.H);
                 var point = curve.Curve.CreatePoint(
-                    new Org.BouncyCastle.Math.BigInteger(pubkey.X.Value.ToString()),
-                    new Org.BouncyCastle.Math.BigInteger(pubkey.Y.Value.ToString()));
-                var pubKey = new Org.BouncyCastle.Crypto.Parameters.ECPublicKeyParameters("ECDSA", point, domain);
+                    new BigInteger(pubkey.X.Value.ToString()),
+                    new BigInteger(pubkey.Y.Value.ToString()));
+                var pubKey = new ECPublicKeyParameters("ECDSA", point, domain);
                 var signer = new Org.BouncyCastle.Crypto.Signers.ECDsaSigner();
                 signer.Init(false, pubKey);
 
                 var sig = signature.ToArray();
-                var r = new Org.BouncyCastle.Math.BigInteger(1, sig, 0, 32);
-                var s = new Org.BouncyCastle.Math.BigInteger(1, sig, 32, 32);
+                var r = new BigInteger(1, sig, 0, 32);
+                var s = new BigInteger(1, sig, 32, 32);
 
                 return signer.VerifySignature(message.Sha256(), r, s);
             }

--- a/src/Neo/Cryptography/Crypto.cs
+++ b/src/Neo/Cryptography/Crypto.cs
@@ -13,6 +13,7 @@ using Neo.IO.Caching;
 using Org.BouncyCastle.Crypto.Parameters;
 using Org.BouncyCastle.Math;
 using System;
+using System.Linq;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 
@@ -89,8 +90,8 @@ namespace Neo.Cryptography
                 D = priKey,
                 Q = new ECPoint
                 {
-                    X = pubKey[..32],
-                    Y = pubKey[32..]
+                    X = pubKey.Take(32).ToArray(),
+                    Y = pubKey.Skip(32).Take(32).ToArray()
                 }
             });
             return ecdsa.SignData(message, HashAlgorithmName.SHA256);

--- a/src/Neo/Wallets/Helper.cs
+++ b/src/Neo/Wallets/Helper.cs
@@ -36,7 +36,7 @@ namespace Neo.Wallets
         /// <returns>The signature for the <see cref="IVerifiable"/>.</returns>
         public static byte[] Sign(this IVerifiable verifiable, KeyPair key, uint network)
         {
-            return Crypto.Sign(verifiable.GetSignData(network), key.PrivateKey, key.PublicKey.EncodePoint(false)[1..]);
+            return Crypto.Sign(verifiable.GetSignData(network), key.PrivateKey);
         }
 
         /// <summary>

--- a/tests/Neo.UnitTests/Cryptography/UT_Crypto.cs
+++ b/tests/Neo.UnitTests/Cryptography/UT_Crypto.cs
@@ -54,7 +54,7 @@ namespace Neo.UnitTests.Cryptography
         public void TestVerifySignature()
         {
             byte[] message = System.Text.Encoding.Default.GetBytes("HelloWorld");
-            byte[] signature = Crypto.Sign(message, key.PrivateKey, key.PublicKey.EncodePoint(false).Skip(1).ToArray());
+            byte[] signature = Crypto.Sign(message, key.PrivateKey);
             Crypto.VerifySignature(message, signature, key.PublicKey).Should().BeTrue();
 
             byte[] wrongKey = new byte[33];
@@ -76,14 +76,14 @@ namespace Neo.UnitTests.Cryptography
         {
             byte[] privkey = "7177f0d04c79fa0b8c91fe90c1cf1d44772d1fba6e5eb9b281a22cd3aafb51fe".HexToBytes();
             byte[] message = "2d46a712699bae19a634563d74d04cc2da497b841456da270dccb75ac2f7c4e7".HexToBytes();
-            byte[] pubKey = "04fd0a8c1ce5ae5570fdd46e7599c16b175bf0ebdfe9c178f1ab848fb16dac74a5d301b0534c7bcf1b3760881f0c420d17084907edd771e1c9c8e941bbf6ff9108".HexToBytes();
-            var signature = Crypto.Sign(message, privkey, pubKey, Neo.Cryptography.ECC.ECCurve.Secp256k1);
+            var signature = Crypto.Sign(message, privkey, Neo.Cryptography.ECC.ECCurve.Secp256k1);
 
+            byte[] pubKey = "04fd0a8c1ce5ae5570fdd46e7599c16b175bf0ebdfe9c178f1ab848fb16dac74a5d301b0534c7bcf1b3760881f0c420d17084907edd771e1c9c8e941bbf6ff9108".HexToBytes();
             Crypto.VerifySignature(message, signature, pubKey, Neo.Cryptography.ECC.ECCurve.Secp256k1)
                 .Should().BeTrue();
 
             message = System.Text.Encoding.Default.GetBytes("world");
-            signature = Crypto.Sign(message, privkey, pubKey, Neo.Cryptography.ECC.ECCurve.Secp256k1);
+            signature = Crypto.Sign(message, privkey, Neo.Cryptography.ECC.ECCurve.Secp256k1);
 
             Crypto.VerifySignature(message, signature, pubKey, Neo.Cryptography.ECC.ECCurve.Secp256k1)
                 .Should().BeTrue();

--- a/tests/Neo.UnitTests/Cryptography/UT_Crypto.cs
+++ b/tests/Neo.UnitTests/Cryptography/UT_Crypto.cs
@@ -74,16 +74,16 @@ namespace Neo.UnitTests.Cryptography
         [TestMethod]
         public void TestSecp256k1()
         {
-            byte[] message = System.Text.Encoding.Default.GetBytes("hello");
-            byte[] signature = "5331be791532d157df5b5620620d938bcb622ad02c81cfc184c460efdad18e695480d77440c511e9ad02ea30d773cb54e88f8cbb069644aefa283957085f38b5".HexToBytes();
-            byte[] pubKey = "03ea01cb94bdaf0cd1c01b159d474f9604f4af35a3e2196f6bdfdb33b2aa4961fa".HexToBytes();
+            byte[] privkey = "7177f0d04c79fa0b8c91fe90c1cf1d44772d1fba6e5eb9b281a22cd3aafb51fe".HexToBytes();
+            byte[] message = "2d46a712699bae19a634563d74d04cc2da497b841456da270dccb75ac2f7c4e7".HexToBytes();
+            byte[] pubKey = "04fd0a8c1ce5ae5570fdd46e7599c16b175bf0ebdfe9c178f1ab848fb16dac74a5d301b0534c7bcf1b3760881f0c420d17084907edd771e1c9c8e941bbf6ff9108".HexToBytes();
+            var signature = Crypto.Sign(message, privkey, pubKey, Neo.Cryptography.ECC.ECCurve.Secp256k1);
 
             Crypto.VerifySignature(message, signature, pubKey, Neo.Cryptography.ECC.ECCurve.Secp256k1)
                 .Should().BeTrue();
 
             message = System.Text.Encoding.Default.GetBytes("world");
-            signature = "b1e6ff4f40536fb7ed706b0f7567903cc227a5241a079fb86f3de51b8321c1e690f37ad0c788848605c1653567935845f0d35a8a1a37174dcbbd235caac8e969".HexToBytes();
-            pubKey = "03661b86d54eb3a8e7ea2399e0db36ab65753f95fff661da53ae0121278b881ad0".HexToBytes();
+            signature = Crypto.Sign(message, privkey, pubKey, Neo.Cryptography.ECC.ECCurve.Secp256k1);
 
             Crypto.VerifySignature(message, signature, pubKey, Neo.Cryptography.ECC.ECCurve.Secp256k1)
                 .Should().BeTrue();

--- a/tests/Neo.UnitTests/SmartContract/Manifest/UT_ContractGroup.cs
+++ b/tests/Neo.UnitTests/SmartContract/Manifest/UT_ContractGroup.cs
@@ -44,7 +44,7 @@ namespace Neo.UnitTests.SmartContract.Manifest
         public void TestIsValid()
         {
             Random random = new();
-            byte[] privateKey = new byte[32];
+            var privateKey = new byte[32];
             random.NextBytes(privateKey);
             KeyPair keyPair = new(privateKey);
             ContractGroup contractGroup = new()
@@ -55,11 +55,11 @@ namespace Neo.UnitTests.SmartContract.Manifest
             Assert.AreEqual(false, contractGroup.IsValid(UInt160.Zero));
 
 
-            byte[] message = new byte[] {  0x01,0x01,0x01,0x01,0x01,
+            var message = new byte[] {  0x01,0x01,0x01,0x01,0x01,
                                            0x01,0x01,0x01,0x01,0x01,
                                            0x01,0x01,0x01,0x01,0x01,
                                            0x01,0x01,0x01,0x01,0x01 };
-            byte[] signature = Crypto.Sign(message, keyPair.PrivateKey, keyPair.PublicKey.EncodePoint(false).Skip(1).ToArray());
+            var signature = Crypto.Sign(message, keyPair.PrivateKey);
             contractGroup = new ContractGroup
             {
                 PubKey = keyPair.PublicKey,

--- a/tests/Neo.UnitTests/SmartContract/UT_InteropService.NEO.cs
+++ b/tests/Neo.UnitTests/SmartContract/UT_InteropService.NEO.cs
@@ -33,13 +33,13 @@ namespace Neo.UnitTests.SmartContract
         public void TestCheckSig()
         {
             var engine = GetEngine(true);
-            IVerifiable iv = engine.ScriptContainer;
-            byte[] message = iv.GetSignData(TestProtocolSettings.Default.Network);
+            var iv = engine.ScriptContainer;
+            var message = iv.GetSignData(TestProtocolSettings.Default.Network);
             byte[] privateKey = { 0x01,0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
                 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01};
-            KeyPair keyPair = new KeyPair(privateKey);
-            ECPoint pubkey = keyPair.PublicKey;
-            byte[] signature = Crypto.Sign(message, privateKey, pubkey.EncodePoint(false).Skip(1).ToArray());
+            var keyPair = new KeyPair(privateKey);
+            var pubkey = keyPair.PublicKey;
+            var signature = Crypto.Sign(message, privateKey);
             engine.CheckSig(pubkey.EncodePoint(false), signature).Should().BeTrue();
             Action action = () => engine.CheckSig(new byte[70], signature);
             action.Should().Throw<FormatException>();
@@ -49,20 +49,20 @@ namespace Neo.UnitTests.SmartContract
         public void TestCrypto_CheckMultiSig()
         {
             var engine = GetEngine(true);
-            IVerifiable iv = engine.ScriptContainer;
-            byte[] message = iv.GetSignData(TestProtocolSettings.Default.Network);
+            var iv = engine.ScriptContainer;
+            var message = iv.GetSignData(TestProtocolSettings.Default.Network);
 
             byte[] privkey1 = { 0x01,0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
                 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01};
-            KeyPair key1 = new KeyPair(privkey1);
-            ECPoint pubkey1 = key1.PublicKey;
-            byte[] signature1 = Crypto.Sign(message, privkey1, pubkey1.EncodePoint(false).Skip(1).ToArray());
+            var key1 = new KeyPair(privkey1);
+            var pubkey1 = key1.PublicKey;
+            var signature1 = Crypto.Sign(message, privkey1);
 
             byte[] privkey2 = { 0x01,0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
                 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x02};
-            KeyPair key2 = new KeyPair(privkey2);
-            ECPoint pubkey2 = key2.PublicKey;
-            byte[] signature2 = Crypto.Sign(message, privkey2, pubkey2.EncodePoint(false).Skip(1).ToArray());
+            var key2 = new KeyPair(privkey2);
+            var pubkey2 = key2.PublicKey;
+            var signature2 = Crypto.Sign(message, privkey2);
 
             var pubkeys = new[]
             {
@@ -168,7 +168,7 @@ namespace Neo.UnitTests.SmartContract
                 Script = new[] { (byte)OpCode.RET },
                 Source = string.Empty,
                 Compiler = "",
-                Tokens = System.Array.Empty<MethodToken>()
+                Tokens = Array.Empty<MethodToken>()
             };
             nef.CheckSum = NefFile.ComputeChecksum(nef);
             Assert.ThrowsException<InvalidOperationException>(() => snapshot.UpdateContract(null, nef.ToArray(), new byte[0]));
@@ -176,13 +176,13 @@ namespace Neo.UnitTests.SmartContract
             var manifest = TestUtils.CreateDefaultManifest();
             byte[] privkey = { 0x01,0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
                 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01};
-            KeyPair key = new KeyPair(privkey);
-            ECPoint pubkey = key.PublicKey;
+            var key = new KeyPair(privkey);
+            var pubkey = key.PublicKey;
             var state = TestUtils.GetContract();
-            byte[] signature = Crypto.Sign(state.Hash.ToArray(), privkey, pubkey.EncodePoint(false).Skip(1).ToArray());
+            var signature = Crypto.Sign(state.Hash.ToArray(), privkey);
             manifest.Groups = new ContractGroup[]
             {
-                new ContractGroup()
+                new()
                 {
                     PubKey = pubkey,
                     Signature = signature

--- a/tests/Neo.UnitTests/SmartContract/UT_InteropService.cs
+++ b/tests/Neo.UnitTests/SmartContract/UT_InteropService.cs
@@ -402,7 +402,7 @@ namespace Neo.UnitTests.SmartContract
                 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01};
             KeyPair keyPair = new(privateKey);
             var pubkey = keyPair.PublicKey;
-            var signature = Crypto.Sign(message, privateKey, pubkey.EncodePoint(false).Skip(1).ToArray());
+            var signature = Crypto.Sign(message, privateKey);
             engine.CheckSig(pubkey.EncodePoint(false), signature).Should().BeTrue();
 
             var wrongkey = pubkey.EncodePoint(false);


### PR DESCRIPTION
# Description

The issue is that the default C# dotnet does not support SECP256K1 curve on macos platform. We added support to SECP256K1 signature `verify` method for macos but did not add its `sign` method. 

I found this issue when i was trying to run unit test here https://github.com/neo-project/neo-devpack-dotnet/blob/53a383ab5670d3c22d9761a113a50f7ef1a75ee0/tests/Neo.SmartContract.Framework.UnitTests/Services/CryptoTest.cs#L53

Fixes # (issue)

```
Test method Neo.SmartContract.Framework.UnitTests.Services.CryptoTest.Test_VerifySignatureWithMessage threw exception: 
System.PlatformNotSupportedException: The specified curve '1.3.132.0.10' or its parameters are not valid for this platform.
    at System.Security.Cryptography.EccSecurityTransforms.ImportParameters(ECParameters parameters)
   at System.Security.Cryptography.ECDsaImplementation.ECDsaSecurityTransforms.ImportParameters(ECParameters parameters)
   at System.Security.Cryptography.ECDsa.Create(ECParameters parameters)
   at Neo.SmartContract.Framework.UnitTests.Services.CryptoTest.Test_VerifySignatureWithMessage() in /Users/jinghuiliao/git/neo-devpack-dotnet/tests/Neo.SmartContract.Framework.UnitTests/Services/CryptoTest.cs:line 70
   at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
   at System.Reflection.MethodInvoker.Invoke(Object obj, IntPtr* args, BindingFlags invokeAttr)

```


## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] TestSecp256k1


**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
