### PR TITLE
[Neo VM Optimization] Detect reference counter miscalculation.

### DIFF
--- a/src/Neo.VM/CompoundTypeReferenceCountChecker.cs
+++ b/src/Neo.VM/CompoundTypeReferenceCountChecker.cs
@@ -43,23 +43,25 @@ internal class CompoundTypeReferenceCountChecker(int maxItems = 2048)
 
             foreach (var subItem in currentCompound.SubItems)
             {
-                // An item added to the stack must have a reference count higher than 0
-                if (subItem.ReferenceCount <= 0)
+                // if a compound type item has reference counter assigned
+                // Then its subitem is referred.
+                if (subItem is CompoundType compoundType)
                 {
-                    throw new InvalidOperationException("Invalid stackitem being pushed.");
-                }
+                    // If a compound type has no reference counter
+                    // Then this compound type is problematic
+                    if (compoundType.ReferenceCounter == null)
+                    {
+                        throw new InvalidOperationException("Invalid stackitem being pushed.");
+                    }
 
-                // If the subItem is a CompoundType, process it
-                if (subItem is CompoundType compoundSubItem)
-                {
                     // Check if this subItem has been visited already
-                    if (!visited.Add(compoundSubItem))
+                    if (!visited.Add(compoundType))
                     {
                         continue;
                     }
 
                     // Add the subItem to the stack and increment the itemCount
-                    stack.Push(compoundSubItem);
+                    stack.Push(compoundType);
                     itemCount++;
 
                     // Check if the itemCount exceeds the maximum allowed items
@@ -67,6 +69,7 @@ internal class CompoundTypeReferenceCountChecker(int maxItems = 2048)
                     {
                         throw new InvalidOperationException($"Exceeded maximum of {maxItems} items.");
                     }
+
                 }
             }
         }

--- a/src/Neo.VM/CompoundTypeReferenceCountChecker.cs
+++ b/src/Neo.VM/CompoundTypeReferenceCountChecker.cs
@@ -1,0 +1,76 @@
+// Copyright (C) 2015-2024 The Neo Project.
+//
+// CompoundTypeReferenceCountChecker.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Neo.VM.Types;
+using System;
+using System.Collections.Generic;
+
+namespace Neo.VM;
+
+internal class CompoundTypeReferenceCountChecker(int maxItems = 2048)
+{
+    public void CheckCompoundType(CompoundType rootItem)
+    {
+        if (rootItem is null) throw new ArgumentNullException(nameof(rootItem));
+
+        var visited = new HashSet<StackItem>(ReferenceEqualityComparer.Instance);
+        var itemCount = TraverseCompoundType(rootItem, visited, 0);
+
+        if (itemCount > maxItems)
+        {
+            throw new InvalidOperationException($"Exceeded maximum of {maxItems} items.");
+        }
+    }
+
+    private int TraverseCompoundType(CompoundType rootItem, HashSet<StackItem> visited, int itemCount)
+    {
+        var stack = new Stack<CompoundType>();
+        stack.Push(rootItem);
+        visited.Add(rootItem);
+        itemCount++;
+
+        while (stack.Count > 0)
+        {
+            var currentCompound = stack.Pop();
+
+            foreach (var subItem in currentCompound.SubItems)
+            {
+                // An item added to the stack must have a reference count higher than 0
+                if (subItem.ReferenceCount <= 0)
+                {
+                    throw new InvalidOperationException("Invalid stackitem being pushed.");
+                }
+
+                // If the subItem is a CompoundType, process it
+                if (subItem is CompoundType compoundSubItem)
+                {
+                    // Check if this subItem has been visited already
+                    if (!visited.Add(compoundSubItem))
+                    {
+                        continue;
+                    }
+
+                    // Add the subItem to the stack and increment the itemCount
+                    stack.Push(compoundSubItem);
+                    itemCount++;
+
+                    // Check if the itemCount exceeds the maximum allowed items
+                    if (itemCount > maxItems)
+                    {
+                        throw new InvalidOperationException($"Exceeded maximum of {maxItems} items.");
+                    }
+                }
+            }
+        }
+
+        return itemCount;
+    }
+}

