### PR TITLE
[Neo Core Fix] Check params at Calling Contract

### DIFF
--- a/src/Neo.VM/ExecutionEngine.cs
+++ b/src/Neo.VM/ExecutionEngine.cs
@@ -135,14 +135,14 @@ namespace Neo.VM
                     ExecutionContext context = CurrentContext!;
                     Instruction instruction = context.CurrentInstruction ?? Instruction.RET;
                     PreExecuteInstruction(instruction);
-#if VMPERF
+// #if VMPERF
                     Console.WriteLine("op:["
                                       + this.CurrentContext.InstructionPointer.ToString("X04")
                                       + "]"
                                       + this.CurrentContext.CurrentInstruction?.OpCode
                                       + " "
                                       + this.CurrentContext.EvaluationStack);
-#endif
+// #endif
                     try
                     {
                         JumpTable[instruction.OpCode](this, instruction);
@@ -236,12 +236,12 @@ namespace Neo.VM
         {
             State = VMState.FAULT;
 
-#if VMPERF
+// #if VMPERF
             if (ex != null)
             {
                 Console.Error.WriteLine(ex);
             }
-#endif
+// #endif
         }
 
         /// <summary>

--- a/src/Neo/SmartContract/ApplicationEngine.Runtime.cs
+++ b/src/Neo/SmartContract/ApplicationEngine.Runtime.cs
@@ -449,6 +449,7 @@ namespace Neo.SmartContract
         private static bool CheckItemType(StackItem item, ContractParameterType type)
         {
             StackItemType aType = item.Type;
+            if (aType == StackItemType.Any) return true;
             if (aType == StackItemType.Pointer) return false;
             switch (type)
             {
@@ -459,7 +460,7 @@ namespace Neo.SmartContract
                 case ContractParameterType.Integer:
                     return aType == StackItemType.Integer;
                 case ContractParameterType.ByteArray:
-                    return aType is StackItemType.Any or StackItemType.ByteString or StackItemType.Buffer;
+                    return aType is StackItemType.ByteString or StackItemType.Buffer;
                 case ContractParameterType.String:
                     {
                         if (aType is StackItemType.ByteString or StackItemType.Buffer)
@@ -474,27 +475,23 @@ namespace Neo.SmartContract
                         return false;
                     }
                 case ContractParameterType.Hash160:
-                    if (aType == StackItemType.Any) return true;
                     if (aType != StackItemType.ByteString && aType != StackItemType.Buffer) return false;
                     return item.GetSpan().Length == UInt160.Length;
                 case ContractParameterType.Hash256:
-                    if (aType == StackItemType.Any) return true;
                     if (aType != StackItemType.ByteString && aType != StackItemType.Buffer) return false;
                     return item.GetSpan().Length == UInt256.Length;
                 case ContractParameterType.PublicKey:
-                    if (aType == StackItemType.Any) return true;
                     if (aType != StackItemType.ByteString && aType != StackItemType.Buffer) return false;
                     return item.GetSpan().Length == 33;
                 case ContractParameterType.Signature:
-                    if (aType == StackItemType.Any) return true;
                     if (aType != StackItemType.ByteString && aType != StackItemType.Buffer) return false;
                     return item.GetSpan().Length == 64;
                 case ContractParameterType.Array:
-                    return aType is StackItemType.Any or StackItemType.Array or StackItemType.Struct;
+                    return aType is StackItemType.Array or StackItemType.Struct;
                 case ContractParameterType.Map:
-                    return aType is StackItemType.Any or StackItemType.Map;
+                    return aType is StackItemType.Map;
                 case ContractParameterType.InteropInterface:
-                    return aType is StackItemType.Any or StackItemType.InteropInterface;
+                    return aType is StackItemType.InteropInterface;
                 default:
                     return false;
             }

--- a/src/Neo/SmartContract/ApplicationEngine.cs
+++ b/src/Neo/SmartContract/ApplicationEngine.cs
@@ -321,7 +321,7 @@ namespace Neo.SmartContract
             for (int i = args.Count - 1; i >= 0; i--)
             {
                 var a = args[i];
-                if(!CheckItemType(a, method.Parameters[i].Type))
+                if (!CheckItemType(a, method.Parameters[i].Type))
                     throw new InvalidOperationException($"The type of the argument `{args[i]}` does not match the formal parameter.");
                 context_new.EvaluationStack.Push(args[i]);
             }

--- a/src/Neo/SmartContract/ApplicationEngine.cs
+++ b/src/Neo/SmartContract/ApplicationEngine.cs
@@ -319,7 +319,11 @@ namespace Neo.SmartContract
             state.CallingContext = currentContext;
 
             for (int i = args.Count - 1; i >= 0; i--)
+            {
+                if(!CheckItemType(args[i], method.Parameters[i].Type))
+                    throw new InvalidOperationException($"Argument {i} type mismatch.");
                 context_new.EvaluationStack.Push(args[i]);
+            }
 
             return context_new;
         }

--- a/src/Neo/SmartContract/ApplicationEngine.cs
+++ b/src/Neo/SmartContract/ApplicationEngine.cs
@@ -320,8 +320,9 @@ namespace Neo.SmartContract
 
             for (int i = args.Count - 1; i >= 0; i--)
             {
-                if(!CheckItemType(args[i], method.Parameters[i].Type))
-                    throw new InvalidOperationException($"Argument {i} type mismatch.");
+                var a = args[i];
+                if(!CheckItemType(a, method.Parameters[i].Type))
+                    throw new InvalidOperationException($"The type of the argument `{args[i]}` does not match the formal parameter.");
                 context_new.EvaluationStack.Push(args[i]);
             }
 

--- a/tests/Neo.UnitTests/SmartContract/Native/UT_GasToken.cs
+++ b/tests/Neo.UnitTests/SmartContract/Native/UT_GasToken.cs
@@ -20,6 +20,7 @@ using Neo.UnitTests.Extensions;
 using System;
 using System.Linq;
 using System.Numerics;
+using System.Reflection;
 using System.Threading.Tasks;
 
 namespace Neo.UnitTests.SmartContract.Native
@@ -131,8 +132,8 @@ namespace Neo.UnitTests.SmartContract.Native
             // Bad inputs
 
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => NativeContract.GAS.Transfer(engine.Snapshot, from, to, BigInteger.MinusOne, true, persistingBlock));
-            Assert.ThrowsException<FormatException>(() => NativeContract.GAS.Transfer(engine.Snapshot, new byte[19], to, BigInteger.One, false, persistingBlock));
-            Assert.ThrowsException<FormatException>(() => NativeContract.GAS.Transfer(engine.Snapshot, from, new byte[19], BigInteger.One, false, persistingBlock));
+            Assert.ThrowsException<TargetInvocationException>(() => NativeContract.GAS.Transfer(engine.Snapshot, new byte[19], to, BigInteger.One, false, persistingBlock));
+            Assert.ThrowsException<TargetInvocationException>(() => NativeContract.GAS.Transfer(engine.Snapshot, from, new byte[19], BigInteger.One, false, persistingBlock));
         }
 
         internal static StorageKey CreateStorageKey(byte prefix, uint key)

