### PR TITLE
[`Refactor`] Avoid `this.` and `Me.` if not necessary

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -60,11 +60,12 @@ dotnet_diagnostic.CS1591.severity = silent
 # Sort using and Import directives with System.* appearing first
 dotnet_sort_system_directives_first = false
 dotnet_separate_import_directive_groups = false
+
 # Avoid "this." and "Me." if not necessary
-dotnet_style_qualification_for_field = false:refactoring
-dotnet_style_qualification_for_property = false:refactoring
-dotnet_style_qualification_for_method = false:refactoring
-dotnet_style_qualification_for_event = false:refactoring
+dotnet_style_qualification_for_field = false:warning
+dotnet_style_qualification_for_property = false:warning
+dotnet_style_qualification_for_method = false:warning
+dotnet_style_qualification_for_event = false:warning
 
 # Use language keywords instead of framework type names for type references
 dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
@@ -254,6 +255,10 @@ csharp_preserve_single_line_statements = true
 dotnet_diagnostic.IDE0060.severity = none
 
 [src/{Analyzers,CodeStyle,Features,Workspaces,EditorFeatures,VisualStudio}/**/*.{cs,vb}]
+
+# Avoid "this." and "Me." if not necessary
+dotnet_diagnostic.IDE0003.severity = warning
+dotnet_diagnostic.IDE0009.severity = warning
 
 # IDE0011: Add braces
 csharp_prefer_braces = when_multiline:warning

--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,8 @@
 # Set default behavior to automatically normalize line endings.
 ###############################################################################
 * text eol=lf
+*.cs eol=lf
+*.csproj eol=lf
 
 ###############################################################################
 # Set default behavior for command prompt diff.
@@ -44,6 +46,7 @@
 *.png binary
 *.gif binary
 *.ico binary
+*.zip binary
 
 ###############################################################################
 # diff behavior for common document formats

--- a/src/Neo.ConsoleService/ServiceProxy.cs
+++ b/src/Neo.ConsoleService/ServiceProxy.cs
@@ -19,7 +19,7 @@ namespace Neo.ConsoleService
 
         public ServiceProxy(ConsoleServiceBase service)
         {
-            this._service = service;
+            _service = service;
         }
 
         protected override void OnStart(string[] args)

--- a/src/Neo.GUI/GUI/InputBox.cs
+++ b/src/Neo.GUI/GUI/InputBox.cs
@@ -18,7 +18,7 @@ namespace Neo.GUI
         private InputBox(string text, string caption, string content)
         {
             InitializeComponent();
-            this.Text = caption;
+            Text = caption;
             groupBox1.Text = text;
             textBox1.Text = content;
         }

--- a/src/Neo.Json/JBoolean.cs
+++ b/src/Neo.Json/JBoolean.cs
@@ -29,7 +29,7 @@ namespace Neo.Json
         /// <param name="value">The value of the JSON token.</param>
         public JBoolean(bool value = false)
         {
-            this.Value = value;
+            Value = value;
         }
 
         public override bool AsBoolean()
@@ -91,7 +91,7 @@ namespace Neo.Json
             }
             if (obj is JBoolean other)
             {
-                return this.Value.Equals(other.Value);
+                return Value.Equals(other.Value);
             }
             return false;
         }

--- a/src/Neo.Json/JNumber.cs
+++ b/src/Neo.Json/JNumber.cs
@@ -41,7 +41,7 @@ namespace Neo.Json
         public JNumber(double value = 0)
         {
             if (!double.IsFinite(value)) throw new FormatException();
-            this.Value = value;
+            Value = value;
         }
 
         /// <summary>

--- a/src/Neo.Json/JString.cs
+++ b/src/Neo.Json/JString.cs
@@ -30,7 +30,7 @@ namespace Neo.Json
         /// <param name="value">The value of the JSON token.</param>
         public JString(string value)
         {
-            this.Value = value ?? throw new ArgumentNullException(nameof(value));
+            Value = value ?? throw new ArgumentNullException(nameof(value));
         }
 
         /// <summary>
@@ -115,7 +115,7 @@ namespace Neo.Json
             }
             if (obj is string str)
             {
-                return this.Value == str;
+                return Value == str;
             }
             return false;
         }

--- a/src/Neo.VM/Collections/OrderedDictionary.cs
+++ b/src/Neo.VM/Collections/OrderedDictionary.cs
@@ -27,8 +27,8 @@ namespace Neo.VM.Collections
 
             public TItem(TKey key, TValue value)
             {
-                this.Key = key;
-                this.Value = value;
+                Key = key;
+                Value = value;
             }
         }
 

--- a/src/Neo.VM/ExceptionHandlingContext.cs
+++ b/src/Neo.VM/ExceptionHandlingContext.cs
@@ -51,8 +51,8 @@ namespace Neo.VM
 
         internal ExceptionHandlingContext(int catchPointer, int finallyPointer)
         {
-            this.CatchPointer = catchPointer;
-            this.FinallyPointer = finallyPointer;
+            CatchPointer = catchPointer;
+            FinallyPointer = finallyPointer;
         }
     }
 }

