### PR TITLE
[Neo Core Style] Rename parameters, update comments, fix code style

### DIFF
--- a/src/Neo/SmartContract/Native/NativeContract.cs
+++ b/src/Neo/SmartContract/Native/NativeContract.cs
@@ -161,8 +161,8 @@ namespace Neo.SmartContract.Native
             _usedHardforks =
                 _methodDescriptors.Select(u => u.ActiveIn)
                     .Concat(_methodDescriptors.Select(u => u.DeprecatedIn))
-                    .Concat(_eventsDescriptors != null ? _eventsDescriptors.Select(u => u.ActiveIn) : [])
-                    .Concat(new Hardfork?[] { ActiveIn })
+                    .Concat(_eventsDescriptors.Select(u => u.ActiveIn))
+                    .Concat([ActiveIn])
                     .Where(u => u is not null)
                     .OrderBy(u => (byte)u)
                     .Cast<Hardfork>().ToImmutableHashSet();


### PR DESCRIPTION
# Description

This pr is mainly intended to rename the `index` to `blockHeight`. Reason of making this update is because when we use 

```C#
    public static Manifest.ContractManifest Manifest { get; } =
        NativeContract.Ledger.GetContractState(ProtocolSettings.Default, uint.MaxValue).Manifest;
```

the second parameter is confusing, as native contract itself has a field Id, sort of confusing to people who is not familer with neo as core-devs. Well, i am also lost for a while thought shargon was passing the contract id/index in the devpack test engine.

And to avoid this pr be a `single line pr`, I also fixed some style issues, and a nullable issue here:

```C#
.Concat(_eventsDescriptors != null ? _eventsDescriptors.Select(u => u.ActiveIn) : [])
```
As `Concat` requires left and right value both be `NotNull` while `_eventsDescriptors` is nullable.

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Optimization (the change is only an optimization)
- [x] Style (the change is only a code style for better maintenance or standard purpose)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Existing tests.

**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