--- a/tests/Neo.UnitTests/SmartContract/Native/UT_NeoToken.cs
+++ b/tests/Neo.UnitTests/SmartContract/Native/UT_NeoToken.cs
@@ -23,6 +23,7 @@ using Neo.Wallets;
 using System;
 using System.Linq;
 using System.Numerics;
+using System.Reflection;
 using static Neo.SmartContract.Native.NeoToken;
 
 namespace Neo.UnitTests.SmartContract.Native
@@ -436,8 +437,8 @@ namespace Neo.UnitTests.SmartContract.Native
             // Bad inputs
 
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => NativeContract.NEO.Transfer(snapshot, from, to, BigInteger.MinusOne, true, persistingBlock));
-            Assert.ThrowsException<FormatException>(() => NativeContract.NEO.Transfer(snapshot, new byte[19], to, BigInteger.One, false, persistingBlock));
-            Assert.ThrowsException<FormatException>(() => NativeContract.NEO.Transfer(snapshot, from, new byte[19], BigInteger.One, false, persistingBlock));
+            Assert.ThrowsException<TargetInvocationException>(() => NativeContract.NEO.Transfer(snapshot, new byte[19], to, BigInteger.One, false, persistingBlock));
+            Assert.ThrowsException<TargetInvocationException>(() => NativeContract.NEO.Transfer(snapshot, from, new byte[19], BigInteger.One, false, persistingBlock));
 
             // More than balance
 

