### PR TITLE
[Neo Core] Part 1. Isolate Plugins Exceptions from the Node.

### DIFF
--- a/src/Neo/Ledger/Blockchain.cs
+++ b/src/Neo/Ledger/Blockchain.cs
@@ -505,18 +505,15 @@ namespace Neo.Ledger
                 {
                     handlerAction(handler);
                 }
+                catch (Exception ex) when (handler.Target is Plugin)
+                {
+                    // Log the exception and continue with the next handler
+                    // Isolate the plugin exception
+                    Utility.Log(nameof(handler.Target), LogLevel.Error, ex);
+                }
                 catch (Exception ex)
                 {
-                    if (handler.Target is Plugin)
-                    {
-                        // Log the exception and continue with the next handler
-                        // Isolate the plugin exception
-                        Utility.Log(nameof(handler.Target), LogLevel.Error, ex);
-                    }
-                    else
-                    {
-                        exceptions.Add(ex);
-                    }
+                    exceptions.Add(ex);
                 }
             })).ToList();
 

--- a/src/Neo/Ledger/Blockchain.cs
+++ b/src/Neo/Ledger/Blockchain.cs
@@ -481,7 +481,7 @@ namespace Neo.Ledger
                 Debug.Assert(header.Index == block.Index);
         }
 
-        private void InvokeCommitting(NeoSystem system, Block block, DataCache snapshot, IReadOnlyList<ApplicationExecuted> applicationExecutedList)
+        internal static void InvokeCommitting(NeoSystem system, Block block, DataCache snapshot, IReadOnlyList<ApplicationExecuted> applicationExecutedList)
         {
             var handlers = Committing?.GetInvocationList();
             if (handlers == null) return;
@@ -510,7 +510,7 @@ namespace Neo.Ledger
             }
         }
 
-        private void InvokeCommitted(NeoSystem system, Block block)
+        internal static void InvokeCommitted(NeoSystem system, Block block)
         {
             var handlers = Committed?.GetInvocationList();
             if (handlers == null) return;

--- a/src/Neo/Plugins/Plugin.cs
+++ b/src/Neo/Plugins/Plugin.cs
@@ -229,7 +229,15 @@ namespace Neo.Plugins
         /// <returns><see langword="true"/> if the <paramref name="message"/> is handled by a plugin; otherwise, <see langword="false"/>.</returns>
         public static bool SendMessage(object message)
         {
-            return Plugins.Any(plugin => plugin.OnMessage(message));
+            try
+            {
+                return Plugins.Any(plugin => plugin.OnMessage(message));
+            }
+            catch (Exception ex)
+            {
+                Utility.Log(nameof(Plugin), LogLevel.Error, ex);
+                return false;
+            }
         }
     }
 }

--- a/tests/Neo.UnitTests/Plugins/TestPlugin.cs
+++ b/tests/Neo.UnitTests/Plugins/TestPlugin.cs
@@ -10,13 +10,22 @@
 // modifications are permitted.
 
 using Microsoft.Extensions.Configuration;
+using Neo.Ledger;
+using Neo.Network.P2P.Payloads;
+using Neo.Persistence;
 using Neo.Plugins;
