### PR TITLE
Neo.CLI: update MaxTraceableBlocks setting for NeoFS networks

### DIFF
--- a/src/Neo.CLI/config.fs.mainnet.json
+++ b/src/Neo.CLI/config.fs.mainnet.json
@@ -33,7 +33,7 @@
     "MillisecondsPerBlock": 15000,
     "MaxTransactionsPerBlock": 512,
     "MemoryPoolMaxTransactions": 50000,
-    "MaxTraceableBlocks": 2102400,
+    "MaxTraceableBlocks": 17280,
     "InitialGasDistribution": 5200000000000000,
     "ValidatorsCount": 7,
     "Hardforks": {

--- a/src/Neo.CLI/config.fs.testnet.json
+++ b/src/Neo.CLI/config.fs.testnet.json
@@ -33,7 +33,7 @@
     "MillisecondsPerBlock": 15000,
     "MaxTransactionsPerBlock": 512,
     "MemoryPoolMaxTransactions": 50000,
-    "MaxTraceableBlocks": 2102400,
+    "MaxTraceableBlocks": 17280,
     "InitialGasDistribution": 5200000000000000,
     "ValidatorsCount": 7,
     "StandbyCommittee": [


### PR DESCRIPTION
# Description

We don't need long tails for NeoFS networks, 3 days is enough for now. It's checked that this change does not affect the network states.

Port https://github.com/nspcc-dev/neo-go/pull/3518.

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Configuration change

# How Has This Been Tested?

- [X] Tested via https://github.com/nspcc-dev/neo-go/issues/3493.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
