### PR TITLE
Fixed `Path` and `Property` for `*.csproj` files

### DIFF
--- a/src/Neo.CLI/Neo.CLI.csproj
+++ b/src/Neo.CLI/Neo.CLI.csproj
@@ -10,7 +10,7 @@
     <Product>Neo.CLI</Product>
     <ApplicationIcon>neo.ico</ApplicationIcon>
     <Nullable>enable</Nullable>
-    <BaseOutputPath>$(SolutionDir)/bin/$(AssemblyTitle)</BaseOutputPath>
+    <OutputPath>../../bin/$(AssemblyTitle)</OutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Neo.ConsoleService/Neo.ConsoleService.csproj
+++ b/src/Neo.ConsoleService/Neo.ConsoleService.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netstandard2.1;net8.0</TargetFrameworks>
     <PackageId>Neo.ConsoleService</PackageId>
     <Nullable>enable</Nullable>
-    <BaseOutputPath>$(SolutionDir)/bin/$(PackageId)</BaseOutputPath>
+    <OutputPath>../../bin/$(PackageId)</OutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Neo.Cryptography.BLS12_381/Neo.Cryptography.BLS12_381.csproj
+++ b/src/Neo.Cryptography.BLS12_381/Neo.Cryptography.BLS12_381.csproj
@@ -6,7 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackageId>Neo.Cryptography.BLS12_381</PackageId>
-    <BaseOutputPath>$(SolutionDir)/bin/$(PackageId)</BaseOutputPath>
+    <OutputPath>../../bin/$(PackageId)</OutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Neo.Extensions/Neo.Extensions.csproj
+++ b/src/Neo.Extensions/Neo.Extensions.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
     <PackageId>Neo.Extensions</PackageId>
     <PackageTags>NEO;Blockchain;Extensions</PackageTags>
-    <BaseOutputPath>$(SolutionDir)/bin/$(PackageId)</BaseOutputPath>
+    <OutputPath>../../bin/$(PackageId)</OutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Neo.GUI/Neo.GUI.csproj
+++ b/src/Neo.GUI/Neo.GUI.csproj
@@ -11,7 +11,7 @@
     <Product>Neo.GUI</Product>
     <ApplicationIcon>neo.ico</ApplicationIcon>
     <GenerateResourceWarnOnBinaryFormatterUse>false</GenerateResourceWarnOnBinaryFormatterUse>
-    <BaseOutputPath>$(SolutionDir)/bin/$(AssemblyTitle)</BaseOutputPath>
+    <OutputPath>../../bin/$(AssemblyTitle)</OutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Neo.IO/Neo.IO.csproj
+++ b/src/Neo.IO/Neo.IO.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <PackageId>Neo.IO</PackageId>
     <PackageTags>NEO;Blockchain;IO</PackageTags>
-    <BaseOutputPath>$(SolutionDir)/bin/$(PackageId)</BaseOutputPath>
+    <OutputPath>../../bin/$(PackageId)</OutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Neo.Json/Neo.Json.csproj
+++ b/src/Neo.Json/Neo.Json.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <PackageId>Neo.Json</PackageId>
     <PackageTags>NEO;JSON</PackageTags>
-    <BaseOutputPath>$(SolutionDir)/bin/$(PackageId)</BaseOutputPath>
+    <OutputPath>../../bin/$(PackageId)</OutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Neo.VM/Neo.VM.csproj
+++ b/src/Neo.VM/Neo.VM.csproj
@@ -5,7 +5,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>enable</Nullable>
     <PackageId>Neo.VM</PackageId>
-    <BaseOutputPath>$(SolutionDir)/bin/$(PackageId)</BaseOutputPath>
+    <OutputPath>../../bin/$(PackageId)</OutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Neo/Neo.csproj
+++ b/src/Neo/Neo.csproj
@@ -5,7 +5,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackageId>Neo</PackageId>
     <PackageTags>NEO;AntShares;Blockchain;Smart Contract</PackageTags>
-    <BaseOutputPath>$(SolutionDir)/bin/$(PackageId)</BaseOutputPath>
+    <OutputPath>../../bin/$(PackageId)</OutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Plugins/ApplicationLogs/ApplicationLogs.csproj
+++ b/src/Plugins/ApplicationLogs/ApplicationLogs.csproj
@@ -4,7 +4,7 @@
     <PackageId>Neo.Plugins.ApplicationLogs</PackageId>
     <RootNamespace>Neo.Plugins</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
-    <BaseOutputPath>$(SolutionDir)/bin/$(PackageId)</BaseOutputPath>
+    <OutputPath>../../../bin/$(PackageId)</OutputPath>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/Plugins/DBFTPlugin/DBFTPlugin.csproj
+++ b/src/Plugins/DBFTPlugin/DBFTPlugin.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net8.0</TargetFrameworks>
     <PackageId>Neo.Consensus.DBFT</PackageId>
     <RootNamespace>Neo.Consensus</RootNamespace>