--- a/src/Neo.VM/EvaluationStack.cs
+++ b/src/Neo.VM/EvaluationStack.cs
@@ -110,6 +110,8 @@ namespace Neo.VM
         {
             innerList.Add(item);
             referenceCounter.AddStackReference(item);
+            if (item is CompoundType compoundType)
+                CheckCompoundType(compoundType);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -163,6 +165,31 @@ namespace Neo.VM
         public override string ToString()
         {
             return $"[{string.Join(", ", innerList.Select(p => $"{p.Type}({p})"))}]";
+        }
+
+        private static void CheckCompoundType(CompoundType rootItem)
+        {
+            ArgumentNullException.ThrowIfNull(rootItem);
+            var stack = new Stack<CompoundType>();
+            stack.Push(rootItem);
+
+            while (stack.Count > 0)
+            {
+                var currentCompound = stack.Pop();
+
+                foreach (var subItem in currentCompound.SubItems)
+                {
+                    if (!subItem.OnStack)
+                    {
+                        throw new InvalidOperationException("Invalid stackitem being pushed.");
+                    }
+
+                    if (subItem is CompoundType compoundSubItem)
+                    {
+                        stack.Push(compoundSubItem);
+                    }
+                }
+            }
         }
     }
 }

--- a/src/Neo.VM/EvaluationStack.cs
+++ b/src/Neo.VM/EvaluationStack.cs
@@ -204,9 +204,7 @@ namespace Neo.VM
 
                 foreach (var subItem in currentCompound.SubItems)
                 {
-                    if (subItem.StackReferences <= 0 &&
-                        !subItem.ObjectReferences?.Values
-                            .Any(p => p is { References: > 0, Item.OnStack: true }) == true)
+                    if (subItem.ReferenceCount <= 0)
                     {
                         throw new InvalidOperationException("Invalid stackitem being pushed.");
                     }

--- a/src/Neo.VM/EvaluationStack.cs
+++ b/src/Neo.VM/EvaluationStack.cs
@@ -169,7 +169,7 @@ namespace Neo.VM
 
         private static void CheckCompoundType(CompoundType rootItem)
         {
-            ArgumentNullException.ThrowIfNull(rootItem);
+            if (rootItem is null) throw new ArgumentNullException();
             var stack = new Stack<CompoundType>();
             stack.Push(rootItem);
 

--- a/src/Neo.VM/EvaluationStack.cs
+++ b/src/Neo.VM/EvaluationStack.cs
@@ -171,67 +171,8 @@ namespace Neo.VM
         {
             if (rootItem is null)
                 throw new ArgumentNullException();
-            var checker = new CompoundTypeChecker(maxItems: 2048);
+            var checker = new CompoundTypeReferenceCountChecker(maxItems: 2048);
             checker.CheckCompoundType(rootItem);
-        }
-    }
-
-    internal class CompoundTypeChecker(int maxItems = 2048)
-    {
-        public void CheckCompoundType(CompoundType rootItem)
-        {
-            if (rootItem is null) throw new ArgumentNullException(nameof(rootItem));
-
-            var visited = new HashSet<StackItem>(ReferenceEqualityComparer.Instance);
-            var itemCount = TraverseCompoundType(rootItem, visited, 0);
-
-            if (itemCount > maxItems)
-            {
-                throw new InvalidOperationException($"Exceeded maximum of {maxItems} items.");
-            }
-        }
-
-        private int TraverseCompoundType(CompoundType rootItem, HashSet<StackItem> visited, int itemCount)
-        {
-            var stack = new Stack<CompoundType>();
-            stack.Push(rootItem);
-            visited.Add(rootItem);
-            itemCount++;
-
-            while (stack.Count > 0)
-            {
-                var currentCompound = stack.Pop();
-
-                foreach (var subItem in currentCompound.SubItems)
-                {
-                    if (subItem.ReferenceCount <= 0)
-                    {
-                        throw new InvalidOperationException("Invalid stackitem being pushed.");
-                    }
-
-                    // If the subItem is a CompoundType, process it
-                    if (subItem is CompoundType compoundSubItem)
-                    {
-                        // Check if this subItem has been visited already
-                        if (!visited.Add(compoundSubItem))
-                        {
-                            continue;
-                        }
-
-                        // Add the subItem to the stack and increment the itemCount
-                        stack.Push(compoundSubItem);
-                        itemCount++;
-
-                        // Check if the itemCount exceeds the maximum allowed items
-                        if (itemCount > maxItems)
-                        {
-                            throw new InvalidOperationException($"Exceeded maximum of {maxItems} items.");
-                        }
-                    }
-                }
-            }
-
-            return itemCount;
         }
     }
 }