--- a/src/Neo.VM/ExecutionContext.SharedStates.cs
+++ b/src/Neo.VM/ExecutionContext.SharedStates.cs
@@ -25,9 +25,9 @@ namespace Neo.VM
 
             public SharedStates(Script script, ReferenceCounter referenceCounter)
             {
-                this.Script = script;
-                this.EvaluationStack = new EvaluationStack(referenceCounter);
-                this.States = new Dictionary<Type, object>();
+                Script = script;
+                EvaluationStack = new EvaluationStack(referenceCounter);
+                States = new Dictionary<Type, object>();
             }
         }
     }

--- a/src/Neo.VM/ExecutionContext.cs
+++ b/src/Neo.VM/ExecutionContext.cs
@@ -117,8 +117,8 @@ namespace Neo.VM
             if (rvcount < -1 || rvcount > ushort.MaxValue)
                 throw new ArgumentOutOfRangeException(nameof(rvcount));
             this.shared_states = shared_states;
-            this.RVCount = rvcount;
-            this.InstructionPointer = initialPosition;
+            RVCount = rvcount;
+            InstructionPointer = initialPosition;
         }
 
         /// <summary>

--- a/src/Neo.VM/ExecutionEngine.cs
+++ b/src/Neo.VM/ExecutionEngine.cs
@@ -95,10 +95,10 @@ namespace Neo.VM
         /// <param name="limits">Restrictions on the VM.</param>
         protected ExecutionEngine(JumpTable? jumpTable, ReferenceCounter referenceCounter, ExecutionEngineLimits limits)
         {
-            this.JumpTable = jumpTable ?? JumpTable.Default;
-            this.Limits = limits;
-            this.ReferenceCounter = referenceCounter;
-            this.ResultStack = new EvaluationStack(referenceCounter);
+            JumpTable = jumpTable ?? JumpTable.Default;
+            Limits = limits;
+            ReferenceCounter = referenceCounter;
+            ResultStack = new EvaluationStack(referenceCounter);
         }
 
         public virtual void Dispose()

--- a/src/Neo.VM/Instruction.cs
+++ b/src/Neo.VM/Instruction.cs
@@ -191,7 +191,7 @@ namespace Neo.VM
 
         private Instruction(OpCode opcode)
         {
-            this.OpCode = opcode;
+            OpCode = opcode;
             if (!Enum.IsDefined(typeof(OpCode), opcode)) throw new BadScriptException();
         }
 

--- a/src/Neo.VM/Script.cs
+++ b/src/Neo.VM/Script.cs
@@ -72,7 +72,7 @@ namespace Neo.VM
         /// <exception cref="BadScriptException">In strict mode, the script was found to contain bad instructions.</exception>
         public Script(ReadOnlyMemory<byte> script, bool strictMode)
         {
-            this._value = script;
+            _value = script;
             if (strictMode)
             {
                 for (int ip = 0; ip < script.Length; ip += GetInstruction(ip).Size) { }

--- a/src/Neo.VM/Slot.cs
+++ b/src/Neo.VM/Slot.cs
@@ -69,7 +69,7 @@ namespace Neo.VM
         public Slot(int count, ReferenceCounter referenceCounter)
         {
             this.referenceCounter = referenceCounter;
-            this.items = new StackItem[count];
+            items = new StackItem[count];
             System.Array.Fill(items, StackItem.Null);
             referenceCounter.AddStackReference(StackItem.Null, count);
         }

--- a/src/Neo.VM/Types/ByteString.cs
+++ b/src/Neo.VM/Types/ByteString.cs
@@ -41,7 +41,7 @@ namespace Neo.VM.Types
         /// <param name="data">The data to be contained in this <see cref="ByteString"/>.</param>
         public ByteString(ReadOnlyMemory<byte> data)
         {
-            this.Memory = data;
+            Memory = data;
         }
 
         private bool Equals(ByteString other)

--- a/src/Neo.VM/Types/CompoundType.cs
+++ b/src/Neo.VM/Types/CompoundType.cs
@@ -32,7 +32,7 @@ namespace Neo.VM.Types
         /// <param name="referenceCounter">The reference counter to be used.</param>
         protected CompoundType(ReferenceCounter? referenceCounter)
         {
-            this.ReferenceCounter = referenceCounter;
+            ReferenceCounter = referenceCounter;
             referenceCounter?.AddZeroReferred(this);
         }
 

--- a/src/Neo.VM/Types/Pointer.cs
+++ b/src/Neo.VM/Types/Pointer.cs
@@ -39,8 +39,8 @@ namespace Neo.VM.Types
         /// <param name="position">The position of the pointer in the script.</param>
         public Pointer(Script script, int position)
         {
-            this.Script = script;
-            this.Position = position;
+            Script = script;
+            Position = position;
         }
 
         public override bool Equals(StackItem? other)

--- a/src/Neo/BigDecimal.cs
+++ b/src/Neo/BigDecimal.cs
@@ -61,7 +61,7 @@ namespace Neo
                 ReadOnlySpan<byte> buffer = new(p, 16);
                 this.value = new BigInteger(buffer[..12], isUnsigned: true);
                 if (buffer[15] != 0) this.value = -this.value;
-                this.decimals = buffer[14];
+                decimals = buffer[14];
             }
         }
 

