### PR TITLE
[Neo Plugin New feature]  UnhandledExceptionPolicy on Plugin Unhandled Exception

### DIFF
--- a/src/Neo/Ledger/Blockchain.cs
+++ b/src/Neo/Ledger/Blockchain.cs
@@ -541,8 +541,6 @@ namespace Neo.Ledger
 
             exceptions.ForEach(e => throw e);
         }
-
-
         /// <summary>
         /// Gets a <see cref="Akka.Actor.Props"/> object used for creating the <see cref="Blockchain"/> actor.
         /// </summary>

--- a/src/Neo/Ledger/Blockchain.cs
+++ b/src/Neo/Ledger/Blockchain.cs
@@ -513,11 +513,22 @@ namespace Neo.Ledger
                 }
                 catch (Exception ex) when (handler.Target is Plugin plugin)
                 {
-                    // Log the exception and continue with the next handler
-                    // Isolate the plugin exception
-                    //Stop plugin on exception
-                    if (plugin.StopOnUnhandledException)
-                        plugin.IsStopped = true;
+                    switch (plugin.ExceptionPolicy)
+                    {
+                        case UnhandledExceptionPolicy.StopNode:
+                            exceptions.Add(ex);
+                            throw;
+                        case UnhandledExceptionPolicy.StopPlugin:
+                            //Stop plugin on exception
+                            plugin.IsStopped = true;
+                            break;
+                        case UnhandledExceptionPolicy.Ignore:
+                            // Log the exception and continue with the next handler
+                            break;
+                        default:
+                            throw new ArgumentOutOfRangeException();
+                    }
+
                     Utility.Log(nameof(plugin), LogLevel.Error, ex);
                 }
                 catch (Exception ex)

--- a/src/Neo/Ledger/Blockchain.cs
+++ b/src/Neo/Ledger/Blockchain.cs
@@ -481,7 +481,7 @@ namespace Neo.Ledger
                 Debug.Assert(header.Index == block.Index);
         }
 
-        private void InvokeCommitting(NeoSystem system, Block block, DataCache snapshot, IReadOnlyList<ApplicationExecuted> applicationExecutedList)
+        internal static void InvokeCommitting(NeoSystem system, Block block, DataCache snapshot, IReadOnlyList<ApplicationExecuted> applicationExecutedList)
         {
             var handlers = Committing?.GetInvocationList();
             if (handlers == null) return;
@@ -510,7 +510,7 @@ namespace Neo.Ledger
             }
         }
 
-        private void InvokeCommitted(NeoSystem system, Block block)
+        internal static void InvokeCommitted(NeoSystem system, Block block)
         {
             var handlers = Committed?.GetInvocationList();
             if (handlers == null) return;

--- a/src/Neo/Plugins/Plugin.cs
+++ b/src/Neo/Plugins/Plugin.cs
@@ -72,11 +72,11 @@ namespace Neo.Plugins
         /// If the plugin should be stopped when an exception is thrown.
         /// Default is <see langword="true"/>.
         /// </summary>
-        protected internal virtual bool StopOnUnhandledException { get; init; } = true;
+        protected internal virtual UnhandledExceptionPolicy ExceptionPolicy { get; init; } = UnhandledExceptionPolicy.StopNode;
 
         /// <summary>
         /// The plugin will be stopped if an exception is thrown.
-        /// But it also depends on <see cref="StopOnUnhandledException"/>.
+        /// But it also depends on <see cref="UnhandledExceptionPolicy"/>.
         /// </summary>
         internal bool IsStopped { get; set; }
 
@@ -257,8 +257,18 @@ namespace Neo.Plugins
                     }
                     catch (Exception ex)
                     {
-                        if (plugin.StopOnUnhandledException)
-                            plugin.IsStopped = true;
+                        switch (plugin.ExceptionPolicy)
+                        {
+                            case UnhandledExceptionPolicy.StopNode:
+                                throw;
+                            case UnhandledExceptionPolicy.StopPlugin:
+                                plugin.IsStopped = true;
+                                break;
+                            case UnhandledExceptionPolicy.Ignore:
+                                break;
+                            default:
+                                throw new ArgumentOutOfRangeException();
+                        }
                         Utility.Log(nameof(Plugin), LogLevel.Error, ex);
                         return false;
                     }

--- a/src/Neo/Plugins/Plugin.cs
+++ b/src/Neo/Plugins/Plugin.cs
@@ -229,7 +229,15 @@ namespace Neo.Plugins
         /// <returns><see langword="true"/> if the <paramref name="message"/> is handled by a plugin; otherwise, <see langword="false"/>.</returns>
         public static bool SendMessage(object message)
         {
-            return Plugins.Any(plugin => plugin.OnMessage(message));
+            try
+            {
+                return Plugins.Any(plugin => plugin.OnMessage(message));
+            }
+            catch (Exception ex)
+            {
+                Utility.Log(nameof(Plugin), LogLevel.Error, ex);
+                return false;
+            }
         }
     }
 }

--- a/src/Neo/Plugins/Plugin.cs
+++ b/src/Neo/Plugins/Plugin.cs
@@ -33,7 +33,8 @@ namespace Neo.Plugins
         /// <summary>
         /// The directory containing the plugin folders. Files can be contained in any subdirectory.
         /// </summary>
-        public static readonly string PluginsDirectory = Combine(GetDirectoryName(System.AppContext.BaseDirectory), "Plugins");
+        public static readonly string PluginsDirectory =
+            Combine(GetDirectoryName(System.AppContext.BaseDirectory), "Plugins");
 
         private static readonly FileSystemWatcher configWatcher;
 
@@ -67,6 +68,18 @@ namespace Neo.Plugins
         /// </summary>
         public virtual Version Version => GetType().Assembly.GetName().Version;
 
