### PR TITLE
[Neo VM Bug] Kill the process on negative reference counter

### DIFF
--- a/src/Neo.VM/ReferenceCounter.cs
+++ b/src/Neo.VM/ReferenceCounter.cs
@@ -11,8 +11,8 @@
 
 using Neo.VM.StronglyConnectedComponents;
 using Neo.VM.Types;
+using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using Buffer = Neo.VM.Types.Buffer;

--- a/src/Neo.VM/ReferenceCounter.cs
+++ b/src/Neo.VM/ReferenceCounter.cs
@@ -159,7 +159,7 @@ namespace Neo.VM
             references_count -= count;
             // Negative counter means critical bug exists in the system
             // Need to stop the process and halt the network immediately.
-            if (references_count < 0) Process.GetCurrentProcess().Kill();
+            if (references_count < 0) Environment.Exit(1);
         }
     }
 }


### PR DESCRIPTION
# Description

Replace https://github.com/neo-project/neo/pull/3304. 
Ensure the network is halted over critical bugs.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?



**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
