### PR TITLE
[Neo Plugin RPCServer]fix getcontractstate

### DIFF
--- a/src/Plugins/RpcServer/RpcServer.Blockchain.cs
+++ b/src/Plugins/RpcServer/RpcServer.Blockchain.cs
@@ -119,15 +119,13 @@ namespace Neo.Plugins
         {
             if (int.TryParse(_params[0].AsString(), out int contractId))
             {
-                var contracts = NativeContract.ContractManagement.GetContractById(system.StoreView, contractId);
-                return contracts?.ToJson().NotNull_Or(RpcError.UnknownContract);
+                var contractState = NativeContract.ContractManagement.GetContractById(system.StoreView, contractId);
+                return contractState.NotNull_Or(RpcError.UnknownContract).ToJson();
             }
-            else
-            {
-                UInt160 script_hash = ToScriptHash(_params[0].AsString());
-                ContractState contract = NativeContract.ContractManagement.GetContract(system.StoreView, script_hash);
-                return contract?.ToJson().NotNull_Or(RpcError.UnknownContract);
-            }
+
+            var scriptHash = ToScriptHash(_params[0].AsString());
+            var contract = NativeContract.ContractManagement.GetContract(system.StoreView, scriptHash);
+            return contract.NotNull_Or(RpcError.UnknownContract).ToJson();
         }
 
         private static UInt160 ToScriptHash(string keyword)

--- a/tests/Neo.Plugins.RpcServer.Tests/UT_Result.cs
+++ b/tests/Neo.Plugins.RpcServer.Tests/UT_Result.cs
@@ -1,0 +1,26 @@
+// Copyright (C) 2015-2024 The Neo Project.
+//
+// UT_Result.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.SmartContract;
+
+namespace Neo.Plugins.RpcServer.Tests;
+
+[TestClass]
+public class UT_Result
+{
+    [TestMethod]
+    public void TestNotNull_Or()
+    {
+        ContractState? contracts = null;
+        Assert.ThrowsException<RpcException>(() => contracts.NotNull_Or(RpcError.UnknownContract).ToJson());
+    }
+}


### PR DESCRIPTION
# Description

This pr fixes the syntax issue in the getcontractstate method of the rpcserver. The issue is because with the nullable symbol ?, the rpcerror will never be triggered.

Fixes # (issue) #3280 

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] TestNotNull_Or

**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
