### PR TITLE
`[Fixes]` Props Duplicate - Path Packing

### DIFF
--- a/src/Plugins/Directory.Build.props
+++ b/src/Plugins/Directory.Build.props
@@ -4,11 +4,6 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 
   <ItemGroup>
-    <None Include="$(SolutionDir)/.neo/neo.png" Pack="true" Visible="false" PackagePath=""/>
-    <None Include="$(SolutionDir)/.neo/README.md" Pack="true" Visible="false" PackagePath=""/>
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="../../Neo/Neo.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
# Description

Fixed Props Pathing for `dotnet pack` with `nuget`

# Change Log
 - Remove duplicate Paths in `./src/Plugins/Directory.Build.props`
 - Removes `warning` for files already added on `dotnet pack`

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Locally

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