-    <BaseOutputPath>$(SolutionDir)/bin/$(PackageId)</BaseOutputPath>
+    <OutputPath>../../../bin/$(PackageId)</OutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Plugins/LevelDBStore/LevelDBStore.csproj
+++ b/src/Plugins/LevelDBStore/LevelDBStore.csproj
@@ -5,7 +5,7 @@
     <PackageId>Neo.Plugins.Storage.LevelDBStore</PackageId>
     <RootNamespace>Neo.Plugins.Storage</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <BaseOutputPath>$(SolutionDir)/bin/$(PackageId)</BaseOutputPath>
+    <OutputPath>../../../bin/$(PackageId)</OutputPath>
   </PropertyGroup>
 
 </Project>

--- a/src/Plugins/MPTTrie/MPTTrie.csproj
+++ b/src/Plugins/MPTTrie/MPTTrie.csproj
@@ -5,7 +5,7 @@
     <PackageId>Neo.Cryptography.MPT</PackageId>
     <RootNamespace>Neo.Cryptography</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <BaseOutputPath>$(SolutionDir)/bin/$(PackageId)</BaseOutputPath>
+    <OutputPath>../../../bin/$(PackageId)</OutputPath>
   </PropertyGroup>
 
 </Project>

--- a/src/Plugins/OracleService/OracleService.csproj
+++ b/src/Plugins/OracleService/OracleService.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
     <PackageId>Neo.Plugins.OracleService</PackageId>
-    <BaseOutputPath>$(SolutionDir)/bin/$(PackageId)</BaseOutputPath>
+    <OutputPath>../../../bin/$(PackageId)</OutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Plugins/RocksDBStore/RocksDBStore.csproj
+++ b/src/Plugins/RocksDBStore/RocksDBStore.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net8.0</TargetFrameworks>
     <PackageId>Neo.Plugins.Storage.RocksDBStore</PackageId>
     <RootNamespace>Neo.Plugins.Storage</RootNamespace>
-    <BaseOutputPath>$(SolutionDir)/bin/$(PackageId)</BaseOutputPath>
+    <OutputPath>../../../bin/$(PackageId)</OutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Plugins/RpcClient/RpcClient.csproj
+++ b/src/Plugins/RpcClient/RpcClient.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net8.0</TargetFrameworks>
     <PackageId>Neo.Network.RPC.RpcClient</PackageId>
     <RootNamespace>Neo.Network.RPC</RootNamespace>
-    <BaseOutputPath>$(SolutionDir)/bin/$(PackageId)</BaseOutputPath>
+    <OutputPath>../../../bin/$(PackageId)</OutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Plugins/RpcServer/RpcServer.csproj
+++ b/src/Plugins/RpcServer/RpcServer.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <PackageId>Neo.Plugins.RpcServer</PackageId>
-    <BaseOutputPath>$(SolutionDir)/bin/$(PackageId)</BaseOutputPath>
+    <OutputPath>../../../bin/$(PackageId)</OutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Plugins/SQLiteWallet/SQLiteWallet.csproj
+++ b/src/Plugins/SQLiteWallet/SQLiteWallet.csproj
@@ -5,7 +5,7 @@
     <RootNamespace>Neo.Wallets.SQLite</RootNamespace>
     <PackageId>Neo.Wallets.SQLite</PackageId>
     <ImplicitUsings>enable</ImplicitUsings>
-    <BaseOutputPath>$(SolutionDir)/bin/$(PackageId)</BaseOutputPath>
+    <OutputPath>../../../bin/$(PackageId)</OutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Plugins/StateService/StateService.csproj
+++ b/src/Plugins/StateService/StateService.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net8.0</TargetFrameworks>
     <PackageId>Neo.Plugins.StateService</PackageId>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <BaseOutputPath>$(SolutionDir)/bin/$(PackageId)</BaseOutputPath>
+    <OutputPath>../../../bin/$(PackageId)</OutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Plugins/StorageDumper/StorageDumper.csproj
+++ b/src/Plugins/StorageDumper/StorageDumper.csproj
@@ -5,7 +5,7 @@
     <PackageId>Neo.Plugins.StorageDumper</PackageId>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <BaseOutputPath>$(SolutionDir)/bin/$(PackageId)</BaseOutputPath>
+    <OutputPath>../../../bin/$(PackageId)</OutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Plugins/TokensTracker/TokensTracker.csproj
+++ b/src/Plugins/TokensTracker/TokensTracker.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
     <PackageId>Neo.Plugins.TokensTracker</PackageId>
-    <BaseOutputPath>$(SolutionDir)/bin/$(PackageId)</BaseOutputPath>
+    <OutputPath>../../../bin/$(PackageId)</OutputPath>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
# Change Log
- Changed Pathing
- Changed from `BaseOutputPath` to `OutputPath` cause of a `dotnet` `CLI` bug

Wasn't able to use just the `*.csproj` files to `build` or `publish` files _(on linux)_.

closes #3305

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Optimization (the change is only an optimization)
- [x] Style (the change is only a code style for better maintenance or standard purpose)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Locally

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