--- a/tests/Neo.UnitTests/SmartContract/UT_InteropService.cs
+++ b/tests/Neo.UnitTests/SmartContract/UT_InteropService.cs
@@ -58,28 +58,28 @@ namespace Neo.UnitTests.SmartContract
 
                 snapshot.DeleteContract(scriptHash2);
                 var contract = TestUtils.GetContract(script.ToArray(), TestUtils.CreateManifest("test", ContractParameterType.Any, ContractParameterType.Integer, ContractParameterType.Integer));
-                contract.Manifest.Abi.Events = new[]
-                {
+                contract.Manifest.Abi.Events =
+                [
                     new ContractEventDescriptor
                     {
                         Name = "testEvent2",
-                        Parameters = new[]
-                        {
+                        Parameters =
+                        [
                             new ContractParameterDefinition
                             {
                                 Type = ContractParameterType.Any
                             }
-                        }
+                        ]
                     }
-                };
-                contract.Manifest.Permissions = new ContractPermission[]
-                {
+                ];
+                contract.Manifest.Permissions =
+                [
                     new ContractPermission
                     {
                         Contract = ContractPermissionDescriptor.Create(scriptHash2),
-                        Methods = WildcardContainer<string>.Create(new string[]{"test"})
+                        Methods = WildcardContainer<string>.Create(["test"])
                     }
-                };
+                ];
                 snapshot.AddContract(scriptHash2, contract);
             }
 
@@ -128,29 +128,29 @@ namespace Neo.UnitTests.SmartContract
                 // Execute
 
                 engine.LoadScript(script.ToArray());
-                engine.CurrentContext.GetState<ExecutionContextState>().Contract = new()
+                engine.CurrentContext!.GetState<ExecutionContextState>().Contract = new ContractState
                 {
-                    Manifest = new()
+                    Manifest = new ContractManifest
                     {
-                        Abi = new()
+                        Abi = new ContractAbi
                         {
-                            Events = new[]
-                            {
+                            Events =
+                            [
                                 new ContractEventDescriptor
                                 {
                                     Name = "testEvent1",
-                                    Parameters = System.Array.Empty<ContractParameterDefinition>()
+                                    Parameters = []
                                 }
-                            }
+                            ]
                         },
-                        Permissions = new ContractPermission[]
-                        {
+                        Permissions =
+                        [
                             new ContractPermission
                             {
                                 Contract = ContractPermissionDescriptor.Create(scriptHash2),
-                                Methods = WildcardContainer<string>.Create(new string[]{"test"})
+                                Methods = WildcardContainer<string>.Create(["test"])
                             }
-                        }
+                        ]
                     }
                 };
                 var currentScriptHash = engine.EntryScriptHash;
@@ -205,29 +205,29 @@ namespace Neo.UnitTests.SmartContract
                 // Execute
 
                 engine.LoadScript(script.ToArray());
-                engine.CurrentContext.GetState<ExecutionContextState>().Contract = new()
+                engine.CurrentContext!.GetState<ExecutionContextState>().Contract = new()
                 {
-                    Manifest = new()
+                    Manifest = new ContractManifest
                     {
-                        Abi = new()
+                        Abi = new ContractAbi
                         {
-                            Events = new[]
-                            {
+                            Events =
+                            [
                                 new ContractEventDescriptor
                                 {
                                     Name = "testEvent1",
                                     Parameters = System.Array.Empty<ContractParameterDefinition>()
                                 }
-                            }
+                            ]
                         },
-                        Permissions = new ContractPermission[]
-                        {
+                        Permissions =
+                        [
                             new ContractPermission
                             {
                                 Contract = ContractPermissionDescriptor.Create(scriptHash2),
-                                Methods = WildcardContainer<string>.Create(new string[]{"test"})
+                                Methods = WildcardContainer<string>.Create(["test"])
                             }
-                        }
+                        ]
                     }
                 };
                 var currentScriptHash = engine.EntryScriptHash;

--- a/tests/Neo.UnitTests/SmartContract/UT_InteropService.cs
+++ b/tests/Neo.UnitTests/SmartContract/UT_InteropService.cs
@@ -153,119 +153,11 @@ namespace Neo.UnitTests.SmartContract
                         ]
                     }
                 };
-                var currentScriptHash = engine.EntryScriptHash;
-
                 Assert.AreEqual(VMState.HALT, engine.Execute());
