### PR TITLE
[Neo Store Exception] Add exception to `Use after Commit` operation to Snapshots and Cache.

### DIFF
--- a/src/Neo/Persistence/DataCache.cs
+++ b/src/Neo/Persistence/DataCache.cs
@@ -168,7 +168,7 @@ namespace Neo.Persistence
         /// <param name="key">The key of the entry.</param>
         public void Delete(StorageKey key)
         {
-            if (isCommitted) throw new InvalidOperationException("Can not read/write a  committed data cache.");
+            if (isCommitted) throw new InvalidOperationException("Can not read/write a committed data cache.");
             lock (dictionary)
             {
                 if (dictionary.TryGetValue(key, out Trackable trackable))
@@ -213,7 +213,7 @@ namespace Neo.Persistence
         /// <returns>The entries found with the desired prefix.</returns>
         public IEnumerable<(StorageKey Key, StorageItem Value)> Find(byte[] key_prefix = null, SeekDirection direction = SeekDirection.Forward)
         {
-            if (isCommitted) throw new InvalidOperationException("Can not read/write a  committed data cache.");
+            if (isCommitted) throw new InvalidOperationException("Can not read/write a committed data cache.");
 
             var seek_prefix = key_prefix;
             if (direction == SeekDirection.Backward)
@@ -243,7 +243,7 @@ namespace Neo.Persistence
 
         private IEnumerable<(StorageKey Key, StorageItem Value)> FindInternal(byte[] key_prefix, byte[] seek_prefix, SeekDirection direction)
         {
-            if (isCommitted) throw new InvalidOperationException("Can not read/write a  committed data cache.");
+            if (isCommitted) throw new InvalidOperationException("Can not read/write a committed data cache.");
 
             foreach (var (key, value) in Seek(seek_prefix, direction))
                 if (key.ToArray().AsSpan().StartsWith(key_prefix))
@@ -261,7 +261,7 @@ namespace Neo.Persistence
         /// <returns>The entries found with the desired range.</returns>
         public IEnumerable<(StorageKey Key, StorageItem Value)> FindRange(byte[] start, byte[] end, SeekDirection direction = SeekDirection.Forward)
         {
-            if (isCommitted) throw new InvalidOperationException("Can not read/write a  committed data cache.");
+            if (isCommitted) throw new InvalidOperationException("Can not read/write a committed data cache.");
 
             ByteArrayComparer comparer = direction == SeekDirection.Forward
                 ? ByteArrayComparer.Default
@@ -279,7 +279,7 @@ namespace Neo.Persistence
         /// <returns>The change set.</returns>
         public IEnumerable<Trackable> GetChangeSet()
         {
-            if (isCommitted) throw new InvalidOperationException("Can not read/write a  committed data cache.");
+            if (isCommitted) throw new InvalidOperationException("Can not read/write a committed data cache.");
 
             lock (dictionary)
             {
@@ -295,7 +295,7 @@ namespace Neo.Persistence
         /// <returns><see langword="true"/> if the cache contains an entry with the specified key; otherwise, <see langword="false"/>.</returns>
         public bool Contains(StorageKey key)
         {
-            if (isCommitted) throw new InvalidOperationException("Can not read/write a  committed data cache.");
+            if (isCommitted) throw new InvalidOperationException("Can not read/write a committed data cache.");
 
             lock (dictionary)
             {
@@ -327,7 +327,7 @@ namespace Neo.Persistence
         /// <returns>The cached data. Or <see langword="null"/> if it doesn't exist and the <paramref name="factory"/> is not provided.</returns>
         public StorageItem GetAndChange(StorageKey key, Func<StorageItem> factory = null)
         {
-            if (isCommitted) throw new InvalidOperationException("Can not read/write a  committed data cache.");
+            if (isCommitted) throw new InvalidOperationException("Can not read/write a committed data cache.");
 
             lock (dictionary)
             {
@@ -385,7 +385,7 @@ namespace Neo.Persistence
         /// <returns>The cached data.</returns>
         public StorageItem GetOrAdd(StorageKey key, Func<StorageItem> factory)
         {
-            if (isCommitted) throw new InvalidOperationException("Can not read/write a  committed data cache.");
+            if (isCommitted) throw new InvalidOperationException("Can not read/write a committed data cache.");
 
             lock (dictionary)
             {
@@ -436,7 +436,7 @@ namespace Neo.Persistence
         /// <returns>An enumerator containing all the entries after seeking.</returns>
         public IEnumerable<(StorageKey Key, StorageItem Value)> Seek(byte[] keyOrPrefix = null, SeekDirection direction = SeekDirection.Forward)
         {
-            if (isCommitted) throw new InvalidOperationException("Can not read/write a  committed data cache.");
+            if (isCommitted) throw new InvalidOperationException("Can not read/write a committed data cache.");
 
             IEnumerable<(byte[], StorageKey, StorageItem)> cached;
             HashSet<StorageKey> cachedKeySet;
@@ -502,7 +502,7 @@ namespace Neo.Persistence
         /// <returns>The cached data. Or <see langword="null"/> if it is neither in the cache nor in the underlying storage.</returns>
         public StorageItem TryGet(StorageKey key)
         {
-            if (isCommitted) throw new InvalidOperationException("Can not read/write a  committed data cache.");
+            if (isCommitted) throw new InvalidOperationException("Can not read/write a committed data cache.");
 
             lock (dictionary)
             {

--- a/src/Neo/Persistence/SnapshotCache.cs
+++ b/src/Neo/Persistence/SnapshotCache.cs
@@ -37,11 +37,15 @@ namespace Neo.Persistence
 
         protected override void AddInternal(StorageKey key, StorageItem value)
         {
+            if (isCommitted) throw new InvalidOperationException("Can not read/write a  committed data cache.");
+
             snapshot?.Put(key.ToArray(), value.ToArray());
         }
 
         protected override void DeleteInternal(StorageKey key)
         {
+            if (isCommitted) throw new InvalidOperationException("Can not read/write a  committed data cache.");
+
             snapshot?.Delete(key.ToArray());
         }
 
@@ -53,16 +57,22 @@ namespace Neo.Persistence
 
         protected override bool ContainsInternal(StorageKey key)
         {
+            if (isCommitted) throw new InvalidOperationException("Can not read/write a  committed data cache.");
+
             return store.Contains(key.ToArray());
         }
 
         public void Dispose()
         {
+            if (isCommitted) throw new InvalidOperationException("Can not read/write a  committed data cache.");
+
             snapshot?.Dispose();
         }
 
         protected override StorageItem GetInternal(StorageKey key)
         {
+            if (isCommitted) throw new InvalidOperationException("Can not read/write a  committed data cache.");
+
             byte[] value = store.TryGet(key.ToArray());
             if (value == null) throw new KeyNotFoundException();
             return new(value);
@@ -70,11 +80,15 @@ namespace Neo.Persistence
 
         protected override IEnumerable<(StorageKey, StorageItem)> SeekInternal(byte[] keyOrPrefix, SeekDirection direction)
         {
+            if (isCommitted) throw new InvalidOperationException("Can not read/write a  committed data cache.");
+
             return store.Seek(keyOrPrefix, direction).Select(p => (new StorageKey(p.Key), new StorageItem(p.Value)));
         }
 
         protected override StorageItem TryGetInternal(StorageKey key)
         {
+            if (isCommitted) throw new InvalidOperationException("Can not read/write a  committed data cache.");
+
             byte[] value = store.TryGet(key.ToArray());
             if (value == null) return null;
             return new(value);
@@ -82,6 +96,8 @@ namespace Neo.Persistence
 
         protected override void UpdateInternal(StorageKey key, StorageItem value)
         {
+            if (isCommitted) throw new InvalidOperationException("Can not read/write a  committed data cache.");
+
             snapshot?.Put(key.ToArray(), value.ToArray());
         }
     }

--- a/src/Neo/Persistence/SnapshotCache.cs
+++ b/src/Neo/Persistence/SnapshotCache.cs
@@ -37,14 +37,14 @@ namespace Neo.Persistence
 
         protected override void AddInternal(StorageKey key, StorageItem value)
         {
-            if (isCommitted) throw new InvalidOperationException("Can not read/write a  committed data cache.");
+            if (isCommitted) throw new InvalidOperationException("Can not read/write a committed data cache.");
 
             snapshot?.Put(key.ToArray(), value.ToArray());
         }
 
         protected override void DeleteInternal(StorageKey key)
         {
-            if (isCommitted) throw new InvalidOperationException("Can not read/write a  committed data cache.");
+            if (isCommitted) throw new InvalidOperationException("Can not read/write a committed data cache.");
 
             snapshot?.Delete(key.ToArray());
         }
@@ -57,21 +57,21 @@ namespace Neo.Persistence
 
         protected override bool ContainsInternal(StorageKey key)
         {
-            if (isCommitted) throw new InvalidOperationException("Can not read/write a  committed data cache.");
+            if (isCommitted) throw new InvalidOperationException("Can not read/write a committed data cache.");
 
             return store.Contains(key.ToArray());
         }
 
         public void Dispose()
         {
-            if (isCommitted) throw new InvalidOperationException("Can not read/write a  committed data cache.");
+            if (isCommitted) throw new InvalidOperationException("Can not read/write a committed data cache.");
 
             snapshot?.Dispose();
         }
 
         protected override StorageItem GetInternal(StorageKey key)
         {
-            if (isCommitted) throw new InvalidOperationException("Can not read/write a  committed data cache.");
+            if (isCommitted) throw new InvalidOperationException("Can not read/write a committed data cache.");
 
             byte[] value = store.TryGet(key.ToArray());
             if (value == null) throw new KeyNotFoundException();
@@ -87,7 +87,7 @@ namespace Neo.Persistence
 
         protected override StorageItem TryGetInternal(StorageKey key)
         {
-            if (isCommitted) throw new InvalidOperationException("Can not read/write a  committed data cache.");
+            if (isCommitted) throw new InvalidOperationException("Can not read/write a committed data cache.");
 
             byte[] value = store.TryGet(key.ToArray());
             if (value == null) return null;
@@ -96,7 +96,7 @@ namespace Neo.Persistence
 
         protected override void UpdateInternal(StorageKey key, StorageItem value)
         {
-            if (isCommitted) throw new InvalidOperationException("Can not read/write a  committed data cache.");
+            if (isCommitted) throw new InvalidOperationException("Can not read/write a committed data cache.");
 
             snapshot?.Put(key.ToArray(), value.ToArray());
         }

--- a/tests/Neo.Cryptography.MPTTrie.Tests/Cryptography/MPTTrie/UT_Trie.cs
+++ b/tests/Neo.Cryptography.MPTTrie.Tests/Cryptography/MPTTrie/UT_Trie.cs
@@ -170,9 +170,9 @@ namespace Neo.Cryptography.MPTTrie.Tests
             var snapshot2 = store.GetSnapshot();
             var mpt2 = new Trie(snapshot2, mpt1.Root.Hash);
             Assert.IsTrue(mpt2.Delete("ac00".HexToBytes()));
+            Assert.IsTrue(mpt2.Delete("ac10".HexToBytes()));
             mpt2.Commit();
             snapshot2.Commit();
-            Assert.IsTrue(mpt2.Delete("ac10".HexToBytes()));
         }
 
         [TestMethod]


### PR DESCRIPTION
# Description

Store snapshot and datacache are not supposed to be used after they are commited since there will be data inconsistancy and very hard to figure out the exact value. Thus we need to ban any attacmpt of using the snapshot or data cache after they are committed. 

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

**Test Configuration**:


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