+        /// <summary>
+        /// If the plugin should be stopped when an exception is thrown.
+        /// Default is <see langword="true"/>.
+        /// </summary>
+        protected internal virtual bool StopOnUnhandledException { get; init; } = true;
+
+        /// <summary>
+        /// The plugin will be stopped if an exception is thrown.
+        /// But it also depends on <see cref="StopOnUnhandledException"/>.
+        /// </summary>
+        internal bool IsStopped { get; set; }
+
         static Plugin()
         {
             if (!Directory.Exists(PluginsDirectory)) return;
@@ -74,7 +87,8 @@ namespace Neo.Plugins
             {
                 EnableRaisingEvents = true,
                 IncludeSubdirectories = true,
-                NotifyFilter = NotifyFilters.FileName | NotifyFilters.DirectoryName | NotifyFilters.CreationTime | NotifyFilters.LastWrite | NotifyFilters.Size,
+                NotifyFilter = NotifyFilters.FileName | NotifyFilters.DirectoryName | NotifyFilters.CreationTime |
+                               NotifyFilters.LastWrite | NotifyFilters.Size,
             };
             configWatcher.Changed += ConfigWatcher_Changed;
             configWatcher.Created += ConfigWatcher_Changed;
@@ -106,7 +120,8 @@ namespace Neo.Plugins
             {
                 case ".json":
                 case ".dll":
-                    Utility.Log(nameof(Plugin), LogLevel.Warning, $"File {e.Name} is {e.ChangeType}, please restart node.");
+                    Utility.Log(nameof(Plugin), LogLevel.Warning,
+                        $"File {e.Name} is {e.ChangeType}, please restart node.");
                     break;
             }
         }
@@ -119,7 +134,8 @@ namespace Neo.Plugins
             AssemblyName an = new(args.Name);
 
             Assembly assembly = AppDomain.CurrentDomain.GetAssemblies().FirstOrDefault(a => a.FullName == args.Name) ??
-                                AppDomain.CurrentDomain.GetAssemblies().FirstOrDefault(a => a.GetName().Name == an.Name);
+                                AppDomain.CurrentDomain.GetAssemblies()
+                                    .FirstOrDefault(a => a.GetName().Name == an.Name);
             if (assembly != null) return assembly;
 
             string filename = an.Name + ".dll";
@@ -150,7 +166,8 @@ namespace Neo.Plugins
         /// <returns>The content of the configuration file read.</returns>
         protected IConfigurationSection GetConfiguration()
         {
-            return new ConfigurationBuilder().AddJsonFile(ConfigFile, optional: true).Build().GetSection("PluginConfiguration");
+            return new ConfigurationBuilder().AddJsonFile(ConfigFile, optional: true).Build()
+                .GetSection("PluginConfiguration");
         }
 
         private static void LoadPlugin(Assembly assembly)
@@ -187,6 +204,7 @@ namespace Neo.Plugins
                     catch { }
                 }
             }
+
             foreach (Assembly assembly in assemblies)
             {
                 LoadPlugin(assembly);
@@ -229,15 +247,23 @@ namespace Neo.Plugins
         /// <returns><see langword="true"/> if the <paramref name="message"/> is handled by a plugin; otherwise, <see langword="false"/>.</returns>
         public static bool SendMessage(object message)
         {
-            try
-            {
-                return Plugins.Any(plugin => plugin.OnMessage(message));
-            }
-            catch (Exception ex)
-            {
-                Utility.Log(nameof(Plugin), LogLevel.Error, ex);
-                return false;
-            }
+
+            return Plugins.Any(plugin =>
+                {
+                    try
+                    {
+                        return !plugin.IsStopped &&
+                               plugin.OnMessage(message);
+                    }
+                    catch (Exception ex)
+                    {
+                        if (plugin.StopOnUnhandledException)
+                            plugin.IsStopped = true;
+                        Utility.Log(nameof(Plugin), LogLevel.Error, ex);
+                        return false;
+                    }
+                }
+            );
         }
     }
 }

--- a/src/Neo/Plugins/PluginSettings.cs
+++ b/src/Neo/Plugins/PluginSettings.cs
@@ -10,10 +10,25 @@
 // modifications are permitted.
 
 using Microsoft.Extensions.Configuration;
+using Org.BouncyCastle.Security;
+using System;
 
 namespace Neo.Plugins;
 
 public abstract class PluginSettings(IConfigurationSection section)
 {
-    public bool StopOnUnhandledException { get; } = section.GetValue("StopOnUnhandledException", true);
+    public UnhandledExceptionPolicy ExceptionPolicy
+    {
+        get
+        {
+            var policyString = section.GetValue("UnhandledExceptionPolicy", "StopNode");
+            if (Enum.TryParse(policyString, out UnhandledExceptionPolicy policy))
+            {
+
+                return policy;
+            }
+
+            throw new InvalidParameterException($"{policyString} is not a valid UnhandledExceptionPolicy");
+        }
+    }
 }

--- a/src/Neo/Plugins/PluginSettings.cs
+++ b/src/Neo/Plugins/PluginSettings.cs
@@ -1,0 +1,19 @@
+// Copyright (C) 2015-2024 The Neo Project.
+//
+// PluginSettings.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.Extensions.Configuration;
+
+namespace Neo.Plugins;
+
+public abstract class PluginSettings(IConfigurationSection section)
+{
+    public bool StopOnUnhandledException { get; } = section.GetValue("StopOnUnhandledException", true);
+}