--- a/src/Neo/Cryptography/BloomFilter.cs
+++ b/src/Neo/Cryptography/BloomFilter.cs
@@ -47,10 +47,10 @@ namespace Neo.Cryptography
         public BloomFilter(int m, int k, uint nTweak)
         {
             if (k < 0 || m < 0) throw new ArgumentOutOfRangeException();
-            this.seeds = Enumerable.Range(0, k).Select(p => (uint)p * 0xFBA4C795 + nTweak).ToArray();
-            this.bits = new BitArray(m);
-            this.bits.Length = m;
-            this.Tweak = nTweak;
+            seeds = Enumerable.Range(0, k).Select(p => (uint)p * 0xFBA4C795 + nTweak).ToArray();
+            bits = new BitArray(m);
+            bits.Length = m;
+            Tweak = nTweak;
         }
 
         /// <summary>
@@ -63,10 +63,10 @@ namespace Neo.Cryptography
         public BloomFilter(int m, int k, uint nTweak, ReadOnlyMemory<byte> elements)
         {
             if (k < 0 || m < 0) throw new ArgumentOutOfRangeException();
-            this.seeds = Enumerable.Range(0, k).Select(p => (uint)p * 0xFBA4C795 + nTweak).ToArray();
-            this.bits = new BitArray(elements.ToArray());
-            this.bits.Length = m;
-            this.Tweak = nTweak;
+            seeds = Enumerable.Range(0, k).Select(p => (uint)p * 0xFBA4C795 + nTweak).ToArray();
+            bits = new BitArray(elements.ToArray());
+            bits.Length = m;
+            Tweak = nTweak;
         }
 
         /// <summary>

--- a/src/Neo/Cryptography/ECC/ECCurve.cs
+++ b/src/Neo/Cryptography/ECC/ECCurve.cs
@@ -37,11 +37,11 @@ namespace Neo.Cryptography.ECC
         private ECCurve(BigInteger Q, BigInteger A, BigInteger B, BigInteger N, byte[] G)
         {
             this.Q = Q;
-            this.ExpectedECPointLength = ((int)VM.Utility.GetBitLength(Q) + 7) / 8;
+            ExpectedECPointLength = ((int)VM.Utility.GetBitLength(Q) + 7) / 8;
             this.A = new ECFieldElement(A, this);
             this.B = new ECFieldElement(B, this);
             this.N = N;
-            this.Infinity = new ECPoint(null, null, this);
+            Infinity = new ECPoint(null, null, this);
             this.G = ECPoint.DecodePoint(G, this);
         }
 

--- a/src/Neo/Cryptography/ECC/ECFieldElement.cs
+++ b/src/Neo/Cryptography/ECC/ECFieldElement.cs
@@ -25,7 +25,7 @@ namespace Neo.Cryptography.ECC
                 throw new ArgumentNullException(nameof(curve));
             if (value >= curve.Q)
                 throw new ArgumentException("x value too large in field element");
-            this.Value = value;
+            Value = value;
             this.curve = curve;
         }
 
@@ -117,7 +117,7 @@ namespace Neo.Cryptography.ECC
                 return null;
             BigInteger u = qMinusOne >> 2;
             BigInteger k = (u << 1) + 1;
-            BigInteger Q = this.Value;
+            BigInteger Q = Value;
             BigInteger fourQ = (Q << 2).Mod(curve.Q);
             BigInteger U, V;
             do

--- a/src/Neo/Cryptography/ECC/ECPoint.cs
+++ b/src/Neo/Cryptography/ECC/ECPoint.cs
@@ -49,9 +49,9 @@ namespace Neo.Cryptography.ECC
         {
             if ((x is null ^ y is null) || (curve is null))
                 throw new ArgumentException("Exactly one of the field elements is null");
-            this.X = x;
-            this.Y = y;
-            this.Curve = curve;
+            X = x;
+            Y = y;
+            Curve = curve;
         }
 
         public int CompareTo(ECPoint other)
@@ -378,15 +378,15 @@ namespace Neo.Cryptography.ECC
 
         internal ECPoint Twice()
         {
-            if (this.IsInfinity)
+            if (IsInfinity)
                 return this;
-            if (this.Y.Value.Sign == 0)
+            if (Y.Value.Sign == 0)
                 return Curve.Infinity;
             ECFieldElement TWO = new(2, Curve);
             ECFieldElement THREE = new(3, Curve);
-            ECFieldElement gamma = (this.X.Square() * THREE + Curve.A) / (Y * TWO);
-            ECFieldElement x3 = gamma.Square() - this.X * TWO;
-            ECFieldElement y3 = gamma * (this.X - x3) - this.Y;
+            ECFieldElement gamma = (X.Square() * THREE + Curve.A) / (Y * TWO);
+            ECFieldElement x3 = gamma.Square() - X * TWO;
+            ECFieldElement y3 = gamma * (X - x3) - Y;
             return new ECPoint(x3, y3, Curve);
         }
 

