### PR TITLE
[`dbft`] Prevent Store Creation

### DIFF
--- a/src/Plugins/DBFTPlugin/Consensus/ConsensusContext.cs
+++ b/src/Plugins/DBFTPlugin/Consensus/ConsensusContext.cs
@@ -116,7 +116,9 @@ namespace Neo.Plugins.DBFTPlugin.Consensus
             this.wallet = wallet;
             this.neoSystem = neoSystem;
             dbftSettings = settings;
-            store = neoSystem.LoadStore(settings.RecoveryLogs);
+
+            if (dbftSettings.IgnoreRecoveryLogs == false)
+                store = neoSystem.LoadStore(settings.RecoveryLogs);
         }
 
         public Block CreateBlock()
@@ -168,7 +170,7 @@ namespace Neo.Plugins.DBFTPlugin.Consensus
 
         public bool Load()
         {
-            byte[] data = store.TryGet(ConsensusStateKey);
+            byte[] data = store?.TryGet(ConsensusStateKey);
             if (data is null || data.Length == 0) return false;
             MemoryReader reader = new(data);
             try
@@ -272,7 +274,7 @@ namespace Neo.Plugins.DBFTPlugin.Consensus
 
         public void Save()
         {
-            store.PutSync(ConsensusStateKey, this.ToArray());
+            store?.PutSync(ConsensusStateKey, this.ToArray());
         }
 
         public void Deserialize(ref MemoryReader reader)


### PR DESCRIPTION
# Description
This PR prevents the directory and an empty store from being created when `IgnoreRecoveryLogs` is set to `true`.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Unit tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