--- a/src/Neo/Plugins/PluginSettings.cs
+++ b/src/Neo/Plugins/PluginSettings.cs
@@ -21,7 +21,7 @@ public abstract class PluginSettings(IConfigurationSection section)
     {
         get
         {
-            var policyString = section.GetValue("UnhandledExceptionPolicy", nameof(UnhandledExceptionPolicy.StopNode));
+            var policyString = section.GetValue(nameof(UnhandledExceptionPolicy), nameof(UnhandledExceptionPolicy.StopNode));
             if (Enum.TryParse(policyString, out UnhandledExceptionPolicy policy))
             {
                 return policy;

--- a/src/Neo/Plugins/PluginSettings.cs
+++ b/src/Neo/Plugins/PluginSettings.cs
@@ -24,7 +24,6 @@ public abstract class PluginSettings(IConfigurationSection section)
             var policyString = section.GetValue("UnhandledExceptionPolicy", "StopNode");
             if (Enum.TryParse(policyString, out UnhandledExceptionPolicy policy))
             {
-
                 return policy;
             }
 

--- a/src/Neo/Plugins/PluginSettings.cs
+++ b/src/Neo/Plugins/PluginSettings.cs
@@ -21,7 +21,7 @@ public abstract class PluginSettings(IConfigurationSection section)
     {
         get
         {
-            var policyString = section.GetValue("UnhandledExceptionPolicy", "StopNode");
+            var policyString = section.GetValue("UnhandledExceptionPolicy", nameof(UnhandledExceptionPolicy.StopNode));
             if (Enum.TryParse(policyString, out UnhandledExceptionPolicy policy))
             {
                 return policy;

--- a/src/Neo/Plugins/UnhandledExceptionPolicy.cs
+++ b/src/Neo/Plugins/UnhandledExceptionPolicy.cs
@@ -1,0 +1,20 @@
+// Copyright (C) 2015-2024 The Neo Project.
+//
+// UnhandledExceptionPolicy.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+namespace Neo.Plugins
+{
+    public enum UnhandledExceptionPolicy
+    {
+        Ignore = 0,
+        StopPlugin = 1,
+        StopNode = 2,
+    }
+}

--- a/src/Plugins/ApplicationLogs/ApplicationLogs.json
+++ b/src/Plugins/ApplicationLogs/ApplicationLogs.json
@@ -3,7 +3,8 @@
     "Path": "ApplicationLogs_{0}",
     "Network": 860833102,
     "MaxStackSize": 65535,
-    "Debug": false
+    "Debug": false,
+    "StopOnUnhandledException": false
   },
   "Dependency": [
     "RpcServer"

--- a/src/Plugins/ApplicationLogs/ApplicationLogs.json
+++ b/src/Plugins/ApplicationLogs/ApplicationLogs.json
@@ -4,7 +4,7 @@
     "Network": 860833102,
     "MaxStackSize": 65535,
     "Debug": false,
-    "StopOnUnhandledException": false
+    "UnhandledExceptionPolicy": "StopPlugin"
   },
   "Dependency": [
     "RpcServer"

--- a/src/Plugins/ApplicationLogs/LogReader.cs
+++ b/src/Plugins/ApplicationLogs/LogReader.cs
@@ -37,6 +37,7 @@ namespace Neo.Plugins.ApplicationLogs
 
         public override string Name => "ApplicationLogs";
         public override string Description => "Synchronizes smart contract VM executions and notifications (NotifyLog) on blockchain.";
+        protected override UnhandledExceptionPolicy ExceptionPolicy => Settings.Default.ExceptionPolicy;
 
         #region Ctor
 

--- a/src/Plugins/ApplicationLogs/Settings.cs
+++ b/src/Plugins/ApplicationLogs/Settings.cs
@@ -13,7 +13,7 @@ using Microsoft.Extensions.Configuration;
 
 namespace Neo.Plugins.ApplicationLogs
 {
-    internal class Settings: PluginSettings
+    internal class Settings : PluginSettings
     {
         public string Path { get; }
         public uint Network { get; }

--- a/src/Plugins/ApplicationLogs/Settings.cs
+++ b/src/Plugins/ApplicationLogs/Settings.cs
@@ -13,7 +13,7 @@ using Microsoft.Extensions.Configuration;
 
 namespace Neo.Plugins.ApplicationLogs
 {
-    internal class Settings
+    internal class Settings: PluginSettings
     {
         public string Path { get; }
         public uint Network { get; }
@@ -23,7 +23,7 @@ namespace Neo.Plugins.ApplicationLogs
 
         public static Settings Default { get; private set; }
 
-        private Settings(IConfigurationSection section)
+        private Settings(IConfigurationSection section) : base(section)
         {
             Path = section.GetValue("Path", "ApplicationLogs_{0}");
             Network = section.GetValue("Network", 5195086u);

--- a/src/Plugins/DBFTPlugin/DBFTPlugin.cs
+++ b/src/Plugins/DBFTPlugin/DBFTPlugin.cs
@@ -31,6 +31,8 @@ namespace Neo.Plugins.DBFTPlugin
 
         public override string ConfigFile => System.IO.Path.Combine(RootPath, "DBFTPlugin.json");
 
+        protected override bool StopOnUnhandledException => settings.StopOnUnhandledException;
+
         public DBFTPlugin()
         {
             RemoteNode.MessageReceived += RemoteNode_MessageReceived;

--- a/src/Plugins/DBFTPlugin/DBFTPlugin.cs
+++ b/src/Plugins/DBFTPlugin/DBFTPlugin.cs
@@ -31,7 +31,7 @@ namespace Neo.Plugins.DBFTPlugin
 
         public override string ConfigFile => System.IO.Path.Combine(RootPath, "DBFTPlugin.json");
 
-        protected override bool StopOnUnhandledException => settings.StopOnUnhandledException;
+        protected override UnhandledExceptionPolicy ExceptionPolicy => settings.ExceptionPolicy;
 
         public DBFTPlugin()
         {

--- a/src/Plugins/DBFTPlugin/DBFTPlugin.json
+++ b/src/Plugins/DBFTPlugin/DBFTPlugin.json
@@ -6,6 +6,6 @@
     "Network": 860833102,
     "MaxBlockSize": 2097152,
     "MaxBlockSystemFee": 150000000000,
-    "StopOnUnhandledException": true
+    "UnhandledExceptionPolicy": "StopNode"
   }
 }

--- a/src/Plugins/DBFTPlugin/DBFTPlugin.json
+++ b/src/Plugins/DBFTPlugin/DBFTPlugin.json
@@ -5,6 +5,7 @@
     "AutoStart": false,
     "Network": 860833102,
     "MaxBlockSize": 2097152,
-    "MaxBlockSystemFee": 150000000000
+    "MaxBlockSystemFee": 150000000000,
+    "StopOnUnhandledException": true
   }
 }

--- a/src/Plugins/DBFTPlugin/Settings.cs
+++ b/src/Plugins/DBFTPlugin/Settings.cs
@@ -13,7 +13,7 @@ using Microsoft.Extensions.Configuration;
 
 namespace Neo.Plugins.DBFTPlugin
 {
-    public class Settings
+    public class Settings : PluginSettings
     {
         public string RecoveryLogs { get; }
         public bool IgnoreRecoveryLogs { get; }
@@ -22,7 +22,7 @@ namespace Neo.Plugins.DBFTPlugin
         public uint MaxBlockSize { get; }
         public long MaxBlockSystemFee { get; }
 
-        public Settings(IConfigurationSection section)
+        public Settings(IConfigurationSection section) : base(section)
         {
             RecoveryLogs = section.GetValue("RecoveryLogs", "ConsensusState");
             IgnoreRecoveryLogs = section.GetValue("IgnoreRecoveryLogs", false);

--- a/src/Plugins/OracleService/OracleService.cs
+++ b/src/Plugins/OracleService/OracleService.cs
@@ -61,6 +61,8 @@ namespace Neo.Plugins.OracleService
 
         public override string Description => "Built-in oracle plugin";
 
+        protected override bool StopOnUnhandledException => Settings.Default.StopOnUnhandledException;
+
         public override string ConfigFile => System.IO.Path.Combine(RootPath, "OracleService.json");
 
         public OracleService()

--- a/src/Plugins/OracleService/OracleService.cs
+++ b/src/Plugins/OracleService/OracleService.cs
@@ -61,7 +61,7 @@ namespace Neo.Plugins.OracleService
 
         public override string Description => "Built-in oracle plugin";
 
-        protected override bool StopOnUnhandledException => Settings.Default.StopOnUnhandledException;
+        protected override UnhandledExceptionPolicy ExceptionPolicy => Settings.Default.ExceptionPolicy;
 
         public override string ConfigFile => System.IO.Path.Combine(RootPath, "OracleService.json");
 

--- a/src/Plugins/OracleService/OracleService.json
+++ b/src/Plugins/OracleService/OracleService.json
@@ -6,7 +6,7 @@
     "MaxOracleTimeout": 10000,
     "AllowPrivateHost": false,
     "AllowedContentTypes": [ "application/json" ],
-    "StopOnUnhandledException": false,
+    "UnhandledExceptionPolicy": "Ignore",
     "Https": {
       "Timeout": 5000
     },

--- a/src/Plugins/OracleService/OracleService.json
+++ b/src/Plugins/OracleService/OracleService.json
@@ -6,6 +6,7 @@
     "MaxOracleTimeout": 10000,
     "AllowPrivateHost": false,
     "AllowedContentTypes": [ "application/json" ],
+    "StopOnUnhandledException": false,
     "Https": {
       "Timeout": 5000
     },

--- a/src/Plugins/OracleService/Settings.cs
+++ b/src/Plugins/OracleService/Settings.cs
@@ -37,7 +37,7 @@ namespace Neo.Plugins.OracleService
         }
     }
 
-    class Settings
+    class Settings : PluginSettings
     {
         public uint Network { get; }
         public Uri[] Nodes { get; }
@@ -51,7 +51,7 @@ namespace Neo.Plugins.OracleService
 
         public static Settings Default { get; private set; }
 
-        private Settings(IConfigurationSection section)
+        private Settings(IConfigurationSection section) : base(section)
         {
             Network = section.GetValue("Network", 5195086u);
             Nodes = section.GetSection("Nodes").GetChildren().Select(p => new Uri(p.Get<string>(), UriKind.Absolute)).ToArray();

--- a/src/Plugins/RpcServer/RpcServer.json
+++ b/src/Plugins/RpcServer/RpcServer.json
@@ -1,5 +1,6 @@
 {
   "PluginConfiguration": {
+    "StopOnUnhandledException": false,
     "Servers": [
       {
         "Network": 860833102,

--- a/src/Plugins/RpcServer/RpcServer.json
+++ b/src/Plugins/RpcServer/RpcServer.json
@@ -1,6 +1,6 @@
 {
   "PluginConfiguration": {
-    "StopOnUnhandledException": false,
+    "UnhandledExceptionPolicy": "Ignore",
     "Servers": [
       {
         "Network": 860833102,

--- a/src/Plugins/RpcServer/RpcServerPlugin.cs
+++ b/src/Plugins/RpcServer/RpcServerPlugin.cs
@@ -24,6 +24,7 @@ namespace Neo.Plugins.RpcServer
         private static readonly Dictionary<uint, List<object>> handlers = new();
 
         public override string ConfigFile => System.IO.Path.Combine(RootPath, "RpcServer.json");
+        protected override bool StopOnUnhandledException => settings.StopOnUnhandledException;
 
         protected override void Configure()
         {

--- a/src/Plugins/RpcServer/RpcServerPlugin.cs
+++ b/src/Plugins/RpcServer/RpcServerPlugin.cs
@@ -24,7 +24,7 @@ namespace Neo.Plugins.RpcServer
         private static readonly Dictionary<uint, List<object>> handlers = new();
 
         public override string ConfigFile => System.IO.Path.Combine(RootPath, "RpcServer.json");
-        protected override bool StopOnUnhandledException => settings.StopOnUnhandledException;
+        protected override UnhandledExceptionPolicy ExceptionPolicy => settings.ExceptionPolicy;
 
         protected override void Configure()
         {

--- a/src/Plugins/RpcServer/Settings.cs
+++ b/src/Plugins/RpcServer/Settings.cs
@@ -18,11 +18,11 @@ using System.Net;
 
 namespace Neo.Plugins.RpcServer
 {
-    class Settings
+    class Settings : PluginSettings
     {
         public IReadOnlyList<RpcServerSettings> Servers { get; init; }
 
-        public Settings(IConfigurationSection section)
+        public Settings(IConfigurationSection section) : base(section)
         {
             Servers = section.GetSection(nameof(Servers)).GetChildren().Select(p => RpcServerSettings.Load(p)).ToArray();
         }

--- a/src/Plugins/StateService/Settings.cs
+++ b/src/Plugins/StateService/Settings.cs
@@ -13,7 +13,7 @@ using Microsoft.Extensions.Configuration;
 
 namespace Neo.Plugins.StateService
 {
-    internal class Settings
+    internal class Settings : PluginSettings
     {
         public string Path { get; }
         public bool FullState { get; }
@@ -23,7 +23,7 @@ namespace Neo.Plugins.StateService
 
         public static Settings Default { get; private set; }
 
-        private Settings(IConfigurationSection section)
+        private Settings(IConfigurationSection section) : base(section)
         {
             Path = section.GetValue("Path", "Data_MPT_{0}");
             FullState = section.GetValue("FullState", false);

--- a/src/Plugins/StateService/StatePlugin.cs
+++ b/src/Plugins/StateService/StatePlugin.cs
@@ -40,6 +40,8 @@ namespace Neo.Plugins.StateService
         public override string Description => "Enables MPT for the node";
         public override string ConfigFile => System.IO.Path.Combine(RootPath, "StateService.json");
 
+        protected override bool StopOnUnhandledException => Settings.Default.StopOnUnhandledException;
+
         internal IActorRef Store;
         internal IActorRef Verifier;
 

--- a/src/Plugins/StateService/StatePlugin.cs
+++ b/src/Plugins/StateService/StatePlugin.cs
@@ -40,7 +40,7 @@ namespace Neo.Plugins.StateService
         public override string Description => "Enables MPT for the node";
         public override string ConfigFile => System.IO.Path.Combine(RootPath, "StateService.json");
 
-        protected override bool StopOnUnhandledException => Settings.Default.StopOnUnhandledException;
+        protected override UnhandledExceptionPolicy ExceptionPolicy => Settings.Default.ExceptionPolicy;
 
         internal IActorRef Store;
         internal IActorRef Verifier;

--- a/src/Plugins/StateService/StateService.json
+++ b/src/Plugins/StateService/StateService.json
@@ -5,7 +5,7 @@
     "Network": 860833102,
     "AutoVerify": false,
     "MaxFindResultItems": 100,
-    "StopOnUnhandledException": true
+    "UnhandledExceptionPolicy": "StopPlugin"
   },
   "Dependency": [
     "RpcServer"

--- a/src/Plugins/StateService/StateService.json
+++ b/src/Plugins/StateService/StateService.json
@@ -4,7 +4,8 @@
     "FullState": false,
     "Network": 860833102,
     "AutoVerify": false,
-    "MaxFindResultItems": 100
+    "MaxFindResultItems": 100,
+    "StopOnUnhandledException": true
   },
   "Dependency": [
     "RpcServer"

--- a/src/Plugins/StorageDumper/Settings.cs
+++ b/src/Plugins/StorageDumper/Settings.cs
@@ -14,7 +14,7 @@ using Neo.SmartContract.Native;
 
 namespace Neo.Plugins.StorageDumper
 {
-    internal class Settings
+    internal class Settings : PluginSettings
     {
         /// <summary>
         /// Amount of storages states (heights) to be dump in a given json file
@@ -32,7 +32,7 @@ namespace Neo.Plugins.StorageDumper
 
         public static Settings? Default { get; private set; }
 
-        private Settings(IConfigurationSection section)
+        private Settings(IConfigurationSection section) : base(section)
         {
             // Geting settings for storage changes state dumper
             BlockCacheSize = section.GetValue("BlockCacheSize", 1000u);

--- a/src/Plugins/StorageDumper/StorageDumper.cs
+++ b/src/Plugins/StorageDumper/StorageDumper.cs
@@ -29,7 +29,7 @@ namespace Neo.Plugins.StorageDumper
         /// </summary>
         private JObject? _currentBlock;
         private string? _lastCreateDirectory;
-
+        protected override bool StopOnUnhandledException => Settings.Default != null && Settings.Default.StopOnUnhandledException;
 
         public override string Description => "Exports Neo-CLI status data";
 

--- a/src/Plugins/StorageDumper/StorageDumper.cs
+++ b/src/Plugins/StorageDumper/StorageDumper.cs
@@ -29,7 +29,7 @@ namespace Neo.Plugins.StorageDumper
         /// </summary>
         private JObject? _currentBlock;
         private string? _lastCreateDirectory;
-        protected override UnhandledExceptionPolicy ExceptionPolicy => Settings.Default.ExceptionPolicy;
+        protected override UnhandledExceptionPolicy ExceptionPolicy => Settings.Default?.ExceptionPolicy??UnhandledExceptionPolicy.Ignore;
 
         public override string Description => "Exports Neo-CLI status data";
 

--- a/src/Plugins/StorageDumper/StorageDumper.cs
+++ b/src/Plugins/StorageDumper/StorageDumper.cs
@@ -29,7 +29,7 @@ namespace Neo.Plugins.StorageDumper
         /// </summary>
         private JObject? _currentBlock;
         private string? _lastCreateDirectory;
-        protected override UnhandledExceptionPolicy ExceptionPolicy => Settings.Default?.ExceptionPolicy??UnhandledExceptionPolicy.Ignore;
+        protected override UnhandledExceptionPolicy ExceptionPolicy => Settings.Default?.ExceptionPolicy ?? UnhandledExceptionPolicy.Ignore;
 
         public override string Description => "Exports Neo-CLI status data";
 

--- a/src/Plugins/StorageDumper/StorageDumper.cs
+++ b/src/Plugins/StorageDumper/StorageDumper.cs
@@ -29,7 +29,7 @@ namespace Neo.Plugins.StorageDumper
         /// </summary>
         private JObject? _currentBlock;
         private string? _lastCreateDirectory;
-        protected override bool StopOnUnhandledException => Settings.Default != null && Settings.Default.StopOnUnhandledException;
+        protected override UnhandledExceptionPolicy ExceptionPolicy => Settings.Default.ExceptionPolicy;
 
         public override string Description => "Exports Neo-CLI status data";
 

--- a/src/Plugins/StorageDumper/StorageDumper.json
+++ b/src/Plugins/StorageDumper/StorageDumper.json
@@ -3,6 +3,7 @@
     "BlockCacheSize": 1000,
     "HeightToBegin": 0,
     "StoragePerFolder": 100000,
-    "Exclude": [ -4 ]
+    "Exclude": [ -4 ],
+    "StopOnUnhandledException": false
   }
 }

--- a/src/Plugins/StorageDumper/StorageDumper.json
+++ b/src/Plugins/StorageDumper/StorageDumper.json
@@ -4,6 +4,6 @@
     "HeightToBegin": 0,
     "StoragePerFolder": 100000,
     "Exclude": [ -4 ],
-    "StopOnUnhandledException": false
+    "UnhandledExceptionPolicy": "Ignore"
   }
 }

--- a/src/Plugins/TokensTracker/TokensTracker.cs
+++ b/src/Plugins/TokensTracker/TokensTracker.cs
@@ -59,7 +59,7 @@ namespace Neo.Plugins
             _maxResults = config.GetValue("MaxResults", 1000u);
             _network = config.GetValue("Network", 860833102u);
             _enabledTrackers = config.GetSection("EnabledTrackers").GetChildren().Select(p => p.Value).ToArray();
-            var policyString = config.GetValue("UnhandledExceptionPolicy", "StopNode");
+            var policyString = config.GetValue(nameof(UnhandledExceptionPolicy), nameof(UnhandledExceptionPolicy.StopNode));
             if (Enum.TryParse(policyString, out UnhandledExceptionPolicy policy))
             {
                 _exceptionPolicy = policy;

--- a/src/Plugins/TokensTracker/TokensTracker.cs
+++ b/src/Plugins/TokensTracker/TokensTracker.cs
@@ -29,8 +29,10 @@ namespace Neo.Plugins
         private uint _network;
         private string[] _enabledTrackers;
         private IStore _db;
+        private bool _stopOnUnhandledException;
         private NeoSystem neoSystem;
         private readonly List<TrackerBase> trackers = new();
+        protected override bool StopOnUnhandledException => _stopOnUnhandledException;
 
         public override string Description => "Enquiries balances and transaction history of accounts through RPC";
 
@@ -56,6 +58,7 @@ namespace Neo.Plugins
             _maxResults = config.GetValue("MaxResults", 1000u);
             _network = config.GetValue("Network", 860833102u);
             _enabledTrackers = config.GetSection("EnabledTrackers").GetChildren().Select(p => p.Value).ToArray();
+            _stopOnUnhandledException = config.GetValue("StopOnUnhandledException", true);
         }
 
         protected override void OnSystemLoaded(NeoSystem system)

--- a/src/Plugins/TokensTracker/TokensTracker.cs
+++ b/src/Plugins/TokensTracker/TokensTracker.cs
@@ -15,6 +15,7 @@ using Neo.Network.P2P.Payloads;
 using Neo.Persistence;
 using Neo.Plugins.RpcServer;
 using Neo.Plugins.Trackers;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using static System.IO.Path;
@@ -29,10 +30,10 @@ namespace Neo.Plugins
         private uint _network;
         private string[] _enabledTrackers;
         private IStore _db;
-        private bool _stopOnUnhandledException;
+        private UnhandledExceptionPolicy _exceptionPolicy;
         private NeoSystem neoSystem;
         private readonly List<TrackerBase> trackers = new();
-        protected override bool StopOnUnhandledException => _stopOnUnhandledException;
+        protected override UnhandledExceptionPolicy ExceptionPolicy => _exceptionPolicy;
 
         public override string Description => "Enquiries balances and transaction history of accounts through RPC";
 
@@ -58,7 +59,11 @@ namespace Neo.Plugins
             _maxResults = config.GetValue("MaxResults", 1000u);
             _network = config.GetValue("Network", 860833102u);
             _enabledTrackers = config.GetSection("EnabledTrackers").GetChildren().Select(p => p.Value).ToArray();
-            _stopOnUnhandledException = config.GetValue("StopOnUnhandledException", true);
+            var policyString = config.GetValue("UnhandledExceptionPolicy", "StopNode");
+            if (Enum.TryParse(policyString, out UnhandledExceptionPolicy policy))
+            {
+                _exceptionPolicy = policy;
+            }
         }
 
         protected override void OnSystemLoaded(NeoSystem system)

--- a/src/Plugins/TokensTracker/TokensTracker.json
+++ b/src/Plugins/TokensTracker/TokensTracker.json
@@ -5,7 +5,7 @@
     "MaxResults": 1000,
     "Network": 860833102,
     "EnabledTrackers": [ "NEP-11", "NEP-17" ],
-    "UnhandledExceptionPolicy": "Ignore"
+    "UnhandledExceptionPolicy": "StopPlugin"
   },
   "Dependency": [
     "RpcServer"

--- a/src/Plugins/TokensTracker/TokensTracker.json
+++ b/src/Plugins/TokensTracker/TokensTracker.json
@@ -4,7 +4,8 @@
     "TrackHistory": true,
     "MaxResults": 1000,
     "Network": 860833102,
-    "EnabledTrackers": [ "NEP-11", "NEP-17" ]
+    "EnabledTrackers": [ "NEP-11", "NEP-17" ],
+    "StopOnUnhandledException": false
   },
   "Dependency": [
     "RpcServer"

--- a/src/Plugins/TokensTracker/TokensTracker.json
+++ b/src/Plugins/TokensTracker/TokensTracker.json
@@ -5,7 +5,7 @@
     "MaxResults": 1000,
     "Network": 860833102,
     "EnabledTrackers": [ "NEP-11", "NEP-17" ],
-    "StopOnUnhandledException": false
+    "UnhandledExceptionPolicy": "Ignore"
   },
   "Dependency": [
     "RpcServer"

--- a/tests/Neo.UnitTests/Plugins/TestPlugin.cs
+++ b/tests/Neo.UnitTests/Plugins/TestPlugin.cs
@@ -10,13 +10,22 @@
 // modifications are permitted.
 
 using Microsoft.Extensions.Configuration;
+using Neo.Ledger;
+using Neo.Network.P2P.Payloads;
+using Neo.Persistence;
 using Neo.Plugins;
+using System;
+using System.Collections.Generic;
 
 namespace Neo.UnitTests.Plugins
 {
     public class TestPlugin : Plugin
     {
-        public TestPlugin() : base() { }
+        public TestPlugin() : base()
+        {
+            Blockchain.Committing += OnCommitting;
+            Blockchain.Committed += OnCommitted;
+        }
 
         protected override void Configure() { }
 
@@ -36,5 +45,15 @@ namespace Neo.UnitTests.Plugins
         }
 
         protected override bool OnMessage(object message) => true;
+
+        private void OnCommitting(NeoSystem system, Block block, DataCache snapshot, IReadOnlyList<Blockchain.ApplicationExecuted> applicationExecutedList)
+        {
+            throw new NotImplementedException();
+        }
+
+        private void OnCommitted(NeoSystem system, Block block)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/tests/Neo.UnitTests/Plugins/TestPlugin.cs
+++ b/tests/Neo.UnitTests/Plugins/TestPlugin.cs
@@ -19,7 +19,16 @@ using System.Collections.Generic;
 
 namespace Neo.UnitTests.Plugins
 {
-    public class TestNonPlugin
+
+    internal class TestPluginSettings(IConfigurationSection section) : PluginSettings(section)
+    {
+        public static TestPluginSettings Default { get; private set; }
+        public static void Load(IConfigurationSection section)
+        {
+            Default = new TestPluginSettings(section);
+        }
+    }
+    internal class TestNonPlugin
     {
         public TestNonPlugin()
         {
@@ -39,15 +48,22 @@ namespace Neo.UnitTests.Plugins
     }
 
 
-    public class TestPlugin : Plugin
+    internal class TestPlugin : Plugin
     {
-        public TestPlugin() : base()
+        private readonly bool _stopOnUnhandledException;
+        protected internal override bool StopOnUnhandledException => _stopOnUnhandledException && TestPluginSettings.Default.StopOnUnhandledException;
+
+        public TestPlugin(bool stopOnUnhandledException = true) : base()
         {
             Blockchain.Committing += OnCommitting;
             Blockchain.Committed += OnCommitted;
+            _stopOnUnhandledException = stopOnUnhandledException;
         }
 
-        protected override void Configure() { }
+        protected override void Configure()
+        {
+            TestPluginSettings.Load(GetConfiguration());
+        }
 
         public void LogMessage(string message)
         {

--- a/tests/Neo.UnitTests/Plugins/TestPlugin.cs
+++ b/tests/Neo.UnitTests/Plugins/TestPlugin.cs
@@ -50,14 +50,14 @@ namespace Neo.UnitTests.Plugins
 
     internal class TestPlugin : Plugin
     {
-        private readonly bool _stopOnUnhandledException;
-        protected internal override bool StopOnUnhandledException => _stopOnUnhandledException && TestPluginSettings.Default.StopOnUnhandledException;
+        private readonly UnhandledExceptionPolicy _exceptionPolicy;
+        protected internal override UnhandledExceptionPolicy ExceptionPolicy => _exceptionPolicy;
 
-        public TestPlugin(bool stopOnUnhandledException = true) : base()
+        public TestPlugin(UnhandledExceptionPolicy exceptionPolicy = UnhandledExceptionPolicy.StopPlugin) : base()
         {
             Blockchain.Committing += OnCommitting;
             Blockchain.Committed += OnCommitted;
-            _stopOnUnhandledException = stopOnUnhandledException;
+            _exceptionPolicy = exceptionPolicy;
         }
 
         protected override void Configure()

--- a/tests/Neo.UnitTests/Plugins/TestPlugin.cs
+++ b/tests/Neo.UnitTests/Plugins/TestPlugin.cs
@@ -21,7 +21,7 @@ namespace Neo.UnitTests.Plugins
 {
     public class TestNonPlugin
     {
-        public TestNonPlugin() : base()
+        public TestNonPlugin()
         {
             Blockchain.Committing += OnCommitting;
             Blockchain.Committed += OnCommitted;
@@ -29,14 +29,15 @@ namespace Neo.UnitTests.Plugins
 
         private void OnCommitting(NeoSystem system, Block block, DataCache snapshot, IReadOnlyList<Blockchain.ApplicationExecuted> applicationExecutedList)
         {
-            throw new NotImplementedException();
+            throw new NotImplementedException("Test exception from OnCommitting");
         }
 
         private void OnCommitted(NeoSystem system, Block block)
         {
-            throw new NotImplementedException();
+            throw new NotImplementedException("Test exception from OnCommitted");
         }
     }
+
 
     public class TestPlugin : Plugin
     {

--- a/tests/Neo.UnitTests/Plugins/TestPlugin.cs
+++ b/tests/Neo.UnitTests/Plugins/TestPlugin.cs
@@ -19,6 +19,25 @@ using System.Collections.Generic;
 
 namespace Neo.UnitTests.Plugins
 {
+    public class TestNonPlugin
+    {
+        public TestNonPlugin() : base()
+        {
+            Blockchain.Committing += OnCommitting;
+            Blockchain.Committed += OnCommitted;
+        }
+
+        private void OnCommitting(NeoSystem system, Block block, DataCache snapshot, IReadOnlyList<Blockchain.ApplicationExecuted> applicationExecutedList)
+        {
+            throw new NotImplementedException();
+        }
+
+        private void OnCommitted(NeoSystem system, Block block)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
     public class TestPlugin : Plugin
     {
         public TestPlugin() : base()

--- a/tests/Neo.UnitTests/Plugins/UT_Plugin.cs
+++ b/tests/Neo.UnitTests/Plugins/UT_Plugin.cs
@@ -73,7 +73,7 @@ namespace Neo.UnitTests.Plugins
             // Call the InvokeCommitted method and ensure no exception is thrown
             try
             {
-                Blockchain.InvokeCommitting(null, null,null,null);
+                Blockchain.InvokeCommitting(null, null, null, null);
                 Blockchain.InvokeCommitted(null, null);
             }
             catch (Exception ex)

--- a/tests/Neo.UnitTests/Plugins/UT_Plugin.cs
+++ b/tests/Neo.UnitTests/Plugins/UT_Plugin.cs
@@ -14,6 +14,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Neo.Ledger;
 using Neo.Plugins;
 using System;
+using System.Threading.Tasks;
 
 namespace Neo.UnitTests.Plugins
 {
@@ -66,28 +67,31 @@ namespace Neo.UnitTests.Plugins
         }
 
         [TestMethod]
-        public void TestOnException()
+        public async Task TestOnException()
         {
-            _ = new TestPlugin();
-
-            // Call the InvokeCommitted method and ensure no exception is thrown
+            // Ensure no exception is thrown
             try
             {
-                Blockchain.InvokeCommitting(null, null, null, null);
-                Blockchain.InvokeCommitted(null, null);
+                await Blockchain.InvokeCommittingAsync(null, null, null, null);
+                await Blockchain.InvokeCommittedAsync(null, null);
             }
             catch (Exception ex)
             {
-                Assert.Fail($"InvokeCommitted threw an exception: {ex.Message}");
+                Assert.Fail($"InvokeCommitting or InvokeCommitted threw an exception: {ex.Message}");
             }
 
+            // Register TestNonPlugin that throws exceptions
             _ = new TestNonPlugin();
 
-            // Call the InvokeCommitted method and ensure exception is thrown
-            Assert.ThrowsException<NotImplementedException>(() =>
+            // Ensure exception is thrown
+            await Assert.ThrowsExceptionAsync<NotImplementedException>(async () =>
             {
-                Blockchain.InvokeCommitting(null, null, null, null);
-                Blockchain.InvokeCommitted(null, null);
+                await Blockchain.InvokeCommittingAsync(null, null, null, null);
+            });
+
+            await Assert.ThrowsExceptionAsync<NotImplementedException>(async () =>
+            {
+                await Blockchain.InvokeCommittedAsync(null, null);
             });
         }
     }

--- a/tests/Neo.UnitTests/Plugins/UT_Plugin.cs
+++ b/tests/Neo.UnitTests/Plugins/UT_Plugin.cs
@@ -68,7 +68,7 @@ namespace Neo.UnitTests.Plugins
         [TestMethod]
         public void TestOnException()
         {
-            var pp = new TestPlugin();
+            _ = new TestPlugin();
 
             // Call the InvokeCommitted method and ensure no exception is thrown
             try
@@ -80,6 +80,15 @@ namespace Neo.UnitTests.Plugins
             {
                 Assert.Fail($"InvokeCommitted threw an exception: {ex.Message}");
             }
+
+            _ = new TestNonPlugin();
+
+            // Call the InvokeCommitted method and ensure exception is thrown
+            Assert.ThrowsException<NotImplementedException>(() =>
+            {
+                Blockchain.InvokeCommitting(null, null, null, null);
+                Blockchain.InvokeCommitted(null, null);
+            });
         }
     }
 }

--- a/tests/Neo.UnitTests/Plugins/UT_Plugin.cs
+++ b/tests/Neo.UnitTests/Plugins/UT_Plugin.cs
@@ -11,6 +11,7 @@
 
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.Ledger;
 using Neo.Plugins;
 using System;
 
@@ -62,6 +63,14 @@ namespace Neo.UnitTests.Plugins
         {
             var pp = new TestPlugin();
             pp.TestGetConfiguration().Key.Should().Be("PluginConfiguration");
+        }
+
+        [TestMethod]
+        public void TestOnException()
+        {
+            var pp = new TestPlugin();
+
+          Blockchain.InvokeCommitted(null,null);
         }
     }
 }

--- a/tests/Neo.UnitTests/Plugins/UT_Plugin.cs
+++ b/tests/Neo.UnitTests/Plugins/UT_Plugin.cs
@@ -68,7 +68,6 @@ namespace Neo.UnitTests.Plugins
             }
         }
 
-
         [TestMethod]
         public void TestGetConfigFile()
         {
@@ -181,7 +180,7 @@ namespace Neo.UnitTests.Plugins
             Assert.AreEqual(true, pp.IsStopped);
 
             // pp2 will not stop on exception.
-            var pp2 = new TestPlugin(false);
+            var pp2 = new TestPlugin(UnhandledExceptionPolicy.Ignore);
             Assert.AreEqual(false, pp2.IsStopped);
             // Ensure no exception is thrown
             try
@@ -195,6 +194,25 @@ namespace Neo.UnitTests.Plugins
             }
 
             Assert.AreEqual(false, pp2.IsStopped);
+        }
+
+        [TestMethod]
+        public async Task TestOnNodeStopOnPluginException()
+        {
+            // node will stop on pp exception.
+            var pp = new TestPlugin(UnhandledExceptionPolicy.StopNode);
+            Assert.AreEqual(false, pp.IsStopped);
+            await Assert.ThrowsExceptionAsync<NotImplementedException>(async () =>
+            {
+                await Blockchain.InvokeCommittingAsync(null, null, null, null);
+            });
+
+            await Assert.ThrowsExceptionAsync<NotImplementedException>(async () =>
+            {
+                await Blockchain.InvokeCommittedAsync(null, null);
+            });
+
+            Assert.AreEqual(false, pp.IsStopped);
         }
     }
 }

--- a/tests/Neo.UnitTests/Plugins/UT_Plugin.cs
+++ b/tests/Neo.UnitTests/Plugins/UT_Plugin.cs
@@ -70,7 +70,7 @@ namespace Neo.UnitTests.Plugins
         {
             var pp = new TestPlugin();
 
-          Blockchain.InvokeCommitted(null,null);
+            Blockchain.InvokeCommitted(null, null);
         }
     }
 }

--- a/tests/Neo.UnitTests/Plugins/UT_Plugin.cs
+++ b/tests/Neo.UnitTests/Plugins/UT_Plugin.cs
@@ -70,7 +70,15 @@ namespace Neo.UnitTests.Plugins
         {
             var pp = new TestPlugin();
 
-            Blockchain.InvokeCommitted(null, null);
+            // Call the InvokeCommitted method and ensure no exception is thrown
+            try
+            {
+                Blockchain.InvokeCommitted(null, null);
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail($"InvokeCommitted threw an exception: {ex.Message}");
+            }
         }
     }
 }

--- a/tests/Neo.UnitTests/Plugins/UT_Plugin.cs
+++ b/tests/Neo.UnitTests/Plugins/UT_Plugin.cs
@@ -73,6 +73,7 @@ namespace Neo.UnitTests.Plugins
             // Call the InvokeCommitted method and ensure no exception is thrown
             try
             {
+                Blockchain.InvokeCommitting(null, null,null,null);
                 Blockchain.InvokeCommitted(null, null);
             }
             catch (Exception ex)

--- a/tests/Neo.UnitTests/Plugins/UT_Plugin.cs
+++ b/tests/Neo.UnitTests/Plugins/UT_Plugin.cs
@@ -69,6 +69,7 @@ namespace Neo.UnitTests.Plugins
         [TestMethod]
         public async Task TestOnException()
         {
+            _ = new TestPlugin();
             // Ensure no exception is thrown
             try
             {
@@ -94,5 +95,62 @@ namespace Neo.UnitTests.Plugins
                 await Blockchain.InvokeCommittedAsync(null, null);
             });
         }
+
+        [TestMethod]
+        public async Task TestOnPluginStopped()
+        {
+            var pp = new TestPlugin();
+            Assert.AreEqual(false, pp.IsStopped);
+            // Ensure no exception is thrown
+            try
+            {
+                await Blockchain.InvokeCommittingAsync(null, null, null, null);
+                await Blockchain.InvokeCommittedAsync(null, null);
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail($"InvokeCommitting or InvokeCommitted threw an exception: {ex.Message}");
+            }
+
+            Assert.AreEqual(true, pp.IsStopped);
+        }
+
+        [TestMethod]
+        public async Task TestOnPluginStopOnException()
+        {
+            // pp will stop on exception.
+            var pp = new TestPlugin();
+            Assert.AreEqual(false, pp.IsStopped);
+            // Ensure no exception is thrown
+            try
+            {
+                await Blockchain.InvokeCommittingAsync(null, null, null, null);
+                await Blockchain.InvokeCommittedAsync(null, null);
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail($"InvokeCommitting or InvokeCommitted threw an exception: {ex.Message}");
+            }
+
+            Assert.AreEqual(true, pp.IsStopped);
+
+            // pp2 will not stop on exception.
+            var pp2 = new TestPlugin(false);
+            Assert.AreEqual(false, pp2.IsStopped);
+            // Ensure no exception is thrown
+            try
+            {
+                await Blockchain.InvokeCommittingAsync(null, null, null, null);
+                await Blockchain.InvokeCommittedAsync(null, null);
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail($"InvokeCommitting or InvokeCommitted threw an exception: {ex.Message}");
+            }
+
+            Assert.AreEqual(false, pp2.IsStopped);
+
+        }
+
     }
 }


### PR DESCRIPTION
# Description

This is a follow up work after https://github.com/neo-project/neo/pull/3309. This pr will stop a plugin if a plugin throws an unhandled exception, but we also allow user to specify plugins not to stop on exception (except store plugins.).

Every single plugin can specifiy their own policy when unhandled exception is throw out of the plugin:

- **StopNode**. Exception will be throw directly and not handled, this will cause the node to stop working. And this is current logic.
- **StopPlugin**. Exception will be handled by the core and the plugin will be stoped from running.
- **Ignore**. Exception will be recorded, but node and plugin will keep running.


Fixes # follow https://github.com/neo-project/neo/pull/3309

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] TestOnPluginStopOnException
- [x] TestOnPluginStopped
- [x] TestOnNodeStopOnPluginException

**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
