### PR TITLE
Added `CreateStruct` & Fixed `CreateMap`

### DIFF
--- a/src/Neo/VM/Helper.cs
+++ b/src/Neo/VM/Helper.cs
@@ -63,7 +63,7 @@ namespace Neo.VM
             if (count == 0)
                 return builder.Emit(OpCode.NEWMAP);
 
-            foreach (var (key, value) in map)
+            foreach (var (key, value) in map.Reverse())
             {
                 builder.EmitPush(value);
                 builder.EmitPush(key);
@@ -72,6 +72,14 @@ namespace Neo.VM
             return builder.Emit(OpCode.PACKMAP);
         }
 
+        /// <summary>
+        /// Emits the opcodes for creating a map.
+        /// </summary>
+        /// <typeparam name="TKey">The type of the key of the map.</typeparam>
+        /// <typeparam name="TValue">The type of the value of the map.</typeparam>
+        /// <param name="builder">The <see cref="ScriptBuilder"/> to be used.</param>
+        /// <param name="map">The key/value pairs of the map.</param>
+        /// <returns>The same instance as <paramref name="builder"/>.</returns>
         public static ScriptBuilder CreateMap<TKey, TValue>(this ScriptBuilder builder, IReadOnlyDictionary<TKey, TValue> map)
             where TKey : notnull
             where TValue : notnull
@@ -79,7 +87,7 @@ namespace Neo.VM
             if (map.Count == 0)
                 return builder.Emit(OpCode.NEWMAP);
 
-            foreach (var (key, value) in map)
+            foreach (var (key, value) in map.Reverse())
             {
                 builder.EmitPush(value);
                 builder.EmitPush(key);
@@ -88,7 +96,13 @@ namespace Neo.VM
             return builder.Emit(OpCode.PACKMAP);
         }
 
-
+        /// <summary>
+        /// Emits the opcodes for creating a struct.
+        /// </summary>
+        /// <typeparam name="T">The type of the property.</typeparam>
+        /// <param name="builder">The <see cref="ScriptBuilder"/> to be used.</param>
+        /// <param name="array">The list of properties.</param>
+        /// <returns>The same instance as <paramref name="builder"/>.</returns>
         public static ScriptBuilder CreateStruct<T>(this ScriptBuilder builder, IReadOnlyList<T> array)
             where T : notnull
         {

--- a/tests/Neo.UnitTests/VM/UT_Helper.cs
+++ b/tests/Neo.UnitTests/VM/UT_Helper.cs
@@ -107,6 +107,30 @@ namespace Neo.UnitTests.VMT
         }
 
         [TestMethod]
+        public void TestEmitStruct()
+        {
+            var expected = new BigInteger[] { 1, 2, 3 };
+            var sb = new ScriptBuilder();
+            sb.CreateStruct(expected);
+
+            using var engine = ApplicationEngine.Create(TriggerType.Application, null, null);
+            engine.LoadScript(sb.ToArray());
+            Assert.AreEqual(VMState.HALT, engine.Execute());
+
+            CollectionAssert.AreEqual(expected, engine.ResultStack.Pop<VM.Types.Struct>().Select(u => u.GetInteger()).ToArray());
+
+            expected = new BigInteger[] { };
+            sb = new ScriptBuilder();
+            sb.CreateStruct(expected);
+
+            using var engine2 = ApplicationEngine.Create(TriggerType.Application, null, null);
+            engine2.LoadScript(sb.ToArray());
+            Assert.AreEqual(VMState.HALT, engine2.Execute());
+
+            Assert.AreEqual(0, engine2.ResultStack.Pop<VM.Types.Struct>().Count);
+        }
+
+        [TestMethod]
         public void TestEmitMap()
         {
             var expected = new Dictionary<BigInteger, BigInteger>() { { 1, 2 }, { 3, 4 } };


### PR DESCRIPTION
# Description

- Added `CreateStruct` method
- `CreateMap` changed to initialize items on the stack to be packed as a new map. Changed to follow `CreateArray` and `CreateStruct`.
- Type case removed because in C# `char` already is a `ushort`.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Optimization (the change is only an optimization)
- [x] Style (the change is only a code style for better maintenance or standard purpose)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Unit tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
