### PR TITLE
[Neo VM Optimization]Print stack exception

### DIFF
--- a/src/Neo.VM/ExecutionEngine.cs
+++ b/src/Neo.VM/ExecutionEngine.cs
@@ -157,6 +157,9 @@ namespace Neo.VM
                 }
                 catch (Exception e)
                 {
+#if VMPERF
+                    Console.WriteLine(e);
+#endif
                     OnFault(e);
                 }
             }

--- a/src/Neo.VM/ExecutionEngine.cs
+++ b/src/Neo.VM/ExecutionEngine.cs
@@ -157,9 +157,6 @@ namespace Neo.VM
                 }
                 catch (Exception e)
                 {
-#if VMPERF
-                    Console.WriteLine(e);
-#endif
                     OnFault(e);
                 }
             }
@@ -238,6 +235,13 @@ namespace Neo.VM
         protected virtual void OnFault(Exception ex)
         {
             State = VMState.FAULT;
+
+#if VMPERF
+            if (ex != null)
+            {
+                Console.Error.WriteLine(ex);
+            }
+#endif
         }
 
         /// <summary>


### PR DESCRIPTION
# Description

Its not clear what probem happens while testing it, thus we have VMPerf flag to show the executed opcode, but we still cant see the exception message, thus having this pr to print the exception message to the console as well.

Fixes # For debugging the UT fail issue in https://github.com/neo-project/neo/pull/3325

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
