### PR TITLE
fix: always throw `DivideByZeroException ` when `BloomFilter` is empty

### DIFF
--- a/src/Neo/Cryptography/BloomFilter.cs
+++ b/src/Neo/Cryptography/BloomFilter.cs
@@ -79,6 +79,8 @@ namespace Neo.Cryptography
         /// <param name="element">The object to add to the <see cref="BloomFilter"/>.</param>
         public void Add(ReadOnlyMemory<byte> element)
         {
+            if (bits.Length == 0) return;
+
             foreach (uint i in seeds.AsParallel().Select(s => element.Span.Murmur32(s)))
                 bits.Set((int)(i % (uint)bits.Length), true);
         }
@@ -90,6 +92,8 @@ namespace Neo.Cryptography
         /// <returns><see langword="true"/> if <paramref name="element"/> is found in the <see cref="BloomFilter"/>; otherwise, <see langword="false"/>.</returns>
         public bool Check(byte[] element)
         {
+            if (bits.Length == 0) return true; // FPR is 100% when length is 0
+
             foreach (uint i in seeds.AsParallel().Select(s => element.Murmur32(s)))
                 if (!bits.Get((int)(i % (uint)bits.Length)))
                     return false;

--- a/tests/Neo.UnitTests/Cryptography/UT_BloomFilter.cs
+++ b/tests/Neo.UnitTests/Cryptography/UT_BloomFilter.cs
@@ -78,5 +78,17 @@ namespace Neo.UnitTests.Cryptography
             foreach (byte value in result)
                 value.Should().Be(0);
         }
+
+        [TestMethod]
+        public void TestZeroLengthBits()
+        {
+            int m = 0, n = 3;
+            uint nTweak = 123456;
+            BloomFilter filter = new BloomFilter(m, n, nTweak);
+
+            filter.Add(new byte[] { 1, 2, 3 });
+            filter.Check(new byte[] { 1, 2, 3 }).Should().BeTrue();
+            filter.Check(new byte[] { 1, 2, 3, 4 }).Should().BeTrue(); // FPR is 100% when length is 0 or 1
+        }
     }
 }

--- a/tests/Neo.UnitTests/Cryptography/UT_BloomFilter.cs
+++ b/tests/Neo.UnitTests/Cryptography/UT_BloomFilter.cs
@@ -80,15 +80,14 @@ namespace Neo.UnitTests.Cryptography
         }
 
         [TestMethod]
-        public void TestZeroLengthBits()
+        public void TestInvalidArguments()
         {
-            int m = 0, n = 3;
             uint nTweak = 123456;
-            BloomFilter filter = new BloomFilter(m, n, nTweak);
+            Action action = () => new BloomFilter(0, 3, nTweak);
+            action.Should().Throw<ArgumentOutOfRangeException>();
 
-            filter.Add(new byte[] { 1, 2, 3 });
-            filter.Check(new byte[] { 1, 2, 3 }).Should().BeTrue();
-            filter.Check(new byte[] { 1, 2, 3, 4 }).Should().BeTrue(); // FPR is 100% when length is 0 or 1
+            action = () => new BloomFilter(3, 0, nTweak);
+            action.Should().Throw<ArgumentOutOfRangeException>();
         }
     }
 }


### PR DESCRIPTION
# Description

`new BloomFilter` allow to create a bloom filter that length is 0(i.e. `m` allow set to `0`), but if it's length is 0, this `BloomFilter` will always throw `DivideByZeroException` when call `Add` or `Check`.


## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
