### PR TITLE
plugins: remove expressions that are always true

### DIFF
--- a/src/Plugins/ApplicationLogs/LogReader.cs
+++ b/src/Plugins/ApplicationLogs/LogReader.cs
@@ -143,7 +143,7 @@ namespace Neo.Plugins.ApplicationLogs
                 _neostore.GetBlockLog(blockhash, TriggerType.PostPersist) :
                 _neostore.GetBlockLog(blockhash, TriggerType.PostPersist, eventName);
 
-            if (blockOnPersist == null && blockOnPersist == null)
+            if (blockOnPersist == null)
                 ConsoleHelper.Error($"No logs.");
             if (blockOnPersist != null)
                 PrintExecutionToConsole(blockOnPersist);

--- a/src/Plugins/ApplicationLogs/LogReader.cs
+++ b/src/Plugins/ApplicationLogs/LogReader.cs
@@ -145,10 +145,9 @@ namespace Neo.Plugins.ApplicationLogs
 
             if (blockOnPersist == null)
                 ConsoleHelper.Error($"No logs.");
-            if (blockOnPersist != null)
-                PrintExecutionToConsole(blockOnPersist);
-            if (blockPostPersist != null)
+            else
             {
+                PrintExecutionToConsole(blockOnPersist);
                 ConsoleHelper.Info("--------------------------------");
                 PrintExecutionToConsole(blockPostPersist);
             }

--- a/src/Plugins/OracleService/OracleService.cs
+++ b/src/Plugins/OracleService/OracleService.cs
@@ -532,7 +532,7 @@ namespace Neo.Plugins.OracleService
             }
             ECPoint[] oraclesNodes = NativeContract.RoleManagement.GetDesignatedByRole(snapshot, Role.Oracle, height);
             int neededThreshold = oraclesNodes.Length - (oraclesNodes.Length - 1) / 3;
-            if (OracleSigns.Count >= neededThreshold && tx != null)
+            if (OracleSigns.Count >= neededThreshold)
             {
                 var contract = Contract.CreateMultiSigContract(neededThreshold, oraclesNodes);
                 ScriptBuilder sb = new ScriptBuilder();


### PR DESCRIPTION
```cs
if (blockOnPersist == null && blockOnPersist == null)
```
It's judged twice here.

```cs
if (tx.ValidUntilBlock <= height)
……
if (OracleSigns.Count >= neededThreshold && tx != null)
```
Here `tx ! = null` is always true, because if tx is null, a null reference exception is recruited directly in front of it