### PR TITLE
Update ConstantTimeUtility.cs

### DIFF
--- a/src/Neo.Cryptography.BLS12_381/ConstantTimeUtility.cs
+++ b/src/Neo.Cryptography.BLS12_381/ConstantTimeUtility.cs
@@ -26,7 +26,7 @@ public static class ConstantTimeUtility
         for (int i = 0; i < a_u64.Length; i++)
             f |= a_u64[i] ^ b_u64[i];
         for (int i = a_u64.Length * sizeof(ulong); i < a_bytes.Length; i++)
-            f |= (ulong)a_bytes[i] ^ a_bytes[i];
+            f |= (ulong)a_bytes[i] ^ b_bytes[i];
         return f == 0;
     }
 


### PR DESCRIPTION
- Fix typo

# Description

Typo in ConstantTimeEq meant method only worked as intended for inputs qword aligned (8 byte-aligned). 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
