### PR TITLE
fix: concurrency conflict in HeaderCache.Count

### DIFF
--- a/src/Neo/Ledger/HeaderCache.cs
+++ b/src/Neo/Ledger/HeaderCache.cs
@@ -55,12 +55,26 @@ namespace Neo.Ledger
         /// <summary>
         /// Gets the number of elements in the cache.
         /// </summary>
-        public int Count => headers.Count;
+        public int Count
+        {
+            get
+            {
+                readerWriterLock.EnterReadLock();
+                try
+                {
+                    return headers.Count;
+                }
+                finally
+                {
+                    readerWriterLock.ExitReadLock();
+                }
+            }
+        }
 
         /// <summary>
         /// Indicates whether the cache is full.
         /// </summary>
-        public bool Full => headers.Count >= 10000;
+        public bool Full => Count >= 10000;
 
         /// <summary>
         /// Gets the last <see cref="Header"/> in the cache. Or <see langword="null"/> if the cache is empty.

--- a/tests/Neo.UnitTests/Ledger/UT_HeaderCache.cs
+++ b/tests/Neo.UnitTests/Ledger/UT_HeaderCache.cs
@@ -15,7 +15,6 @@ using Neo.Ledger;
 using Neo.Network.P2P.Payloads;
 using System;
 
-
 namespace Neo.UnitTests.Ledger
 {
     [TestClass]

--- a/tests/Neo.UnitTests/Ledger/UT_HeaderCache.cs
+++ b/tests/Neo.UnitTests/Ledger/UT_HeaderCache.cs
@@ -21,7 +21,6 @@ namespace Neo.UnitTests.Ledger
     [TestClass]
     public class UT_HeaderCache
     {
-
         [TestMethod]
         public void TestHeaderCache()
         {

--- a/tests/Neo.UnitTests/Ledger/UT_HeaderCache.cs
+++ b/tests/Neo.UnitTests/Ledger/UT_HeaderCache.cs
@@ -1,0 +1,72 @@
+// Copyright (C) 2015-2024 The Neo Project.
+//
+// UT_HeaderCache.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.Ledger;
+using Neo.Network.P2P.Payloads;
+using System;
+
+
+namespace Neo.UnitTests.Ledger
+{
+    [TestClass]
+    public class UT_HeaderCache
+    {
+
+        [TestMethod]
+        public void TestHeaderCache()
+        {
+            var cache = new HeaderCache();
+            var header = new Header();
+            header.Index = 1;
+            cache.Add(header);
+
+            var got = cache[1];
+            got.Should().NotBeNull();
+            got.Index.Should().Be(1);
+
+            var count = cache.Count;
+            count.Should().Be(1);
+
+            var full = cache.Full;
+            full.Should().BeFalse();
+
+            var last = cache.Last;
+            last.Should().NotBeNull();
+            last.Index.Should().Be(1);
+
+            got = cache[2];
+            got.Should().BeNull();
+
+            // enumerate
+            var enumerator = cache.GetEnumerator();
+            enumerator.MoveNext().Should().BeTrue();
+            enumerator.Current.Index.Should().Be(1);
+            enumerator.MoveNext().Should().BeFalse();
+
+            var removed = cache.TryRemoveFirst(out header);
+            removed.Should().BeTrue();
+
+            count = cache.Count;
+            count.Should().Be(0);
+
+            full = cache.Full;
+            full.Should().BeFalse();
+
+            last = cache.Last;
+            last.Should().BeNull();
+
+            got = cache[1];
+            got.Should().BeNull();
+        }
+    }
+}


### PR DESCRIPTION
# Description

Operations of `HeaderCount` should be protected by `Lock`, but `HeaderCache.Count` omits to acquire `Lock`. Although it is only an int load operation, the `Full` may be inaccurate.

Add add more UTs to `HeaderCache`.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
