### PR TITLE
fix TraverseIterator count

### DIFF
--- a/src/Plugins/RpcServer/RpcServer.SmartContract.cs
+++ b/src/Plugins/RpcServer/RpcServer.SmartContract.cs
@@ -246,7 +246,7 @@ namespace Neo.Plugins
             Guid sid = Result.Ok_Or(() => Guid.Parse(_params[0].GetString()), RpcError.InvalidParams.WithData($"Invalid session id {nameof(sid)}"));
             Guid iid = Result.Ok_Or(() => Guid.Parse(_params[1].GetString()), RpcError.InvalidParams.WithData($"Invliad iterator id {nameof(iid)}"));
             int count = _params[2].GetInt32();
-            Result.True_Or(() => count > settings.MaxIteratorResultItems, RpcError.InvalidParams.WithData($"Invalid iterator items count {nameof(count)}"));
+            Result.True_Or(() => count <= settings.MaxIteratorResultItems, RpcError.InvalidParams.WithData($"Invalid iterator items count {nameof(count)}"));
             Session session;
             lock (sessions)
             {


### PR DESCRIPTION
# Description

It seems we should limit the count of iterator items <= settings.MaxIteratorResultItems, instead of `>`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

No test has been carried out.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