--- a/src/Neo/Cryptography/MerkleTree.cs
+++ b/src/Neo/Cryptography/MerkleTree.cs
@@ -32,12 +32,12 @@ namespace Neo.Cryptography
 
         internal MerkleTree(UInt256[] hashes)
         {
-            this.root = Build(hashes.Select(p => new MerkleTreeNode { Hash = p }).ToArray());
+            root = Build(hashes.Select(p => new MerkleTreeNode { Hash = p }).ToArray());
             if (root is null) return;
             int depth = 1;
             for (MerkleTreeNode i = root; i.LeftChild != null; i = i.LeftChild)
                 depth++;
-            this.Depth = depth;
+            Depth = depth;
         }
 
         private static MerkleTreeNode Build(MerkleTreeNode[] leaves)

--- a/src/Neo/IO/Caching/Cache.cs
+++ b/src/Neo/IO/Caching/Cache.cs
@@ -27,9 +27,9 @@ namespace Neo.IO.Caching
 
             public CacheItem(TKey key, TValue value)
             {
-                this.Key = key;
-                this.Value = value;
-                this.Time = TimeProvider.Current.UtcNow;
+                Key = key;
+                Value = value;
+                Time = TimeProvider.Current.UtcNow;
             }
         }
 
@@ -76,7 +76,7 @@ namespace Neo.IO.Caching
         public Cache(int max_capacity, IEqualityComparer<TKey> comparer = null)
         {
             this.max_capacity = max_capacity;
-            this.InnerDictionary = new Dictionary<TKey, CacheItem>(comparer);
+            InnerDictionary = new Dictionary<TKey, CacheItem>(comparer);
         }
 
         public void Add(TValue item)

--- a/src/Neo/IO/Caching/HashSetCache.cs
+++ b/src/Neo/IO/Caching/HashSetCache.cs
@@ -42,7 +42,7 @@ namespace Neo.IO.Caching
             if (bucketCapacity <= 0) throw new ArgumentOutOfRangeException($"{nameof(bucketCapacity)} should be greater than 0");
             if (maxBucketCount <= 0) throw new ArgumentOutOfRangeException($"{nameof(maxBucketCount)} should be greater than 0");
 
-            this.Count = 0;
+            Count = 0;
             this.bucketCapacity = bucketCapacity;
             this.maxBucketCount = maxBucketCount;
             sets.AddFirst(new HashSet<T>());