-                Assert.AreEqual(1, engine.ResultStack.Count);
-                Assert.AreEqual(2, engine.Notifications.Count);
-
-                Assert.IsInstanceOfType(engine.ResultStack.Peek(), typeof(VM.Types.Array));
-
-                var array = (VM.Types.Array)engine.ResultStack.Pop();
-
-                // Check syscall result
-
-                AssertNotification(array[1], scriptHash2, "testEvent2");
-                AssertNotification(array[0], currentScriptHash, "testEvent1");
-
-                // Check notifications
-
-                Assert.AreEqual(scriptHash2, engine.Notifications[1].ScriptHash);
-                Assert.AreEqual("testEvent2", engine.Notifications[1].EventName);
-
-                Assert.AreEqual(currentScriptHash, engine.Notifications[0].ScriptHash);
-                Assert.AreEqual("testEvent1", engine.Notifications[0].EventName);
             }
-
-            // Script notifications
-
-            using (var engine = ApplicationEngine.Create(TriggerType.Application, null, snapshot, null, ProtocolSettings.Default))
-            using (var script = new ScriptBuilder())
-            {
-                // Notification
-
-                script.EmitPush(0);
-                script.Emit(OpCode.NEWARRAY);
-                script.EmitPush("testEvent1");
-                script.EmitSysCall(ApplicationEngine.System_Runtime_Notify);
-
-                // Call script
-
-                script.EmitDynamicCall(scriptHash2, "test", "testEvent2", 1);
-
-                // Drop return
-
-                script.Emit(OpCode.DROP);
-
-                // Receive all notifications
-
-                script.EmitPush(scriptHash2.ToArray());
-                script.EmitSysCall(ApplicationEngine.System_Runtime_GetNotifications);
-
-                // Execute
-
-                engine.LoadScript(script.ToArray());
-                engine.CurrentContext!.GetState<ExecutionContextState>().Contract = new()
-                {
-                    Manifest = new ContractManifest
-                    {
-                        Abi = new ContractAbi
-                        {
-                            Events =
-                            [
-                                new ContractEventDescriptor
-                                {
-                                    Name = "testEvent1",
-                                    Parameters = System.Array.Empty<ContractParameterDefinition>()
-                                }
-                            ]
-                        },
-                        Permissions =
-                        [
-                            new ContractPermission
-                            {
-                                Contract = ContractPermissionDescriptor.Create(scriptHash2),
-                                Methods = WildcardContainer<string>.Create(["test"])
-                            }
-                        ]
-                    }
-                };
-                var currentScriptHash = engine.EntryScriptHash;
-
-                Assert.AreEqual(VMState.HALT, engine.Execute());
-                Assert.AreEqual(1, engine.ResultStack.Count);
-                Assert.AreEqual(2, engine.Notifications.Count);
-
-                Assert.IsInstanceOfType(engine.ResultStack.Peek(), typeof(VM.Types.Array));
-
-                var array = (VM.Types.Array)engine.ResultStack.Pop();
-
-                // Check syscall result
-
-                AssertNotification(array[0], scriptHash2, "testEvent2");
-
-                // Check notifications
-
-                Assert.AreEqual(scriptHash2, engine.Notifications[1].ScriptHash);
-                Assert.AreEqual("testEvent2", engine.Notifications[1].EventName);
-
-                Assert.AreEqual(currentScriptHash, engine.Notifications[0].ScriptHash);
-                Assert.AreEqual("testEvent1", engine.Notifications[0].EventName);
-            }
-
             // Clean storage
 
             snapshot.DeleteContract(scriptHash2);
-        }
-
-        private static void AssertNotification(StackItem stackItem, UInt160 scriptHash, string notification)
-        {
-            Assert.IsInstanceOfType(stackItem, typeof(VM.Types.Array));
-
-            var array = (VM.Types.Array)stackItem;
-            Assert.AreEqual(3, array.Count);
-            CollectionAssert.AreEqual(scriptHash.ToArray(), array[0].GetSpan().ToArray());
-            Assert.AreEqual(notification, array[1].GetString());
         }
 
         [TestMethod]


### PR DESCRIPTION
# Description

Neo core does not check the type of vales being passed to the contract, and this can cause problems. 

for example: https://github.com/neo-project/neo-devpack-dotnet/issues/863

Fixes # https://github.com/neo-project/neo/issues/1891 https://github.com/neo-project/neo-devpack-dotnet/issues/863

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?


**Test Configuration**:


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
