### PR TITLE
[fixedbug] RpcServer findstorage

### DIFF
--- a/src/Plugins/RpcServer/RpcServer.Blockchain.cs
+++ b/src/Plugins/RpcServer/RpcServer.Blockchain.cs
@@ -285,7 +285,8 @@ namespace Neo.Plugins.RpcServer
             byte[] prefix = Result.Ok_Or(() => Convert.FromBase64String(_params[1].AsString()), RpcError.InvalidParams.WithData($"Invalid Base64 string{_params[1]}"));
             byte[] prefix_key = StorageKey.CreateSearchPrefix(id, prefix);
 
-            if (!int.TryParse(_params[2].AsString(), out int start))
+            int start = 0;
+            if (_params.Count > 2 && !int.TryParse(_params[2].AsString(), out start))
             {
                 start = 0;
             }


### PR DESCRIPTION
Fix a bug that crashes when the findstorage method is called without an optional parameter (start index).

before 
![image](https://github.com/user-attachments/assets/a77f54f2-9503-4f0e-aaeb-629fa02aac75)

after
![image](https://github.com/user-attachments/assets/078d5523-17e6-4c52-8890-c23f8f5ccfa7)
