### PR TITLE
[rpc] Extend `getversion` RPC response with additional protocol settings

### DIFF
--- a/src/Plugins/RpcClient/Models/RpcVersion.cs
+++ b/src/Plugins/RpcClient/Models/RpcVersion.cs
@@ -9,6 +9,7 @@
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
+using Neo.Cryptography.ECC;
 using Neo.Json;
 using System;
 using System.Collections.Generic;
@@ -30,6 +31,8 @@ namespace Neo.Network.RPC.Models
             public int MemoryPoolMaxTransactions { get; set; }
             public ulong InitialGasDistribution { get; set; }
             public IReadOnlyDictionary<Hardfork, uint> Hardforks { get; set; }
+            public IReadOnlyList<string> SeedList { get; set; }
+            public IReadOnlyList<ECPoint> StandbyCommittee { get; set; }
 
             public JObject ToJson()
             {
@@ -49,6 +52,8 @@ namespace Neo.Network.RPC.Models
                     ["name"] = StripPrefix(s.Key.ToString(), "HF_"),
                     ["blockheight"] = s.Value,
                 }));
+                json["standbycommittee"] = new JArray(StandbyCommittee.Select(u => new JString(u.ToString())));
+                json["seedlist"] = new JArray(SeedList.Select(u => new JString(u)));
                 return json;
             }
 
@@ -71,6 +76,14 @@ namespace Neo.Network.RPC.Models
                         // Add HF_ prefix to the hardfork response for proper Hardfork enum parsing.
                         return new KeyValuePair<Hardfork, uint>(Enum.Parse<Hardfork>(name.StartsWith("HF_") ? name : $"HF_{name}"), (uint)s["blockheight"].AsNumber());
                     })),
+                    SeedList = new List<string>(((JArray)json["seedlist"]).Select(s =>
+                    {
+                        return s.AsString();
+                    })),
+                    StandbyCommittee = new List<ECPoint>(((JArray)json["standbycommittee"]).Select(s =>
+                    {
+                        return ECPoint.Parse(s.AsString(), ECCurve.Secp256r1);
+                    }))
                 };
             }
 

--- a/src/Plugins/RpcServer/RpcServer.Node.cs
+++ b/src/Plugins/RpcServer/RpcServer.Node.cs
@@ -139,6 +139,8 @@ namespace Neo.Plugins.RpcServer
                 forkJson["blockheight"] = hf.Value;
                 return forkJson;
             }));
+            protocol["standbycommittee"] = new JArray(system.Settings.StandbyCommittee.Select(u => new JString(u.ToString())));
+            protocol["seedlist"] = new JArray(system.Settings.SeedList.Select(u => new JString(u)));
             json["rpc"] = rpc;
             json["protocol"] = protocol;
             return json;

--- a/tests/Neo.Network.RPC.Tests/RpcTestCases.json
+++ b/tests/Neo.Network.RPC.Tests/RpcTestCases.json
@@ -2496,6 +2496,36 @@
               "name": "Aspidochelone",
               "blockheight": 0
             }
+          ],
+          "standbycommittee": [
+            "03b209fd4f53a7170ea4444e0cb0a6bb6a53c2bd016926989cf85f9b0fba17a70c",
+            "02df48f60e8f3e01c48ff40b9b7f1310d7a8b2a193188befe1c2e3df740e895093",
+            "03b8d9d5771d8f513aa0869b9cc8d50986403b78c6da36890638c3d46a5adce04a",
+            "02ca0e27697b9c248f6f16e085fd0061e26f44da85b58ee835c110caa5ec3ba554",
+            "024c7b7fb6c310fccf1ba33b082519d82964ea93868d676662d4a59ad548df0e7d",
+            "02aaec38470f6aad0042c6e877cfd8087d2676b0f516fddd362801b9bd3936399e",
+            "02486fd15702c4490a26703112a5cc1d0923fd697a33406bd5a1c00e0013b09a70",
+            "023a36c72844610b4d34d1968662424011bf783ca9d984efa19a20babf5582f3fe",
+            "03708b860c1de5d87f5b151a12c2a99feebd2e8b315ee8e7cf8aa19692a9e18379",
+            "03c6aa6e12638b36e88adc1ccdceac4db9929575c3e03576c617c49cce7114a050",
+            "03204223f8c86b8cd5c89ef12e4f0dbb314172e9241e30c9ef2293790793537cf0",
+            "02a62c915cf19c7f19a50ec217e79fac2439bbaad658493de0c7d8ffa92ab0aa62",
+            "03409f31f0d66bdc2f70a9730b66fe186658f84a8018204db01c106edc36553cd0",
+            "0288342b141c30dc8ffcde0204929bb46aed5756b41ef4a56778d15ada8f0c6654",
+            "020f2887f41474cfeb11fd262e982051c1541418137c02a0f4961af911045de639",
+            "0222038884bbd1d8ff109ed3bdef3542e768eef76c1247aea8bc8171f532928c30",
+            "03d281b42002647f0113f36c7b8efb30db66078dfaaa9ab3ff76d043a98d512fde",
+            "02504acbc1f4b3bdad1d86d6e1a08603771db135a73e61c9d565ae06a1938cd2ad",
+            "0226933336f1b75baa42d42b71d9091508b638046d19abd67f4e119bf64a7cfb4d",
+            "03cdcea66032b82f5c30450e381e5295cae85c5e6943af716cc6b646352a6067dc",
+            "02cd5a5547119e24feaa7c2a0f37b8c9366216bab7054de0065c9be42084003c8a"
+          ],
+          "seedlist": [
+            "seed1.neo.org:10333",
+            "seed2.neo.org:10333",
+            "seed3.neo.org:10333",
+            "seed4.neo.org:10333",
+            "seed5.neo.org:10333"
           ]
         }
       }

--- a/tests/Neo.Plugins.RpcServer.Tests/UT_RpcServer.Node.cs
+++ b/tests/Neo.Plugins.RpcServer.Tests/UT_RpcServer.Node.cs
@@ -42,6 +42,8 @@ namespace Neo.Plugins.RpcServer.Tests
             Assert.IsTrue(protocol.ContainsProperty("maxvaliduntilblockincrement"));
             Assert.IsTrue(protocol.ContainsProperty("maxtransactionsperblock"));
             Assert.IsTrue(protocol.ContainsProperty("memorypoolmaxtransactions"));
+            Assert.IsTrue(protocol.ContainsProperty("standbycommittee"));
+            Assert.IsTrue(protocol.ContainsProperty("seedlist"));
         }
 
         #region SendRawTransaction Tests


### PR DESCRIPTION
# Description

Fix https://github.com/neo-project/neo/issues/3401

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] UT_RpcServer.TestGetVersion

**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
