### PR TITLE
Adding validation of the count of parameters in JSON RPC

### DIFF
--- a/src/Plugins/ApplicationLogs/LogReader.cs
+++ b/src/Plugins/ApplicationLogs/LogReader.cs
@@ -90,8 +90,7 @@ namespace Neo.Plugins.ApplicationLogs
         [RpcMethod]
         public JToken GetApplicationLog(JArray _params)
         {
-            if (_params == null || _params.Count == 0)
-                throw new RpcException(RpcError.InvalidParams);
+            Result.True_Or(_params.Count == 1 || _params.Count == 2, RpcError.InvalidParams.WithData("Invalid params, need a txid, a trigger type(optional)."));
             if (UInt256.TryParse(_params[0].AsString(), out var hash))
             {
                 var raw = BlockToJObject(hash);

--- a/src/Plugins/RpcServer/RpcServer.Blockchain.cs
+++ b/src/Plugins/RpcServer/RpcServer.Blockchain.cs
@@ -48,6 +48,7 @@ namespace Neo.Plugins.RpcServer
         [RpcMethod]
         protected internal virtual JToken GetBlock(JArray _params)
         {
+            Result.True_Or(_params.Count == 1 || _params.Count == 2, RpcError.InvalidParams.WithData("Invalid params, need a block hash string or block index, a verbose(optional)."));
             JToken key = Result.Ok_Or(() => _params[0], RpcError.InvalidParams.WithData($"Invalid Block Hash or Index: {_params[0]}"));
             bool verbose = _params.Count >= 2 && _params[1].AsBoolean();
             using var snapshot = system.GetSnapshotCache();
@@ -274,6 +275,7 @@ namespace Neo.Plugins.RpcServer
         [RpcMethod]
         protected internal virtual JToken FindStorage(JArray _params)
         {
+            Result.True_Or(_params.Count >= 2 || _params.Count <= 3, RpcError.InvalidParams.WithData("Invalid params, need a script hash / contract id / native contract name, a base64-encoded storage key prefix, a start index(optional)."));
             using var snapshot = system.GetSnapshotCache();
             if (!int.TryParse(_params[0].AsString(), out int id))
             {

--- a/src/Plugins/RpcServer/RpcServer.Blockchain.cs
+++ b/src/Plugins/RpcServer/RpcServer.Blockchain.cs
@@ -33,6 +33,7 @@ namespace Neo.Plugins.RpcServer
         [RpcMethod]
         protected internal virtual JToken GetBestBlockHash(JArray _params)
         {
+            Result.True_Or(_params.Count == 0, RpcError.InvalidParams.WithData("No parameters required."));
             return NativeContract.Ledger.CurrentHash(system.StoreView).ToString();
         }
 
@@ -84,6 +85,7 @@ namespace Neo.Plugins.RpcServer
         [RpcMethod]
         internal virtual JToken GetBlockHeaderCount(JArray _params)
         {
+            Result.True_Or(_params.Count == 0, RpcError.InvalidParams.WithData("No parameters required."));
             return (system.HeaderCache.Last?.Index ?? NativeContract.Ledger.CurrentIndex(system.StoreView)) + 1;
         }
 
@@ -95,6 +97,7 @@ namespace Neo.Plugins.RpcServer
         [RpcMethod]
         protected internal virtual JToken GetBlockCount(JArray _params)
         {
+            Result.True_Or(_params.Count == 0, RpcError.InvalidParams.WithData("No parameters required."));
             return NativeContract.Ledger.CurrentIndex(system.StoreView) + 1;
         }
 
@@ -106,6 +109,7 @@ namespace Neo.Plugins.RpcServer
         [RpcMethod]
         protected internal virtual JToken GetBlockHash(JArray _params)
         {
+            Result.True_Or(_params.Count == 1, RpcError.InvalidParams.WithData("Invalid params, need a block index."));
             uint height = Result.Ok_Or(() => uint.Parse(_params[0].AsString()), RpcError.InvalidParams.WithData($"Invalid Height: {_params[0]}"));
             var snapshot = system.StoreView;
             if (height <= NativeContract.Ledger.CurrentIndex(snapshot))
@@ -126,6 +130,7 @@ namespace Neo.Plugins.RpcServer
         [RpcMethod]
         protected internal virtual JToken GetBlockHeader(JArray _params)
         {
+            Result.True_Or(_params.Count == 1 || _params.Count == 2, RpcError.InvalidParams.WithData("Invalid params, need a block hash string or block index, a verbose(optional)."));
             JToken key = _params[0];
             bool verbose = _params.Count >= 2 && _params[1].AsBoolean();
             var snapshot = system.StoreView;
@@ -161,6 +166,7 @@ namespace Neo.Plugins.RpcServer
         [RpcMethod]
         protected internal virtual JToken GetContractState(JArray _params)
         {
+            Result.True_Or(_params.Count == 1, RpcError.InvalidParams.WithData("Invalid params, need a script hash / contract id / native contract name."));
             if (int.TryParse(_params[0].AsString(), out int contractId))
             {
                 var contractState = NativeContract.ContractManagement.GetContractById(system.StoreView, contractId);
@@ -191,6 +197,7 @@ namespace Neo.Plugins.RpcServer
         [RpcMethod]
         protected internal virtual JToken GetRawMemPool(JArray _params)
         {
+            Result.True_Or(_params.Count <= 1, RpcError.InvalidParams.WithData("Invalid params, need a should get unverified(optional)."));
             bool shouldGetUnverified = _params.Count >= 1 && _params[0].AsBoolean();
             if (!shouldGetUnverified)
                 return new JArray(system.MemPool.GetVerifiedTransactions().Select(p => (JToken)p.Hash.ToString()));
@@ -345,6 +352,7 @@ namespace Neo.Plugins.RpcServer
         [RpcMethod]
         protected internal virtual JToken GetNextBlockValidators(JArray _params)
         {
+            Result.True_Or(_params.Count == 0, RpcError.InvalidParams.WithData("No parameters required."));
             using var snapshot = system.GetSnapshotCache();
             var validators = NativeContract.NEO.GetNextBlockValidators(snapshot, system.Settings.ValidatorsCount);
             return validators.Select(p =>
@@ -421,6 +429,7 @@ namespace Neo.Plugins.RpcServer
         [RpcMethod]
         protected internal virtual JToken GetCommittee(JArray _params)
         {
+            Result.True_Or(_params.Count == 0, RpcError.InvalidParams.WithData("No parameters required."));
             return new JArray(NativeContract.NEO.GetCommittee(system.StoreView).Select(p => (JToken)p.ToString()));
         }
 
@@ -432,6 +441,7 @@ namespace Neo.Plugins.RpcServer
         [RpcMethod]
         protected internal virtual JToken GetNativeContracts(JArray _params)
         {
+            Result.True_Or(_params.Count == 0, RpcError.InvalidParams.WithData("No parameters required."));
             return new JArray(NativeContract.Contracts.Select(p => NativeContract.ContractManagement.GetContract(system.StoreView, p.Hash).ToJson()));
         }
     }

--- a/src/Plugins/RpcServer/RpcServer.Blockchain.cs
+++ b/src/Plugins/RpcServer/RpcServer.Blockchain.cs
@@ -223,6 +223,7 @@ namespace Neo.Plugins.RpcServer
         [RpcMethod]
         protected internal virtual JToken GetRawTransaction(JArray _params)
         {
+            Result.True_Or(_params.Count == 1 || _params.Count == 2, RpcError.InvalidParams.WithData("Invalid params, need a txid, a verbose(optional)."));
             UInt256 hash = Result.Ok_Or(() => UInt256.Parse(_params[0].AsString()), RpcError.InvalidParams.WithData($"Invalid Transaction Hash: {_params[0]}"));
             bool verbose = _params.Count >= 2 && _params[1].AsBoolean();
             if (system.MemPool.TryGetValue(hash, out Transaction tx) && !verbose)
@@ -254,6 +255,7 @@ namespace Neo.Plugins.RpcServer
         [RpcMethod]
         protected internal virtual JToken GetStorage(JArray _params)
         {
+            Result.True_Or(_params.Count == 2, RpcError.InvalidParams.WithData("Invalid params, need a contract hash / contract id, a key."));
             using var snapshot = system.GetSnapshotCache();
             if (!int.TryParse(_params[0].AsString(), out int id))
             {
@@ -338,6 +340,7 @@ namespace Neo.Plugins.RpcServer
         [RpcMethod]
         protected internal virtual JToken GetTransactionHeight(JArray _params)
         {
+            Result.True_Or(_params.Count == 1, RpcError.InvalidParams.WithData("Invalid params, need a txid."));
             UInt256 hash = Result.Ok_Or(() => UInt256.Parse(_params[0].AsString()), RpcError.InvalidParams.WithData($"Invalid Transaction Hash: {_params[0]}"));
             uint? height = NativeContract.Ledger.GetTransactionState(system.StoreView, hash)?.BlockIndex;
             if (height.HasValue) return height.Value;

--- a/src/Plugins/RpcServer/RpcServer.Node.cs
+++ b/src/Plugins/RpcServer/RpcServer.Node.cs
@@ -26,12 +26,14 @@ namespace Neo.Plugins.RpcServer
         [RpcMethod]
         protected virtual JToken GetConnectionCount(JArray _params)
         {
+            Result.True_Or(_params.Count == 0, RpcError.InvalidParams.WithData("No parameters required."));
             return localNode.ConnectedCount;
         }
 
         [RpcMethod]
         protected virtual JToken GetPeers(JArray _params)
         {
+            Result.True_Or(_params.Count == 0, RpcError.InvalidParams.WithData("No parameters required."));
             JObject json = new();
             json["unconnected"] = new JArray(localNode.GetUnconnectedPeers().Select(p =>
             {

--- a/src/Plugins/RpcServer/RpcServer.Node.cs
+++ b/src/Plugins/RpcServer/RpcServer.Node.cs
@@ -114,6 +114,7 @@ namespace Neo.Plugins.RpcServer
         [RpcMethod]
         protected internal virtual JToken GetVersion(JArray _params)
         {
+            Result.True_Or(_params.Count == 0, RpcError.InvalidParams.WithData("No parameters required."));
             JObject json = new();
             json["tcpport"] = localNode.ListenerTcpPort;
             json["nonce"] = LocalNode.Nonce;
@@ -156,6 +157,7 @@ namespace Neo.Plugins.RpcServer
         [RpcMethod]
         protected internal virtual JToken SendRawTransaction(JArray _params)
         {
+            Result.True_Or(_params.Count == 1, RpcError.InvalidParams.WithData("Invalid params, need a raw transaction."));
             Transaction tx = Result.Ok_Or(() => Convert.FromBase64String(_params[0].AsString()).AsSerializable<Transaction>(), RpcError.InvalidParams.WithData($"Invalid Transaction Format: {_params[0]}"));
             RelayResult reason = system.Blockchain.Ask<RelayResult>(tx).Result;
             return GetRelayResult(reason.Result, tx.Hash);
@@ -164,6 +166,7 @@ namespace Neo.Plugins.RpcServer
         [RpcMethod]
         protected internal virtual JToken SubmitBlock(JArray _params)
         {
+            Result.True_Or(_params.Count == 1, RpcError.InvalidParams.WithData("Invalid params, need a raw block."));
             Block block = Result.Ok_Or(() => Convert.FromBase64String(_params[0].AsString()).AsSerializable<Block>(), RpcError.InvalidParams.WithData($"Invalid Block Format: {_params[0]}"));
             RelayResult reason = system.Blockchain.Ask<RelayResult>(block).Result;
             return GetRelayResult(reason.Result, block.Hash);

--- a/src/Plugins/RpcServer/RpcServer.SmartContract.cs
+++ b/src/Plugins/RpcServer/RpcServer.SmartContract.cs
@@ -215,6 +215,7 @@ namespace Neo.Plugins.RpcServer
         [RpcMethod]
         protected internal virtual JToken InvokeFunction(JArray _params)
         {
+            Result.True_Or(_params.Count >= 2 || _params.Count <= 4, RpcError.InvalidParams.WithData("Invalid params, need a script hash, an operation, an array of parameters, a signers(optional)."));
             UInt160 script_hash = Result.Ok_Or(() => UInt160.Parse(_params[0].AsString()), RpcError.InvalidParams.WithData($"Invalid script hash {nameof(script_hash)}"));
             string operation = Result.Ok_Or(() => _params[1].AsString(), RpcError.InvalidParams);
             ContractParameter[] args = _params.Count >= 3 ? ((JArray)_params[2]).Select(p => ContractParameter.FromJson((JObject)p)).ToArray() : System.Array.Empty<ContractParameter>();
@@ -233,6 +234,7 @@ namespace Neo.Plugins.RpcServer
         [RpcMethod]
         protected internal virtual JToken InvokeScript(JArray _params)
         {
+            Result.True_Or(_params.Count == 1 || _params.Count == 2, RpcError.InvalidParams.WithData("Invalid params, need a script, a signers(optional)."));
             byte[] script = Result.Ok_Or(() => Convert.FromBase64String(_params[0].AsString()), RpcError.InvalidParams);
             Signer[] signers = _params.Count >= 2 ? SignersFromJson((JArray)_params[1], system.Settings) : null;
             Witness[] witnesses = _params.Count >= 2 ? WitnessesFromJson((JArray)_params[1]) : null;
@@ -243,6 +245,7 @@ namespace Neo.Plugins.RpcServer
         [RpcMethod]
         protected internal virtual JToken TraverseIterator(JArray _params)
         {
+            Result.True_Or(_params.Count == 3, RpcError.InvalidParams.WithData("Invalid params, need a session, an iterator id, a count."));
             settings.SessionEnabled.True_Or(RpcError.SessionsDisabled);
             Guid sid = Result.Ok_Or(() => Guid.Parse(_params[0].GetString()), RpcError.InvalidParams.WithData($"Invalid session id {nameof(sid)}"));
             Guid iid = Result.Ok_Or(() => Guid.Parse(_params[1].GetString()), RpcError.InvalidParams.WithData($"Invliad iterator id {nameof(iid)}"));
@@ -280,6 +283,7 @@ namespace Neo.Plugins.RpcServer
         [RpcMethod]
         protected internal virtual JToken GetUnclaimedGas(JArray _params)
         {
+            Result.True_Or(_params.Count == 1, RpcError.InvalidParams.WithData("Invalid params, need an address."));
             string address = Result.Ok_Or(() => _params[0].AsString(), RpcError.InvalidParams.WithData($"Invalid address {nameof(address)}"));
             JObject json = new();
             UInt160 script_hash = Result.Ok_Or(() => AddressToScriptHash(address, system.Settings.AddressVersion), RpcError.InvalidParams);

--- a/src/Plugins/RpcServer/RpcServer.Utilities.cs
+++ b/src/Plugins/RpcServer/RpcServer.Utilities.cs
@@ -20,6 +20,7 @@ namespace Neo.Plugins.RpcServer
         [RpcMethod]
         protected virtual JToken ListPlugins(JArray _params)
         {
+            Result.True_Or(_params.Count == 0, RpcError.InvalidParams.WithData("No parameters required."));
             return new JArray(Plugin.Plugins
                 .OrderBy(u => u.Name)
                 .Select(u => new JObject
@@ -36,6 +37,7 @@ namespace Neo.Plugins.RpcServer
         [RpcMethod]
         protected virtual JToken ValidateAddress(JArray _params)
         {
+            Result.True_Or(_params.Count == 1, RpcError.InvalidParams.WithData("Invalid params, need an address."));
             string address = Result.Ok_Or(() => _params[0].AsString(), RpcError.InvalidParams.WithData($"Invlid address format: {_params[0]}"));
             JObject json = new();
             UInt160 scriptHash;

--- a/src/Plugins/RpcServer/RpcServer.Wallet.cs
+++ b/src/Plugins/RpcServer/RpcServer.Wallet.cs
@@ -96,6 +96,7 @@ namespace Neo.Plugins.RpcServer
         [RpcMethod]
         protected internal virtual JToken GetNewAddress(JArray _params)
         {
+            Result.True_Or(_params.Count == 0, RpcError.InvalidParams.WithData("No parameters required."));
             CheckWallet();
             WalletAccount account = wallet.CreateAccount();
             if (wallet is NEP6Wallet nep6)

--- a/src/Plugins/RpcServer/RpcServer.Wallet.cs
+++ b/src/Plugins/RpcServer/RpcServer.Wallet.cs
@@ -66,6 +66,7 @@ namespace Neo.Plugins.RpcServer
         [RpcMethod]
         protected internal virtual JToken CloseWallet(JArray _params)
         {
+            Result.True_Or(_params.Count == 0, RpcError.InvalidParams.WithData("No parameters required."));
             wallet = null;
             return true;
         }
@@ -79,6 +80,7 @@ namespace Neo.Plugins.RpcServer
         [RpcMethod]
         protected internal virtual JToken DumpPrivKey(JArray _params)
         {
+            Result.True_Or(_params.Count == 1, RpcError.InvalidParams.WithData("Invalid params, need an address."));
             CheckWallet();
             UInt160 scriptHash = AddressToScriptHash(_params[0].AsString(), system.Settings.AddressVersion);
             WalletAccount account = wallet.GetAccount(scriptHash);
@@ -170,10 +172,7 @@ namespace Neo.Plugins.RpcServer
         [RpcMethod]
         protected internal virtual JToken CalculateNetworkFee(JArray _params)
         {
-            if (_params.Count == 0)
-            {
-                throw new RpcException(RpcError.InvalidParams.WithData("Params array is empty, need a raw transaction."));
-            }
+            Result.True_Or(_params.Count == 1, RpcError.InvalidParams.WithData("Invalid params, need a raw transaction."));
             var tx = Result.Ok_Or(() => Convert.FromBase64String(_params[0].AsString()), RpcError.InvalidParams.WithData($"Invalid tx: {_params[0]}")); ;
 
             JObject account = new();

--- a/src/Plugins/RpcServer/RpcServer.Wallet.cs
+++ b/src/Plugins/RpcServer/RpcServer.Wallet.cs
@@ -113,6 +113,7 @@ namespace Neo.Plugins.RpcServer
         [RpcMethod]
         protected internal virtual JToken GetWalletBalance(JArray _params)
         {
+            Result.True_Or(_params.Count == 1, RpcError.InvalidParams.WithData("Invalid params, need an asset id."));
             CheckWallet();
             UInt160 asset_id = Result.Ok_Or(() => UInt160.Parse(_params[0].AsString()), RpcError.InvalidParams.WithData($"Invalid asset id: {_params[0]}"));
             JObject json = new();
@@ -129,6 +130,7 @@ namespace Neo.Plugins.RpcServer
         [RpcMethod]
         protected internal virtual JToken GetWalletUnclaimedGas(JArray _params)
         {
+            Result.True_Or(_params.Count == 0, RpcError.InvalidParams.WithData("No parameters required."));
             CheckWallet();
             // Datoshi is the smallest unit of GAS, 1 GAS = 10^8 Datoshi
             BigInteger datoshi = BigInteger.Zero;
@@ -150,6 +152,7 @@ namespace Neo.Plugins.RpcServer
         [RpcMethod]
         protected internal virtual JToken ImportPrivKey(JArray _params)
         {
+            Result.True_Or(_params.Count == 1, RpcError.InvalidParams.WithData("Invalid params, need a private key."));
             CheckWallet();
             string privkey = _params[0].AsString();
             WalletAccount account = wallet.Import(privkey);
@@ -193,6 +196,7 @@ namespace Neo.Plugins.RpcServer
         [RpcMethod]
         protected internal virtual JToken ListAddress(JArray _params)
         {
+            Result.True_Or(_params.Count == 0, RpcError.InvalidParams.WithData("No parameters required."));
             CheckWallet();
             return wallet.GetAccounts().Select(p =>
             {
@@ -214,6 +218,7 @@ namespace Neo.Plugins.RpcServer
         [RpcMethod]
         protected internal virtual JToken OpenWallet(JArray _params)
         {
+            Result.True_Or(_params.Count == 2, RpcError.InvalidParams.WithData("Invalid params, need a path, a password."));
             string path = _params[0].AsString();
             string password = _params[1].AsString();
             File.Exists(path).True_Or(RpcError.WalletNotFound);
@@ -275,6 +280,7 @@ namespace Neo.Plugins.RpcServer
         [RpcMethod]
         protected internal virtual JToken SendFrom(JArray _params)
         {
+            Result.True_Or(_params.Count == 4 || _params.Count == 5, RpcError.InvalidParams.WithData("Invalid params, need an asset id, a from address, a destination address, an amount, a signers(optional)."));
             CheckWallet();
             UInt160 assetId = Result.Ok_Or(() => UInt160.Parse(_params[0].AsString()), RpcError.InvalidParams.WithData($"Invalid asset id: {_params[0]}"));
             UInt160 from = AddressToScriptHash(_params[1].AsString(), system.Settings.AddressVersion);
@@ -342,6 +348,7 @@ namespace Neo.Plugins.RpcServer
         [RpcMethod]
         protected internal virtual JToken SendMany(JArray _params)
         {
+            Result.True_Or(_params.Count == 2, RpcError.InvalidParams.WithData("Invalid params, need a from address, a outputs array."));
             CheckWallet();
             int to_start = 0;
             UInt160 from = null;
@@ -394,6 +401,8 @@ namespace Neo.Plugins.RpcServer
         [RpcMethod]
         protected internal virtual JToken SendToAddress(JArray _params)
         {
+            Result.True_Or(_params.Count == 3, RpcError.InvalidParams.WithData("Invalid params, need a asset id, a address, an amount."));
+
             CheckWallet();
             UInt160 assetId = Result.Ok_Or(() => UInt160.Parse(_params[0].AsString()), RpcError.InvalidParams.WithData($"Invalid asset hash: {_params[0]}"));
             UInt160 to = AddressToScriptHash(_params[1].AsString(), system.Settings.AddressVersion);
@@ -475,6 +484,7 @@ namespace Neo.Plugins.RpcServer
         [RpcMethod]
         protected internal virtual JToken InvokeContractVerify(JArray _params)
         {
+            Result.True_Or(_params.Count >= 1 || _params.Count <= 3, RpcError.InvalidParams.WithData("Invalid params, need a script hash, an array of parameters(optional), a signers(optional)."));
             UInt160 script_hash = Result.Ok_Or(() => UInt160.Parse(_params[0].AsString()), RpcError.InvalidParams.WithData($"Invalid script hash: {_params[0]}"));
             ContractParameter[] args = _params.Count >= 2 ? ((JArray)_params[1]).Select(p => ContractParameter.FromJson((JObject)p)).ToArray() : Array.Empty<ContractParameter>();
             Signer[] signers = _params.Count >= 3 ? SignersFromJson((JArray)_params[2], system.Settings) : null;

--- a/src/Plugins/StateService/StatePlugin.cs
+++ b/src/Plugins/StateService/StatePlugin.cs
@@ -184,6 +184,7 @@ namespace Neo.Plugins.StateService
         [RpcMethod]
         public JToken GetStateRoot(JArray _params)
         {
+            Result.True_Or(_params.Count == 1, RpcError.InvalidParams.WithData("Invalid params, need a block index."));
             uint index = Result.Ok_Or(() => uint.Parse(_params[0].AsString()), RpcError.InvalidParams.WithData($"Invalid state root index: {_params[0]}"));
             using var snapshot = StateStore.Singleton.GetSnapshot();
             StateRoot state_root = snapshot.GetStateRoot(index).NotNull_Or(RpcError.UnknownStateRoot);
@@ -257,6 +258,7 @@ namespace Neo.Plugins.StateService
         [RpcMethod]
         public JToken VerifyProof(JArray _params)
         {
+            Result.True_Or(_params.Count == 2, RpcError.InvalidParams.WithData("Invalid params, need root hash, a proof."));
             UInt256 root_hash = Result.Ok_Or(() => UInt256.Parse(_params[0].AsString()), RpcError.InvalidParams.WithData($"Invalid root hash: {_params[0]}"));
             byte[] proof_bytes = Result.Ok_Or(() => Convert.FromBase64String(_params[1].AsString()), RpcError.InvalidParams.WithData($"Invalid proof: {_params[1]}"));
             return VerifyProof(root_hash, proof_bytes);
@@ -265,6 +267,7 @@ namespace Neo.Plugins.StateService
         [RpcMethod]
         public JToken GetStateHeight(JArray _params)
         {
+            Result.True_Or(_params.Count == 0, RpcError.InvalidParams.WithData("No parameters required."));
             var json = new JObject();
             json["localrootindex"] = StateStore.Singleton.LocalRootIndex;
             json["validatedrootindex"] = StateStore.Singleton.ValidatedRootIndex;
@@ -347,6 +350,7 @@ namespace Neo.Plugins.StateService
         [RpcMethod]
         public JToken GetState(JArray _params)
         {
+            Result.True_Or(_params.Count == 3, RpcError.InvalidParams.WithData("Invalid params, need a roothash, a scripthash, a key."));
             var root_hash = Result.Ok_Or(() => UInt256.Parse(_params[0].AsString()), RpcError.InvalidParams.WithData($"Invalid root hash: {_params[0]}"));
             (!Settings.Default.FullState && StateStore.Singleton.CurrentLocalRootHash != root_hash).False_Or(RpcError.UnsupportedState);
             var script_hash = Result.Ok_Or(() => UInt160.Parse(_params[1].AsString()), RpcError.InvalidParams.WithData($"Invalid script hash: {_params[1]}"));

--- a/src/Plugins/StateService/StatePlugin.cs
+++ b/src/Plugins/StateService/StatePlugin.cs
@@ -229,6 +229,7 @@ namespace Neo.Plugins.StateService
         [RpcMethod]
         public JToken GetProof(JArray _params)
         {
+            Result.True_Or(_params.Count == 3, RpcError.InvalidParams.WithData("Invalid params, need a root hash, a script hash, a key."));
             UInt256 root_hash = Result.Ok_Or(() => UInt256.Parse(_params[0].AsString()), RpcError.InvalidParams.WithData($"Invalid root hash: {_params[0]}"));
             UInt160 script_hash = Result.Ok_Or(() => UInt160.Parse(_params[1].AsString()), RpcError.InvalidParams.WithData($"Invalid script hash: {_params[1]}"));
             byte[] key = Result.Ok_Or(() => Convert.FromBase64String(_params[2].AsString()), RpcError.InvalidParams.WithData($"Invalid key: {_params[2]}"));

--- a/src/Plugins/StateService/StatePlugin.cs
+++ b/src/Plugins/StateService/StatePlugin.cs
@@ -289,6 +289,7 @@ namespace Neo.Plugins.StateService
         [RpcMethod]
         public JToken FindStates(JArray _params)
         {
+            Result.True_Or(_params.Count >= 3 || _params.Count <= 5, RpcError.InvalidParams.WithData("Invalid params, need a root hash, a script hash, a prefix, a key(optional), a count(optional)."));
             var root_hash = Result.Ok_Or(() => UInt256.Parse(_params[0].AsString()), RpcError.InvalidParams.WithData($"Invalid root hash: {_params[0]}"));
             (!Settings.Default.FullState && StateStore.Singleton.CurrentLocalRootHash != root_hash).False_Or(RpcError.UnsupportedState);
             var script_hash = Result.Ok_Or(() => UInt160.Parse(_params[1].AsString()), RpcError.InvalidParams.WithData($"Invalid script hash: {_params[1]}"));

--- a/src/Plugins/TokensTracker/Trackers/NEP-11/Nep11Tracker.cs
+++ b/src/Plugins/TokensTracker/Trackers/NEP-11/Nep11Tracker.cs
@@ -197,6 +197,7 @@ namespace Neo.Plugins.Trackers.NEP_11
         [RpcMethod]
         public JToken GetNep11Transfers(JArray _params)
         {
+            Result.True_Or(_params.Count >= 1 || _params.Count <= 3, RpcError.InvalidParams.WithData("Invalid params, need an address, a startTime(optional), a endTime(optional)."));
             _shouldTrackHistory.True_Or(RpcError.MethodNotFound);
             UInt160 userScriptHash = GetScriptHashFromParam(_params[0].AsString());
             // If start time not present, default to 1 week of history.
@@ -219,6 +220,7 @@ namespace Neo.Plugins.Trackers.NEP_11
         [RpcMethod]
         public JToken GetNep11Balances(JArray _params)
         {
+            Result.True_Or(_params.Count == 1, RpcError.InvalidParams.WithData("Invalid params, need an address."));
             UInt160 userScriptHash = GetScriptHashFromParam(_params[0].AsString());
 
             JObject json = new();
@@ -279,6 +281,7 @@ namespace Neo.Plugins.Trackers.NEP_11
         [RpcMethod]
         public JToken GetNep11Properties(JArray _params)
         {
+            Result.True_Or(_params.Count == 2, RpcError.InvalidParams.WithData("Invalid params, need a contract hash, a tokenId."));
             UInt160 nep11Hash = GetScriptHashFromParam(_params[0].AsString());
             var tokenId = _params[1].AsString().HexToBytes();
 

--- a/src/Plugins/TokensTracker/Trackers/NEP-17/Nep17Tracker.cs
+++ b/src/Plugins/TokensTracker/Trackers/NEP-17/Nep17Tracker.cs
@@ -145,6 +145,7 @@ namespace Neo.Plugins.Trackers.NEP_17
         [RpcMethod]
         public JToken GetNep17Transfers(JArray _params)
         {
+            Result.True_Or(_params.Count >= 1 || _params.Count <= 3, RpcError.InvalidParams.WithData("Invalid params, need an address, a startTime(optional), a endTime(optional)."));
             _shouldTrackHistory.True_Or(RpcError.MethodNotFound);
             UInt160 userScriptHash = GetScriptHashFromParam(_params[0].AsString());
             // If start time not present, default to 1 week of history.
@@ -168,6 +169,7 @@ namespace Neo.Plugins.Trackers.NEP_17
         [RpcMethod]
         public JToken GetNep17Balances(JArray _params)
         {
+            Result.True_Or(_params.Count == 1, RpcError.InvalidParams.WithData("Invalid params, need an address."));
             UInt160 userScriptHash = GetScriptHashFromParam(_params[0].AsString());
 
             JObject json = new();


### PR DESCRIPTION
Validation the count of parameters in JSON RPC, output an error message in case of wrong count of parameters.

before
![image](https://github.com/user-attachments/assets/8e0db513-742b-4318-8b3d-011853dacf87)
![image](https://github.com/user-attachments/assets/d5aa9bac-777f-4977-911d-3e81ae19f0d3)

after
![image](https://github.com/user-attachments/assets/33ffa9dc-79dc-4c60-b7d9-4d40e46aabd2)
![image](https://github.com/user-attachments/assets/70613b0a-d134-421d-83f4-b0c7c13e455b)