+using System;
+using System.Collections.Generic;
 
 namespace Neo.UnitTests.Plugins
 {
     public class TestPlugin : Plugin
     {
-        public TestPlugin() : base() { }
+        public TestPlugin() : base()
+        {
+            Blockchain.Committing += OnCommitting;
+            Blockchain.Committed += OnCommitted;
+        }
 
         protected override void Configure() { }
 
@@ -36,5 +45,15 @@ namespace Neo.UnitTests.Plugins
         }
 
         protected override bool OnMessage(object message) => true;
+
+        private void OnCommitting(NeoSystem system, Block block, DataCache snapshot, IReadOnlyList<Blockchain.ApplicationExecuted> applicationExecutedList)
+        {
+            throw new NotImplementedException();
+        }
+
+        private void OnCommitted(NeoSystem system, Block block)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/tests/Neo.UnitTests/Plugins/TestPlugin.cs
+++ b/tests/Neo.UnitTests/Plugins/TestPlugin.cs
@@ -21,7 +21,7 @@ namespace Neo.UnitTests.Plugins
 {
     public class TestNonPlugin
     {
-        public TestNonPlugin() : base()
+        public TestNonPlugin()
         {
             Blockchain.Committing += OnCommitting;
             Blockchain.Committed += OnCommitted;
@@ -29,14 +29,15 @@ namespace Neo.UnitTests.Plugins
 
         private void OnCommitting(NeoSystem system, Block block, DataCache snapshot, IReadOnlyList<Blockchain.ApplicationExecuted> applicationExecutedList)
         {
-            throw new NotImplementedException();
+            throw new NotImplementedException("Test exception from OnCommitting");
         }
 
         private void OnCommitted(NeoSystem system, Block block)
         {
-            throw new NotImplementedException();
+            throw new NotImplementedException("Test exception from OnCommitted");
         }
     }
+
 
     public class TestPlugin : Plugin
     {

--- a/tests/Neo.UnitTests/Plugins/TestPlugin.cs
+++ b/tests/Neo.UnitTests/Plugins/TestPlugin.cs
@@ -19,6 +19,25 @@ using System.Collections.Generic;
 
 namespace Neo.UnitTests.Plugins
 {
+    public class TestNonPlugin
+    {
+        public TestNonPlugin() : base()
+        {
+            Blockchain.Committing += OnCommitting;
+            Blockchain.Committed += OnCommitted;
+        }
+
+        private void OnCommitting(NeoSystem system, Block block, DataCache snapshot, IReadOnlyList<Blockchain.ApplicationExecuted> applicationExecutedList)
+        {
+            throw new NotImplementedException();
+        }
+
+        private void OnCommitted(NeoSystem system, Block block)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
     public class TestPlugin : Plugin
     {
         public TestPlugin() : base()

--- a/tests/Neo.UnitTests/Plugins/UT_Plugin.cs
+++ b/tests/Neo.UnitTests/Plugins/UT_Plugin.cs
@@ -73,7 +73,7 @@ namespace Neo.UnitTests.Plugins
             // Call the InvokeCommitted method and ensure no exception is thrown
             try
             {
-                Blockchain.InvokeCommitting(null, null,null,null);
+                Blockchain.InvokeCommitting(null, null, null, null);
                 Blockchain.InvokeCommitted(null, null);
             }
             catch (Exception ex)

--- a/tests/Neo.UnitTests/Plugins/UT_Plugin.cs
+++ b/tests/Neo.UnitTests/Plugins/UT_Plugin.cs
@@ -14,6 +14,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Neo.Ledger;
 using Neo.Plugins;
 using System;
+using System.Threading.Tasks;
 
 namespace Neo.UnitTests.Plugins
 {
@@ -66,28 +67,31 @@ namespace Neo.UnitTests.Plugins
         }
 
         [TestMethod]
-        public void TestOnException()
+        public async Task TestOnException()
         {
-            _ = new TestPlugin();
-
-            // Call the InvokeCommitted method and ensure no exception is thrown
+            // Ensure no exception is thrown
             try
             {
-                Blockchain.InvokeCommitting(null, null, null, null);
-                Blockchain.InvokeCommitted(null, null);
+                await Blockchain.InvokeCommittingAsync(null, null, null, null);
+                await Blockchain.InvokeCommittedAsync(null, null);
             }
             catch (Exception ex)
             {
-                Assert.Fail($"InvokeCommitted threw an exception: {ex.Message}");
+                Assert.Fail($"InvokeCommitting or InvokeCommitted threw an exception: {ex.Message}");
             }
 
+            // Register TestNonPlugin that throws exceptions
             _ = new TestNonPlugin();
 
-            // Call the InvokeCommitted method and ensure exception is thrown
-            Assert.ThrowsException<NotImplementedException>(() =>
+            // Ensure exception is thrown
+            await Assert.ThrowsExceptionAsync<NotImplementedException>(async () =>
             {
-                Blockchain.InvokeCommitting(null, null, null, null);
-                Blockchain.InvokeCommitted(null, null);
+                await Blockchain.InvokeCommittingAsync(null, null, null, null);
+            });
+
+            await Assert.ThrowsExceptionAsync<NotImplementedException>(async () =>
+            {
+                await Blockchain.InvokeCommittedAsync(null, null);
             });
         }
     }

--- a/tests/Neo.UnitTests/Plugins/UT_Plugin.cs
+++ b/tests/Neo.UnitTests/Plugins/UT_Plugin.cs
@@ -68,7 +68,7 @@ namespace Neo.UnitTests.Plugins
         [TestMethod]
         public void TestOnException()
         {
-            var pp = new TestPlugin();
+            _ = new TestPlugin();
 
             // Call the InvokeCommitted method and ensure no exception is thrown
             try
@@ -80,6 +80,15 @@ namespace Neo.UnitTests.Plugins
             {
                 Assert.Fail($"InvokeCommitted threw an exception: {ex.Message}");
             }
+
+            _ = new TestNonPlugin();
+
+            // Call the InvokeCommitted method and ensure exception is thrown
+            Assert.ThrowsException<NotImplementedException>(() =>
+            {
+                Blockchain.InvokeCommitting(null, null, null, null);
+                Blockchain.InvokeCommitted(null, null);
+            });
         }
     }
 }

--- a/tests/Neo.UnitTests/Plugins/UT_Plugin.cs
+++ b/tests/Neo.UnitTests/Plugins/UT_Plugin.cs
@@ -11,6 +11,7 @@
 
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.Ledger;
 using Neo.Plugins;
 using System;
 
@@ -62,6 +63,14 @@ namespace Neo.UnitTests.Plugins
         {
             var pp = new TestPlugin();
             pp.TestGetConfiguration().Key.Should().Be("PluginConfiguration");
+        }
+
+        [TestMethod]
+        public void TestOnException()
+        {
+            var pp = new TestPlugin();
+
+          Blockchain.InvokeCommitted(null,null);
         }
     }
 }

--- a/tests/Neo.UnitTests/Plugins/UT_Plugin.cs
+++ b/tests/Neo.UnitTests/Plugins/UT_Plugin.cs
@@ -70,7 +70,7 @@ namespace Neo.UnitTests.Plugins
         {
             var pp = new TestPlugin();
 
-          Blockchain.InvokeCommitted(null,null);
+            Blockchain.InvokeCommitted(null, null);
         }
     }
 }

--- a/tests/Neo.UnitTests/Plugins/UT_Plugin.cs
+++ b/tests/Neo.UnitTests/Plugins/UT_Plugin.cs
@@ -70,7 +70,15 @@ namespace Neo.UnitTests.Plugins
         {
             var pp = new TestPlugin();
 
-            Blockchain.InvokeCommitted(null, null);
+            // Call the InvokeCommitted method and ensure no exception is thrown
+            try
+            {
+                Blockchain.InvokeCommitted(null, null);
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail($"InvokeCommitted threw an exception: {ex.Message}");
+            }
         }
     }
 }

--- a/tests/Neo.UnitTests/Plugins/UT_Plugin.cs
+++ b/tests/Neo.UnitTests/Plugins/UT_Plugin.cs
@@ -73,6 +73,7 @@ namespace Neo.UnitTests.Plugins
             // Call the InvokeCommitted method and ensure no exception is thrown
             try
             {
+                Blockchain.InvokeCommitting(null, null,null,null);
                 Blockchain.InvokeCommitted(null, null);
             }
             catch (Exception ex)


### PR DESCRIPTION
# Description

Currently plugins and the core runs in the same process, and we lack the measure of handling the plugin exceptions. This makes any plugin can have the ability to block the whole node, turning plugin an attack surface for neo core. Issue https://github.com/neo-project/neo/issues/3296 is a typical example.



Fixes #  https://github.com/neo-project/neo/issues/3296#issuecomment-2154379802

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
