### PR TITLE
`[core]` Load Only Selected Plugins - Option

### DIFF
--- a/src/Neo.CLI/CLI/MainService.cs
+++ b/src/Neo.CLI/CLI/MainService.cs
@@ -378,6 +378,11 @@ namespace Neo.CLI
             CustomApplicationSettings(options, Settings.Default);
             try
             {
+                if (Settings.Default.Plugins.LoadDlls.Length > 0)
+                    Plugin.LoadPlugins(Settings.Default.Plugins.LoadDlls);
+                else
+                    Plugin.LoadPlugins();
+
                 NeoSystem = new NeoSystem(protocol, Settings.Default.Storage.Engine,
                     string.Format(Settings.Default.Storage.Path, protocol.Network.ToString("X8")));
             }

--- a/src/Neo.CLI/Settings.cs
+++ b/src/Neo.CLI/Settings.cs
@@ -13,7 +13,6 @@ using Microsoft.Extensions.Configuration;
 using Neo.Network.P2P;
 using Neo.Persistence;
 using System;
-using System.Linq;
 using System.Reflection;
 using System.Threading;
 
@@ -170,6 +169,8 @@ namespace Neo
         public bool Prerelease { get; init; } = false;
         public Version Version { get; init; } = Assembly.GetExecutingAssembly().GetName().Version!;
 
+        public string[] LoadDlls { get; init; } = [];
+
         public PluginsSettings(IConfigurationSection section)
         {
             if (section.Exists())
@@ -179,6 +180,7 @@ namespace Neo
                 Prerelease = section.GetValue(nameof(Prerelease), Prerelease);
                 Version = section.GetValue(nameof(Version), Version)!;
 #endif
+                LoadDlls = section.GetSection(nameof(LoadDlls)).Get<string[]>() ?? [];
             }
         }
 

--- a/src/Neo/NeoSystem.cs
+++ b/src/Neo/NeoSystem.cs
@@ -107,7 +107,7 @@ namespace Neo
             // Unify unhandled exceptions
             AppDomain.CurrentDomain.UnhandledException += CurrentDomain_UnhandledException;
 
-            Plugin.LoadPlugins();
+            //Plugin.LoadPlugins();
         }
 
         /// <summary>

--- a/src/Neo/Plugins/Plugin.cs
+++ b/src/Neo/Plugins/Plugin.cs
@@ -189,7 +189,24 @@ namespace Neo.Plugins
             }
         }
 
-        internal static void LoadPlugins()
+        public static void LoadPlugins(string[] pluginNames)
+        {
+            if (!Directory.Exists(PluginsDirectory)) return;
+            foreach (var rootPath in Directory.GetDirectories(PluginsDirectory))
+            {
+                foreach (var filename in Directory.EnumerateFiles(rootPath, "*.dll", SearchOption.TopDirectoryOnly))
+                {
+                    try
+                    {
+                        if (pluginNames.Contains(GetFileNameWithoutExtension(filename), StringComparer.InvariantCultureIgnoreCase))
+                            LoadPlugin(Assembly.Load(File.ReadAllBytes(filename)));
+                    }
+                    catch { }
+                }
+            }
+        }
+
+        public static void LoadPlugins()
         {
             if (!Directory.Exists(PluginsDirectory)) return;
             List<Assembly> assemblies = new();


### PR DESCRIPTION
# Description
Added a way to allow only selected plugins to be loaded in `neo-cli`; configurable in `config.json` file within `ApplicationConfiguration:Plugins:LoadDlls` section.

```json
    "Plugins": {
      "DownloadUrl": "https://api.github.com/repos/neo-project/neo/releases",
      "LoadDlls": [
        "LevelDbStore"
      ]
    }
```

# Change Log
 - Added configurable way to allow **ONLY** the plugins you want to be loaded.
 - Updated `neo-cli` to allow this new option.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?
Unit tests and locally run app.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
