### PR TITLE
Fix crash when comparing ContractPermissionDescriptor

### DIFF
--- a/src/Neo/SmartContract/Manifest/ContractPermissionDescriptor.cs
+++ b/src/Neo/SmartContract/Manifest/ContractPermissionDescriptor.cs
@@ -114,7 +114,8 @@ namespace Neo.SmartContract.Manifest
             if (this == other) return true;
             if (IsWildcard == other.IsWildcard) return true;
             if (IsHash) return Hash.Equals(other.Hash);
-            else return Group.Equals(other.Group);
+            if (IsGroup) return Group.Equals(other.Group);
+            return false;
         }
 
         public override int GetHashCode()

--- a/tests/Neo.UnitTests/SmartContract/Manifest/UT_ContractPermissionDescriptor.cs
+++ b/tests/Neo.UnitTests/SmartContract/Manifest/UT_ContractPermissionDescriptor.cs
@@ -11,6 +11,7 @@
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Neo.SmartContract.Manifest;
+using Neo.SmartContract.Native;
 using Neo.Wallets;
 using System.Security.Cryptography;
 
@@ -43,6 +44,19 @@ namespace Neo.UnitTests.SmartContract.Manifest
             ContractPermissionDescriptor result = ContractPermissionDescriptor.FromJson(temp.ToJson());
             Assert.AreEqual(null, result.Hash);
             Assert.AreEqual(result.Group, result.Group);
+        }
+
+        [TestMethod]
+        public void TestEquals()
+        {
+            var descriptor1 = ContractPermissionDescriptor.CreateWildcard();
+            var descriptor2 = ContractPermissionDescriptor.Create(LedgerContract.NEO.Hash);
+
+            Assert.AreNotEqual(descriptor1, descriptor2);
+
+            var descriptor3 = ContractPermissionDescriptor.Create(LedgerContract.NEO.Hash);
+
+            Assert.AreEqual(descriptor2, descriptor3);
         }
     }
 }


### PR DESCRIPTION
Fix crash when comparing ContractPermissionDescriptor

```cs
var descriptor1 = ContractPermissionDescriptor.CreateWildcard();
var descriptor2 = ContractPermissionDescriptor.Create(LedgerContract.NEO.Hash);
var result = descriptor1.Equals(descriptor2);
```
This code will crash because of the null reference exception