--- a/src/Neo.VM/ExecutionEngine.cs
+++ b/src/Neo.VM/ExecutionEngine.cs
@@ -135,14 +135,14 @@ namespace Neo.VM
                     ExecutionContext context = CurrentContext!;
                     Instruction instruction = context.CurrentInstruction ?? Instruction.RET;
                     PreExecuteInstruction(instruction);
-#if VMPERF
+// #if VMPERF
                     Console.WriteLine("op:["
                                       + this.CurrentContext.InstructionPointer.ToString("X04")
                                       + "]"
                                       + this.CurrentContext.CurrentInstruction?.OpCode
                                       + " "
                                       + this.CurrentContext.EvaluationStack);
-#endif
+// #endif
                     try
                     {
                         JumpTable[instruction.OpCode](this, instruction);
@@ -157,6 +157,7 @@ namespace Neo.VM
                 }
                 catch (Exception e)
                 {
+                    Console.WriteLine(e);
                     OnFault(e);
                 }
             }

--- a/src/Neo.VM/ExecutionEngine.cs
+++ b/src/Neo.VM/ExecutionEngine.cs
@@ -135,14 +135,14 @@ namespace Neo.VM
                     ExecutionContext context = CurrentContext!;
                     Instruction instruction = context.CurrentInstruction ?? Instruction.RET;
                     PreExecuteInstruction(instruction);
