### PR TITLE
[Neo MemStore] fix memstore commit bug

### DIFF
--- a/src/Neo/Persistence/SnapshotCache.cs
+++ b/src/Neo/Persistence/SnapshotCache.cs
@@ -48,7 +48,7 @@ namespace Neo.Persistence
         public override void Commit()
         {
             base.Commit();
-            snapshot.Commit();
+            snapshot?.Commit();
         }
 
         protected override bool ContainsInternal(StorageKey key)

--- a/tests/Neo.UnitTests/Persistence/UT_MemoryStore.cs
+++ b/tests/Neo.UnitTests/Persistence/UT_MemoryStore.cs
@@ -11,8 +11,10 @@
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Neo.Persistence;
+using Neo.SmartContract;
 using System;
 using System.Linq;
+using System.Text;
 
 namespace Neo.UnitTests.Persistence
 {
@@ -30,27 +32,42 @@ namespace Neo.UnitTests.Persistence
         {
             using var store = new MemoryStore();
 
-            store.Delete(new byte[] { 1 });
-            Assert.AreEqual(null, store.TryGet(new byte[] { 1 }));
-            store.Put(new byte[] { 1 }, new byte[] { 1, 2, 3 });
-            CollectionAssert.AreEqual(new byte[] { 1, 2, 3 }, store.TryGet(new byte[] { 1 }));
+            store.Delete([1]);
+            Assert.AreEqual(null, store.TryGet([1]));
+            store.Put([1], [1, 2, 3]);
+            CollectionAssert.AreEqual(new byte[] { 1, 2, 3 }, store.TryGet([1]));
 
-            store.Put(new byte[] { 2 }, new byte[] { 4, 5, 6 });
-            CollectionAssert.AreEqual(new byte[] { 1 }, store.Seek(Array.Empty<byte>(), SeekDirection.Forward).Select(u => u.Key).First());
-            CollectionAssert.AreEqual(new byte[] { 2 }, store.Seek(new byte[] { 2 }, SeekDirection.Backward).Select(u => u.Key).First());
-            CollectionAssert.AreEqual(new byte[] { 1 }, store.Seek(new byte[] { 1 }, SeekDirection.Backward).Select(u => u.Key).First());
+            store.Put([2], [4, 5, 6]);
+            CollectionAssert.AreEqual(new byte[] { 1 }, store.Seek(Array.Empty<byte>()).Select(u => u.Key).First());
+            CollectionAssert.AreEqual(new byte[] { 2 }, store.Seek([2], SeekDirection.Backward).Select(u => u.Key).First());
+            CollectionAssert.AreEqual(new byte[] { 1 }, store.Seek([1], SeekDirection.Backward).Select(u => u.Key).First());
 
-            store.Delete(new byte[] { 1 });
-            store.Delete(new byte[] { 2 });
+            store.Delete([1]);
+            store.Delete([2]);
 
-            store.Put(new byte[] { 0x00, 0x00, 0x00 }, new byte[] { 0x00 });
-            store.Put(new byte[] { 0x00, 0x00, 0x01 }, new byte[] { 0x01 });
-            store.Put(new byte[] { 0x00, 0x00, 0x02 }, new byte[] { 0x02 });
-            store.Put(new byte[] { 0x00, 0x00, 0x03 }, new byte[] { 0x03 });
-            store.Put(new byte[] { 0x00, 0x00, 0x04 }, new byte[] { 0x04 });
+            store.Put([0x00, 0x00, 0x00], [0x00]);
+            store.Put([0x00, 0x00, 0x01], [0x01]);
+            store.Put([0x00, 0x00, 0x02], [0x02]);
+            store.Put([0x00, 0x00, 0x03], [0x03]);
+            store.Put([0x00, 0x00, 0x04], [0x04]);
 
             var entries = store.Seek(Array.Empty<byte>(), SeekDirection.Backward).ToArray();
-            Assert.AreEqual(entries.Count(), 0);
+            Assert.AreEqual(entries.Length, 0);
         }
+
+        [TestMethod]
+        public void NeoSystemTest()
+        {
+            var neoSystem = new NeoSystem(TestProtocolSettings.Default, new MemoryStoreProvider());
+            Assert.IsNotNull(neoSystem.StoreView);
+            var snapshot = neoSystem.StoreView;
+            var key = new StorageKey( Encoding.UTF8.GetBytes("testKey"));
+            var value =new StorageItem( Encoding.UTF8.GetBytes("testValue"));
+            snapshot.Add(key, value);
+            snapshot.Commit();
+            var result = snapshot.TryGet(key);
+            Assert.AreEqual("testValue", Encoding.UTF8.GetString(result.Value.ToArray()));
+        }
+
     }
 }

--- a/tests/Neo.UnitTests/Persistence/UT_MemoryStore.cs
+++ b/tests/Neo.UnitTests/Persistence/UT_MemoryStore.cs
@@ -56,16 +56,16 @@ namespace Neo.UnitTests.Persistence
         }
 
         [TestMethod]
-        public void NeoSystemTest()
+        public void NeoSystemStoreViewTest()
         {
             var neoSystem = new NeoSystem(TestProtocolSettings.Default, new MemoryStoreProvider());
             Assert.IsNotNull(neoSystem.StoreView);
-            var snapshot = neoSystem.StoreView;
-            var key = new StorageKey( Encoding.UTF8.GetBytes("testKey"));
-            var value =new StorageItem( Encoding.UTF8.GetBytes("testValue"));
-            snapshot.Add(key, value);
-            snapshot.Commit();
-            var result = snapshot.TryGet(key);
+            var store = neoSystem.StoreView;
+            var key = new StorageKey(Encoding.UTF8.GetBytes("testKey"));
+            var value = new StorageItem(Encoding.UTF8.GetBytes("testValue"));
+            store.Add(key, value);
+            store.Commit();
+            var result = store.TryGet(key);
             Assert.AreEqual("testValue", Encoding.UTF8.GetString(result.Value.ToArray()));
         }
 


### PR DESCRIPTION
# Description

This pr fixes the issue that when the neosystem is initialized with memstore, then called with `neoSystem.StoreView;`, then the commit operation will fail as the snapshot is `null` (`snapshot = store as ISnapshot;` gets null as memorystore is `IStore` only).

exception:

```shell
Test method Neo.UnitTests.Persistence.UT_MemoryStore.NeoSystemTest threw exception: 
System.NullReferenceException: Object reference not set to an instance of an object.
    at Neo.Persistence.SnapshotCache.Commit() in /Users/jinghuiliao/git/neo/src/Neo/Persistence/SnapshotCache.cs:line 51
   at Neo.UnitTests.Persistence.UT_MemoryStore.NeoSystemTest() in /Users/jinghuiliao/git/neo/tests/Neo.UnitTests/Persistence/UT_MemoryStore.cs:line 67
   at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
   at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)

```

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] NeoSystemStoreViewTest

**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