--- a/src/Neo/NeoSystem.cs
+++ b/src/Neo/NeoSystem.cs
@@ -130,15 +130,15 @@ namespace Neo
         /// <param name="storagePath">The path of the storage. If <paramref name="storageProvider"/> is the default in-memory storage engine, this parameter is ignored.</param>
         public NeoSystem(ProtocolSettings settings, IStoreProvider storageProvider, string storagePath = null)
         {
-            this.Settings = settings;
-            this.GenesisBlock = CreateGenesisBlock(settings);
+            Settings = settings;
+            GenesisBlock = CreateGenesisBlock(settings);
             this.storageProvider = storageProvider;
-            this.store = storageProvider.GetStore(storagePath);
-            this.MemPool = new MemoryPool(this);
-            this.Blockchain = ActorSystem.ActorOf(Ledger.Blockchain.Props(this));
-            this.LocalNode = ActorSystem.ActorOf(Network.P2P.LocalNode.Props(this));
-            this.TaskManager = ActorSystem.ActorOf(Network.P2P.TaskManager.Props(this));
-            this.TxRouter = ActorSystem.ActorOf(TransactionRouter.Props(this));
+            store = storageProvider.GetStore(storagePath);
+            MemPool = new MemoryPool(this);
+            Blockchain = ActorSystem.ActorOf(Ledger.Blockchain.Props(this));
+            LocalNode = ActorSystem.ActorOf(Network.P2P.LocalNode.Props(this));
+            TaskManager = ActorSystem.ActorOf(Network.P2P.TaskManager.Props(this));
+            TxRouter = ActorSystem.ActorOf(TransactionRouter.Props(this));
             foreach (var plugin in Plugin.Plugins)
                 plugin.OnSystemLoaded(this);
             Blockchain.Ask(new Blockchain.Initialize()).Wait();

--- a/src/Neo/Network/P2P/Capabilities/NodeCapability.cs
+++ b/src/Neo/Network/P2P/Capabilities/NodeCapability.cs
@@ -33,7 +33,7 @@ namespace Neo.Network.P2P.Capabilities
         /// <param name="type">The type of the <see cref="NodeCapability"/>.</param>
         protected NodeCapability(NodeCapabilityType type)
         {
-            this.Type = type;
+            Type = type;
         }
 
         void ISerializable.Deserialize(ref MemoryReader reader)

--- a/src/Neo/Network/P2P/Connection.cs
+++ b/src/Neo/Network/P2P/Connection.cs
@@ -56,9 +56,9 @@ namespace Neo.Network.P2P
         /// <param name="local">The address of the local node.</param>
         protected Connection(object connection, IPEndPoint remote, IPEndPoint local)
         {
-            this.Remote = remote;
-            this.Local = local;
-            this.timer = Context.System.Scheduler.ScheduleTellOnceCancelable(TimeSpan.FromSeconds(connectionTimeoutLimitStart), Self, new Close { Abort = true }, ActorRefs.NoSender);
+            Remote = remote;
+            Local = local;
+            timer = Context.System.Scheduler.ScheduleTellOnceCancelable(TimeSpan.FromSeconds(connectionTimeoutLimitStart), Self, new Close { Abort = true }, ActorRefs.NoSender);
             switch (connection)
             {
                 case IActorRef tcp:

--- a/src/Neo/Network/P2P/LocalNode.cs
+++ b/src/Neo/Network/P2P/LocalNode.cs
@@ -88,7 +88,7 @@ namespace Neo.Network.P2P
         public LocalNode(NeoSystem system)
         {
             this.system = system;
-            this.SeedList = new IPEndPoint[system.Settings.SeedList.Length];
+            SeedList = new IPEndPoint[system.Settings.SeedList.Length];
 
             // Start dns resolution in parallel
             string[] seedList = system.Settings.SeedList;

--- a/src/Neo/Network/P2P/RemoteNode.cs
+++ b/src/Neo/Network/P2P/RemoteNode.cs
@@ -83,8 +83,8 @@ namespace Neo.Network.P2P
         {
             this.system = system;
             this.localNode = localNode;
-            this.knownHashes = new HashSetCache<UInt256>(system.MemPool.Capacity * 2 / 5);
-            this.sentHashes = new HashSetCache<UInt256>(system.MemPool.Capacity * 2 / 5);
+            knownHashes = new HashSetCache<UInt256>(system.MemPool.Capacity * 2 / 5);
+            sentHashes = new HashSetCache<UInt256>(system.MemPool.Capacity * 2 / 5);
             localNode.RemoteNodes.TryAdd(Self, this);
         }
 

--- a/src/Neo/Network/P2P/TaskManager.cs
+++ b/src/Neo/Network/P2P/TaskManager.cs
@@ -74,7 +74,7 @@ namespace Neo.Network.P2P
         public TaskManager(NeoSystem system)
         {
             this.system = system;
-            this.knownHashes = new HashSetCache<UInt256>(system.MemPool.Capacity * 2 / 5);
+            knownHashes = new HashSetCache<UInt256>(system.MemPool.Capacity * 2 / 5);
             Context.System.EventStream.Subscribe(Self, typeof(Blockchain.PersistCompleted));
             Context.System.EventStream.Subscribe(Self, typeof(Blockchain.RelayResult));
         }

--- a/src/Neo/Network/P2P/TaskSession.cs
+++ b/src/Neo/Network/P2P/TaskSession.cs
@@ -31,8 +31,8 @@ namespace Neo.Network.P2P
         public TaskSession(VersionPayload version)
         {
             var fullNode = version.Capabilities.OfType<FullNodeCapability>().FirstOrDefault();
-            this.IsFullNode = fullNode != null;
-            this.LastBlockIndex = fullNode?.StartHeight ?? 0;
+            IsFullNode = fullNode != null;
+            LastBlockIndex = fullNode?.StartHeight ?? 0;
         }
     }
 }

--- a/src/Neo/Persistence/MemorySnapshot.cs
+++ b/src/Neo/Persistence/MemorySnapshot.cs
@@ -26,8 +26,8 @@ namespace Neo.Persistence
         public MemorySnapshot(ConcurrentDictionary<byte[], byte[]> innerData)
         {
             this.innerData = innerData;
-            this.immutableData = innerData.ToImmutableDictionary(ByteArrayEqualityComparer.Default);
-            this.writeBatch = new ConcurrentDictionary<byte[], byte[]>(ByteArrayEqualityComparer.Default);
+            immutableData = innerData.ToImmutableDictionary(ByteArrayEqualityComparer.Default);
+            writeBatch = new ConcurrentDictionary<byte[], byte[]>(ByteArrayEqualityComparer.Default);
         }
 
         public void Commit()

--- a/src/Neo/Persistence/SnapshotCache.cs
+++ b/src/Neo/Persistence/SnapshotCache.cs
@@ -32,7 +32,7 @@ namespace Neo.Persistence
         public SnapshotCache(IReadOnlyStore store)
         {
             this.store = store;
-            this.snapshot = store as ISnapshot;
+            snapshot = store as ISnapshot;
         }
 
         protected override void AddInternal(StorageKey key, StorageItem value)

--- a/src/Neo/SmartContract/ApplicationEngine.cs
+++ b/src/Neo/SmartContract/ApplicationEngine.cs
@@ -162,16 +162,16 @@ namespace Neo.SmartContract
             ProtocolSettings settings, long gas, IDiagnostic diagnostic, JumpTable jumpTable = null)
             : base(jumpTable ?? DefaultJumpTable)
         {
-            this.Trigger = trigger;
-            this.ScriptContainer = container;
-            this.originalSnapshot = snapshot;
-            this.PersistingBlock = persistingBlock;
-            this.ProtocolSettings = settings;
-            this.gas_amount = gas;
-            this.Diagnostic = diagnostic;
-            this.ExecFeeFactor = snapshot is null || persistingBlock?.Index == 0 ? PolicyContract.DefaultExecFeeFactor : NativeContract.Policy.GetExecFeeFactor(snapshot);
-            this.StoragePrice = snapshot is null || persistingBlock?.Index == 0 ? PolicyContract.DefaultStoragePrice : NativeContract.Policy.GetStoragePrice(snapshot);
-            this.nonceData = container is Transaction tx ? tx.Hash.ToArray()[..16] : new byte[16];
+            Trigger = trigger;
+            ScriptContainer = container;
+            originalSnapshot = snapshot;
+            PersistingBlock = persistingBlock;
+            ProtocolSettings = settings;
+            gas_amount = gas;
+            Diagnostic = diagnostic;
+            ExecFeeFactor = snapshot is null || persistingBlock?.Index == 0 ? PolicyContract.DefaultExecFeeFactor : NativeContract.Policy.GetExecFeeFactor(snapshot);
+            StoragePrice = snapshot is null || persistingBlock?.Index == 0 ? PolicyContract.DefaultStoragePrice : NativeContract.Policy.GetStoragePrice(snapshot);
+            nonceData = container is Transaction tx ? tx.Hash.ToArray()[..16] : new byte[16];
             if (persistingBlock is not null)
             {
                 fixed (byte* p = nonceData)

--- a/src/Neo/SmartContract/ContractParameter.cs
+++ b/src/Neo/SmartContract/ContractParameter.cs
@@ -45,8 +45,8 @@ namespace Neo.SmartContract
         /// <param name="type">The type of the parameter.</param>
         public ContractParameter(ContractParameterType type)
         {
-            this.Type = type;
-            this.Value = type switch
+            Type = type;
+            Value = type switch
             {
                 ContractParameterType.Any => null,
                 ContractParameterType.Signature => new byte[64],

--- a/src/Neo/SmartContract/ContractParametersContext.cs
+++ b/src/Neo/SmartContract/ContractParametersContext.cs
@@ -37,16 +37,16 @@ namespace Neo.SmartContract
 
             public ContextItem(Contract contract)
             {
-                this.Script = contract.Script;
-                this.Parameters = contract.ParameterList.Select(p => new ContractParameter { Type = p }).ToArray();
-                this.Signatures = new Dictionary<ECPoint, byte[]>();
+                Script = contract.Script;
+                Parameters = contract.ParameterList.Select(p => new ContractParameter { Type = p }).ToArray();
+                Signatures = new Dictionary<ECPoint, byte[]>();
             }
 
             public ContextItem(JObject json)
             {
-                this.Script = json["script"] is JToken.Null ? null : Convert.FromBase64String(json["script"].AsString());
-                this.Parameters = ((JArray)json["parameters"]).Select(p => ContractParameter.FromJson((JObject)p)).ToArray();
-                this.Signatures = ((JObject)json["signatures"]).Properties.Select(p => new
+                Script = json["script"] is JToken.Null ? null : Convert.FromBase64String(json["script"].AsString());
+                Parameters = ((JArray)json["parameters"]).Select(p => ContractParameter.FromJson((JObject)p)).ToArray();
+                Signatures = ((JObject)json["signatures"]).Properties.Select(p => new
                 {
                     PublicKey = ECPoint.Parse(p.Key, ECCurve.Secp256r1),
                     Signature = Convert.FromBase64String(p.Value.AsString())
@@ -109,10 +109,10 @@ namespace Neo.SmartContract
         /// <param name="network">The magic number of the network.</param>
         public ContractParametersContext(DataCache snapshot, IVerifiable verifiable, uint network)
         {
-            this.Verifiable = verifiable;
-            this.Snapshot = snapshot;
-            this.ContextItems = new Dictionary<UInt160, ContextItem>();
-            this.Network = network;
+            Verifiable = verifiable;
+            Snapshot = snapshot;
+            ContextItems = new Dictionary<UInt160, ContextItem>();
+            Network = network;
         }
 
         /// <summary>

--- a/src/Neo/SmartContract/InteropParameterDescriptor.cs
+++ b/src/Neo/SmartContract/InteropParameterDescriptor.cs
@@ -82,7 +82,7 @@ namespace Neo.SmartContract
         internal InteropParameterDescriptor(ParameterInfo parameterInfo)
             : this(parameterInfo.ParameterType, parameterInfo.GetCustomAttributes<ValidatorAttribute>(true).ToArray())
         {
-            this.Name = parameterInfo.Name;
+            Name = parameterInfo.Name;
         }
 
         internal InteropParameterDescriptor(Type type, params ValidatorAttribute[] validators)

--- a/src/Neo/SmartContract/LogEventArgs.cs
+++ b/src/Neo/SmartContract/LogEventArgs.cs
@@ -42,9 +42,9 @@ namespace Neo.SmartContract
         /// <param name="message">The message of the log.</param>
         public LogEventArgs(IVerifiable container, UInt160 script_hash, string message)
         {
-            this.ScriptContainer = container;
-            this.ScriptHash = script_hash;
-            this.Message = message;
+            ScriptContainer = container;
+            ScriptHash = script_hash;
+            Message = message;
         }
     }
 }

--- a/src/Neo/SmartContract/Manifest/ContractPermissionDescriptor.cs
+++ b/src/Neo/SmartContract/Manifest/ContractPermissionDescriptor.cs
@@ -49,8 +49,8 @@ namespace Neo.SmartContract.Manifest
 
         private ContractPermissionDescriptor(UInt160 hash, ECPoint group)
         {
-            this.Hash = hash;
-            this.Group = group;
+            Hash = hash;
+            Group = group;
         }
 
         internal ContractPermissionDescriptor(ReadOnlySpan<byte> span)

--- a/src/Neo/SmartContract/Native/ContractMethodMetadata.cs
+++ b/src/Neo/SmartContract/Native/ContractMethodMetadata.cs
@@ -39,28 +39,28 @@ namespace Neo.SmartContract.Native
 
         public ContractMethodMetadata(MemberInfo member, ContractMethodAttribute attribute)
         {
-            this.Name = attribute.Name ?? member.Name.ToLower()[0] + member.Name[1..];
-            this.Handler = member switch
+            Name = attribute.Name ?? member.Name.ToLower()[0] + member.Name[1..];
+            Handler = member switch
             {
                 MethodInfo m => m,
                 PropertyInfo p => p.GetMethod,
                 _ => throw new ArgumentException(null, nameof(member))
             };
-            ParameterInfo[] parameterInfos = this.Handler.GetParameters();
+            ParameterInfo[] parameterInfos = Handler.GetParameters();
             if (parameterInfos.Length > 0)
             {
                 NeedApplicationEngine = parameterInfos[0].ParameterType.IsAssignableFrom(typeof(ApplicationEngine));
                 NeedSnapshot = parameterInfos[0].ParameterType.IsAssignableFrom(typeof(DataCache));
             }
             if (NeedApplicationEngine || NeedSnapshot)
-                this.Parameters = parameterInfos.Skip(1).Select(p => new InteropParameterDescriptor(p)).ToArray();
+                Parameters = parameterInfos.Skip(1).Select(p => new InteropParameterDescriptor(p)).ToArray();
             else
-                this.Parameters = parameterInfos.Select(p => new InteropParameterDescriptor(p)).ToArray();
-            this.CpuFee = attribute.CpuFee;
-            this.StorageFee = attribute.StorageFee;
-            this.RequiredCallFlags = attribute.RequiredCallFlags;
-            this.ActiveIn = attribute.ActiveIn;
-            this.Descriptor = new ContractMethodDescriptor
+                Parameters = parameterInfos.Select(p => new InteropParameterDescriptor(p)).ToArray();
+            CpuFee = attribute.CpuFee;
+            StorageFee = attribute.StorageFee;
+            RequiredCallFlags = attribute.RequiredCallFlags;
+            ActiveIn = attribute.ActiveIn;
+            Descriptor = new ContractMethodDescriptor
             {
                 Name = Name,
                 ReturnType = ToParameterType(Handler.ReturnType),

--- a/src/Neo/SmartContract/Native/FungibleToken.cs
+++ b/src/Neo/SmartContract/Native/FungibleToken.cs
@@ -62,7 +62,7 @@ namespace Neo.SmartContract.Native
            "amount", ContractParameterType.Integer)]
         protected FungibleToken() : base()
         {
-            this.Factor = BigInteger.Pow(10, Decimals);
+            Factor = BigInteger.Pow(10, Decimals);
         }
 
         protected override void OnManifestCompose(ContractManifest manifest)

--- a/src/Neo/SmartContract/Native/NativeContract.cs
+++ b/src/Neo/SmartContract/Native/NativeContract.cs
@@ -135,7 +135,7 @@ namespace Neo.SmartContract.Native
         /// </summary>
         protected NativeContract()
         {
-            this.Hash = Helper.GetContractHash(UInt160.Zero, 0, Name);
+            Hash = Helper.GetContractHash(UInt160.Zero, 0, Name);
 
             // Reflection to get the methods
 

--- a/src/Neo/SmartContract/Native/NeoToken.cs
+++ b/src/Neo/SmartContract/Native/NeoToken.cs
@@ -68,7 +68,7 @@ namespace Neo.SmartContract.Native
            "new", ContractParameterType.Array)]
         internal NeoToken() : base()
         {
-            this.TotalAmount = 100000000 * Factor;
+            TotalAmount = 100000000 * Factor;
         }
 
         public override BigInteger TotalSupply(DataCache snapshot)

--- a/src/Neo/SmartContract/NotifyEventArgs.cs
+++ b/src/Neo/SmartContract/NotifyEventArgs.cs
@@ -52,10 +52,10 @@ namespace Neo.SmartContract
         /// <param name="state">The arguments of the event.</param>
         public NotifyEventArgs(IVerifiable container, UInt160 script_hash, string eventName, Array state)
         {
-            this.ScriptContainer = container;
-            this.ScriptHash = script_hash;
-            this.EventName = eventName;
-            this.State = state;
+            ScriptContainer = container;
+            ScriptHash = script_hash;
+            EventName = eventName;
+            State = state;
         }
 
         public void FromStackItem(StackItem stackItem)

--- a/src/Neo/SmartContract/StorageItem.cs
+++ b/src/Neo/SmartContract/StorageItem.cs
@@ -69,7 +69,7 @@ namespace Neo.SmartContract
         /// <param name="value">The integer value of the <see cref="StorageItem"/>.</param>
         public StorageItem(BigInteger value)
         {
-            this.cache = value;
+            cache = value;
         }
 
         /// <summary>
@@ -78,7 +78,7 @@ namespace Neo.SmartContract
         /// <param name="interoperable">The <see cref="IInteroperable"/> value of the <see cref="StorageItem"/>.</param>
         public StorageItem(IInteroperable interoperable)
         {
-            this.cache = interoperable;
+            cache = interoperable;
         }
 
         /// <summary>

--- a/src/Neo/Wallets/AssetDescriptor.cs
+++ b/src/Neo/Wallets/AssetDescriptor.cs
@@ -62,10 +62,10 @@ namespace Neo.Wallets
             }
             using ApplicationEngine engine = ApplicationEngine.Run(script, snapshot, settings: settings, gas: 0_30000000L);
             if (engine.State != VMState.HALT) throw new ArgumentException(null, nameof(asset_id));
-            this.AssetId = asset_id;
-            this.AssetName = contract.Manifest.Name;
-            this.Symbol = engine.ResultStack.Pop().GetString();
-            this.Decimals = (byte)engine.ResultStack.Pop().GetInteger();
+            AssetId = asset_id;
+            AssetName = contract.Manifest.Name;
+            Symbol = engine.ResultStack.Pop().GetString();
+            Decimals = (byte)engine.ResultStack.Pop().GetInteger();
         }
 
         public override string ToString()

--- a/src/Neo/Wallets/KeyPair.cs
+++ b/src/Neo/Wallets/KeyPair.cs
@@ -48,14 +48,14 @@ namespace Neo.Wallets
         {
             if (privateKey.Length != 32 && privateKey.Length != 96 && privateKey.Length != 104)
                 throw new ArgumentException(null, nameof(privateKey));
-            this.PrivateKey = privateKey[^32..];
+            PrivateKey = privateKey[^32..];
             if (privateKey.Length == 32)
             {
-                this.PublicKey = Cryptography.ECC.ECCurve.Secp256r1.G * privateKey;
+                PublicKey = Cryptography.ECC.ECCurve.Secp256r1.G * privateKey;
             }
             else
             {
-                this.PublicKey = Cryptography.ECC.ECPoint.FromBytes(privateKey, Cryptography.ECC.ECCurve.Secp256r1);
+                PublicKey = Cryptography.ECC.ECPoint.FromBytes(privateKey, Cryptography.ECC.ECCurve.Secp256r1);
             }
         }
 

--- a/src/Neo/Wallets/NEP6/NEP6Wallet.cs
+++ b/src/Neo/Wallets/NEP6/NEP6Wallet.cs
@@ -63,10 +63,10 @@ namespace Neo.Wallets.NEP6
             else
             {
                 this.name = name;
-                this.version = Version.Parse("1.0");
-                this.Scrypt = ScryptParameters.Default;
-                this.accounts = new Dictionary<UInt160, NEP6Account>();
-                this.extra = JToken.Null;
+                version = Version.Parse("1.0");
+                Scrypt = ScryptParameters.Default;
+                accounts = new Dictionary<UInt160, NEP6Account>();
+                extra = JToken.Null;
             }
         }
 
@@ -85,8 +85,8 @@ namespace Neo.Wallets.NEP6
 
         private void LoadFromJson(JObject wallet, out ScryptParameters scrypt, out Dictionary<UInt160, NEP6Account> accounts, out JToken extra)
         {
-            this.version = Version.Parse(wallet["version"].AsString());
-            this.name = wallet["name"]?.AsString();
+            version = Version.Parse(wallet["version"].AsString());
+            name = wallet["name"]?.AsString();
             scrypt = ScryptParameters.FromJson((JObject)wallet["scrypt"]);
             accounts = ((JArray)wallet["accounts"]).Select(p => NEP6Account.FromJson((JObject)p, this)).ToDictionary(p => p.ScriptHash);
             extra = wallet["extra"];

--- a/src/Neo/Wallets/NEP6/ScryptParameters.cs
+++ b/src/Neo/Wallets/NEP6/ScryptParameters.cs
@@ -46,9 +46,9 @@ namespace Neo.Wallets.NEP6
         /// <param name="p">Parallelization parameter.</param>
         public ScryptParameters(int n, int r, int p)
         {
-            this.N = n;
-            this.R = r;
-            this.P = p;
+            N = n;
+            R = r;
+            P = p;
         }
 
         /// <summary>

--- a/src/Neo/Wallets/WalletAccount.cs
+++ b/src/Neo/Wallets/WalletAccount.cs
@@ -76,8 +76,8 @@ namespace Neo.Wallets
         /// <param name="settings">The <see cref="Neo.ProtocolSettings"/> to be used by the wallet.</param>
         protected WalletAccount(UInt160 scriptHash, ProtocolSettings settings)
         {
-            this.ProtocolSettings = settings;
-            this.ScriptHash = scriptHash;
+            ProtocolSettings = settings;
+            ScriptHash = scriptHash;
         }
     }
 }


### PR DESCRIPTION
# Change Log
- Removed `this.` keyword from `*.cs` files

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