-// #if VMPERF
+#if VMPERF
                     Console.WriteLine("op:["
-                                      + this.CurrentContext.InstructionPointer.ToString("X04")
+                                      + CurrentContext.InstructionPointer.ToString("X04")
                                       + "]"
-                                      + this.CurrentContext.CurrentInstruction?.OpCode
+                                      + CurrentContext.CurrentInstruction?.OpCode
                                       + " "
-                                      + this.CurrentContext.EvaluationStack);
-// #endif
+                                      + CurrentContext.EvaluationStack);
+#endif
                     try
                     {
                         JumpTable[instruction.OpCode](this, instruction);

--- a/src/Neo.VM/ReferenceCounter.cs
+++ b/src/Neo.VM/ReferenceCounter.cs
@@ -47,7 +47,6 @@ namespace Neo.VM
         internal void AddReference(StackItem item, CompoundType parent)
         {
             references_count++;
-            item.ReferenceCount++;
             if (!NeedTrack(item)) return;
             cached_components = null;
             tracked_items.Add(item);
@@ -63,7 +62,6 @@ namespace Neo.VM
         internal void AddStackReference(StackItem item, int count = 1)
         {
             references_count += count;
-            item.ReferenceCount += count;
             if (!NeedTrack(item)) return;
             if (tracked_items.Add(item))
                 cached_components?.AddLast(new HashSet<StackItem>(ReferenceEqualityComparer.Instance) { item });
@@ -140,7 +138,6 @@ namespace Neo.VM
         internal void RemoveReference(StackItem item, CompoundType parent)
         {
             references_count--;
-            item.ReferenceCount--;
             if (!NeedTrack(item)) return;
             cached_components = null;
             item.ObjectReferences![parent].References--;
@@ -151,7 +148,6 @@ namespace Neo.VM
         internal void RemoveStackReference(StackItem item)
         {
             references_count--;
-            item.ReferenceCount--;
             if (!NeedTrack(item)) return;
             if (--item.StackReferences == 0)
                 zero_referred.Add(item);

--- a/src/Neo.VM/ReferenceCounter.cs
+++ b/src/Neo.VM/ReferenceCounter.cs
@@ -47,6 +47,7 @@ namespace Neo.VM
         internal void AddReference(StackItem item, CompoundType parent)
         {
             references_count++;
+            item.ReferenceCount++;
             if (!NeedTrack(item)) return;
             cached_components = null;
             tracked_items.Add(item);
@@ -62,6 +63,7 @@ namespace Neo.VM
         internal void AddStackReference(StackItem item, int count = 1)
         {
             references_count += count;
+            item.ReferenceCount += count;
             if (!NeedTrack(item)) return;
             if (tracked_items.Add(item))
                 cached_components?.AddLast(new HashSet<StackItem>(ReferenceEqualityComparer.Instance) { item });
@@ -123,6 +125,7 @@ namespace Neo.VM
                                     subitem.ObjectReferences!.Remove(compound);
                                 }
                             }
+
                             item.Cleanup();
                         }
                         var nodeToRemove = node;
@@ -137,6 +140,7 @@ namespace Neo.VM
         internal void RemoveReference(StackItem item, CompoundType parent)
         {
             references_count--;
+            item.ReferenceCount--;
             if (!NeedTrack(item)) return;
             cached_components = null;
             item.ObjectReferences![parent].References--;
@@ -147,6 +151,7 @@ namespace Neo.VM
         internal void RemoveStackReference(StackItem item)
         {
             references_count--;
+            item.ReferenceCount--;
             if (!NeedTrack(item)) return;
             if (--item.StackReferences == 0)
                 zero_referred.Add(item);

--- a/src/Neo.VM/Types/CompoundType.cs
+++ b/src/Neo.VM/Types/CompoundType.cs
@@ -24,7 +24,7 @@ namespace Neo.VM.Types
         /// <summary>
         /// The reference counter used to count the items in the VM object.
         /// </summary>
-        protected readonly ReferenceCounter? ReferenceCounter;
+        protected internal readonly ReferenceCounter? ReferenceCounter;
 
         /// <summary>
         /// Create a new <see cref="CompoundType"/> with the specified reference counter.

--- a/src/Neo.VM/Types/StackItem.Vertex.cs
+++ b/src/Neo.VM/Types/StackItem.Vertex.cs
@@ -24,10 +24,6 @@ namespace Neo.VM.Types
             public ObjectReferenceEntry(StackItem item) => Item = item;
         }
 
-        /// <summary>
-        /// Indicates how many reference this item has being added to the reference counter.
-        /// </summary>
-        internal int ReferenceCount { get; set; } = 0;
         internal int StackReferences { get; set; } = 0;
         internal Dictionary<CompoundType, ObjectReferenceEntry>? ObjectReferences { get; set; }
         internal int DFN { get; set; } = -1;

--- a/src/Neo.VM/Types/StackItem.Vertex.cs
+++ b/src/Neo.VM/Types/StackItem.Vertex.cs
@@ -24,11 +24,15 @@ namespace Neo.VM.Types
             public ObjectReferenceEntry(StackItem item) => Item = item;
         }
 
-        internal int StackReferences = 0;
-        internal Dictionary<CompoundType, ObjectReferenceEntry>? ObjectReferences;
-        internal int DFN = -1;
-        internal int LowLink = 0;
-        internal bool OnStack = false;
+        /// <summary>
+        /// Indicates how many reference this item has being added to the reference counter.
+        /// </summary>
+        internal int ReferenceCount { get; set; } = 0;
+        internal int StackReferences { get; set; } = 0;
+        internal Dictionary<CompoundType, ObjectReferenceEntry>? ObjectReferences { get; set; }
+        internal int DFN { get; set; } = -1;
+        internal int LowLink { get; set; } = 0;
+        internal bool OnStack { get; set; } = false;
 
         internal IEnumerable<StackItem> Successors => ObjectReferences?.Values.Where(p => p.References > 0).Select(p => p.Item) ?? System.Array.Empty<StackItem>();
 

--- a/tests/Neo.VM.Tests/UT_EvaluationStack.cs
+++ b/tests/Neo.VM.Tests/UT_EvaluationStack.cs
@@ -221,5 +221,22 @@ namespace Neo.Test
             stack.Insert(0, "4CC95219999D421243C8161E3FC0F4290C067845".FromHexString());
             Assert.AreEqual("[ByteString(\"Base64: TMlSGZmdQhJDyBYeP8D0KQwGeEU=\")]", stack.ToString());
         }
+
+        [TestMethod]
+        public void TestInvalidReferenceStackItem()
+        {
+            var stack = new EvaluationStack(new ReferenceCounter());
+            var arr = new Array();
+            var arr2 = new Array();
+
+            for (var i = 0; i < 10; i++)
+            {
+                arr2.Add(i);
+            }
+
+            arr.Add(arr2);
+            Assert.ThrowsException<InvalidOperationException>(()=>stack.Push(arr));
+        }
+
     }
 }

--- a/tests/Neo.VM.Tests/UT_EvaluationStack.cs
+++ b/tests/Neo.VM.Tests/UT_EvaluationStack.cs
@@ -235,7 +235,7 @@ namespace Neo.Test
             }
 
             arr.Add(arr2);
