### PR TITLE
add secp256k1 + keccak256 to signature verification.

### DIFF
--- a/src/Neo/Cryptography/Hasher.cs
+++ b/src/Neo/Cryptography/Hasher.cs
@@ -1,0 +1,18 @@
+// Copyright (C) 2015-2024 The Neo Project.
+//
+// Hasher.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+namespace Neo.Cryptography;
+
+public enum Hasher
+{
+    SHA256,
+    Keccak256,
+}

--- a/src/Neo/Cryptography/Helper.cs
+++ b/src/Neo/Cryptography/Helper.cs
@@ -12,6 +12,7 @@
 using Neo.IO;
 using Neo.Network.P2P.Payloads;
 using Neo.Wallets;
+using Org.BouncyCastle.Crypto.Digests;
 using Org.BouncyCastle.Crypto.Engines;
 using Org.BouncyCastle.Crypto.Modes;
 using Org.BouncyCastle.Crypto.Parameters;
@@ -151,6 +152,25 @@ namespace Neo.Cryptography
         public static byte[] Sha256(this Span<byte> value)
         {
             return Sha256((ReadOnlySpan<byte>)value);
+        }
+
+        public static byte[] Keccak256(this byte[] value)
+        {
+            KeccakDigest keccak = new(256);
+            keccak.BlockUpdate(value, 0, value.Length);
+            byte[] result = new byte[keccak.GetDigestSize()];
+            keccak.DoFinal(result, 0);
+            return result;
+        }
+
+        public static byte[] Keccak256(this ReadOnlySpan<byte> value)
+        {
+            return value.Keccak256();
+        }
+
+        public static byte[] Keccak256(this Span<byte> value)
+        {
+            return Keccak256((ReadOnlySpan<byte>)value);
         }
 
         public static byte[] AES256Encrypt(this byte[] plainData, byte[] key, byte[] nonce, byte[] associatedData = null)

--- a/src/Neo/SmartContract/Native/CryptoLib.cs
+++ b/src/Neo/SmartContract/Native/CryptoLib.cs
@@ -73,11 +73,7 @@ namespace Neo.SmartContract.Native
         [ContractMethod(Hardfork.HF_Cockatrice, CpuFee = 1 << 15)]
         public static byte[] Keccak256(byte[] data)
         {
-            KeccakDigest keccak = new(256);
-            keccak.BlockUpdate(data, 0, data.Length);
-            byte[] result = new byte[keccak.GetDigestSize()];
-            keccak.DoFinal(result, 0);
-            return result;
+            return data.Keccak256();
         }
 
         /// <summary>


### PR DESCRIPTION
# Description

This pr focus on adding support to secp256k1 signed transactions and hashed with Keccak256.

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?


**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
