### PR TITLE
protected OnSysCall and OnCallT methods

### DIFF
--- a/src/Neo/SmartContract/ApplicationEngine.cs
+++ b/src/Neo/SmartContract/ApplicationEngine.cs
@@ -194,7 +194,7 @@ namespace Neo.SmartContract
             return table;
         }
 
-        private static void OnCallT(ExecutionEngine engine, Instruction instruction)
+        protected static void OnCallT(ExecutionEngine engine, Instruction instruction)
         {
             if (engine is ApplicationEngine app)
             {
@@ -218,7 +218,7 @@ namespace Neo.SmartContract
             }
         }
 
-        private static void OnSysCall(ExecutionEngine engine, Instruction instruction)
+        protected static void OnSysCall(ExecutionEngine engine, Instruction instruction)
         {
             if (engine is ApplicationEngine app)
             {

--- a/src/Neo/SmartContract/ApplicationEngine.cs
+++ b/src/Neo/SmartContract/ApplicationEngine.cs
@@ -32,7 +32,7 @@ namespace Neo.SmartContract
     /// </summary>
     public partial class ApplicationEngine : ExecutionEngine
     {
-        private static readonly JumpTable DefaultJumpTable = ComposeDefaultJumpTable();
+        protected static readonly JumpTable DefaultJumpTable = ComposeDefaultJumpTable();
 
         /// <summary>
         /// The maximum cost that can be spent when a contract is executed in test mode.


### PR DESCRIPTION
# Description

For the testability of contracts, could we change the accessibility of `OnSysCall` and `OnCallT` to `protected`?

For example, we may need to use a fixed random number or a given timestamp in the runtime of contracts, in order to test contracts. Consequently we need to modify the InteropServices and the `OnSysCall` method in order to achieve it. I have posted an example at https://github.com/Hecate2/neo-fairy-test/commit/ac22feb73af8cb79be61d780a520794d0530f482 that utilizes the protected `OnCallT`. If `OnCallT` was private, I would have to re-implement the whole `OnCallT` by myself, with more dependent methods still being private.

## Type of change
There is almost no change...
- ***NO*** Bug fix (non-breaking change which fixes an issue)
- ***NO*** New feature (non-breaking change which adds functionality)
- ***NO*** Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change ***DOES NOT*** require a documentation update

# How Has This Been Tested?
No need for new tests. There seems to be no problem in all the existing tests.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