-            Assert.ThrowsException<InvalidOperationException>(()=>stack.Push(arr));
+            Assert.ThrowsException<InvalidOperationException>(() => stack.Push(arr));
         }
 
     }

--- a/tests/Neo.VM.Tests/UT_EvaluationStack.cs
+++ b/tests/Neo.VM.Tests/UT_EvaluationStack.cs
@@ -16,6 +16,7 @@ using Neo.VM.Types;
 using System;
 using System.Collections;
 using System.Linq;
+using Array = Neo.VM.Types.Array;
 
 namespace Neo.Test
 {
@@ -219,6 +220,23 @@ namespace Neo.Test
             var stack = new EvaluationStack(new ReferenceCounter());
             stack.Insert(0, "4CC95219999D421243C8161E3FC0F4290C067845".FromHexString());
             Assert.AreEqual("[ByteString(\"Base64: TMlSGZmdQhJDyBYeP8D0KQwGeEU=\")]", stack.ToString());
+        }
+
+
+        [TestMethod]
+        public void TestPushCompoundItemWithOffStackSubItems()
+        {
+            var referenceCounter = new ReferenceCounter();
+            var evaluationStack = new EvaluationStack(referenceCounter);
+            var array = new Array(referenceCounter);
+            referenceCounter.AddStackReference(array);
+            for (var i = 0; i < 100; i++)
+            {
+                var item = new Integer(i);
+                array.Add(item);
+            }
+
+            Assert.ThrowsException<InvalidOperationException>(() => evaluationStack.Push(array));
         }
     }
 }


### PR DESCRIPTION
# Description

This pr checks the stackitems being pushed to the stack only contains items that are on the stack.


Why is this problem?

We can literarily create stackitems at anywhere in the execition engine and push it to the evaluation stack, it is highly possible that we construct compound type stackitems that also contain compound type, then when we push it to the stack, only the first demension subitem will be added to the reference counter, the second/higher demonsion subitems will be ignored. 

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] TestInvalidReferenceStackItem

**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
