### PR TITLE
OpCodes: extend MODMUL tests with negative base/multiplier/mod

### DIFF
--- a/tests/Neo.VM.Tests/Tests/OpCodes/Arithmetic/MODMUL.json
+++ b/tests/Neo.VM.Tests/Tests/OpCodes/Arithmetic/MODMUL.json
@@ -136,6 +136,242 @@
           }
         }
       ]
+    },
+    {
+      "name": "Real test (-3 * 4 % 5)",
+      "script": [
+        "PUSH3",
+        "NEGATE",
+        "PUSH4",
+        "PUSH5",
+        "MODMUL"
+      ],
+      "steps": [
+        {
+          "actions": [
+            "stepInto",
+            "stepInto",
+            "stepInto",
+            "stepInto"
+          ],
+          "result": {
+            "state": "BREAK",
+            "invocationStack": [
+              {
+                "instructionPointer": 4,
+                "nextInstruction": "MODMUL",
+                "evaluationStack": [
+                  {
+                    "type": "Integer",
+                    "value": 5
+                  },
+                  {
+                    "type": "Integer",
+                    "value": 4
+                  },
+                  {
+                    "type": "Integer",
+                    "value": -3
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "actions": [
+            "execute"
+          ],
+          "result": {
+            "state": "HALT",
+            "invocationStack": [],
+            "resultStack": [
+              {
+                "type": "Integer",
+                "value": -2
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "Real test (3 * 4 % -5)",
+      "script": [
+        "PUSH3",
+        "PUSH4",
+        "PUSH5",
+        "NEGATE",
+        "MODMUL"
+      ],
+      "steps": [
+        {
+          "actions": [
+            "stepInto",
+            "stepInto",
+            "stepInto",
+            "stepInto"
+          ],
+          "result": {
+            "state": "BREAK",
+            "invocationStack": [
+              {
+                "instructionPointer": 4,
+                "nextInstruction": "MODMUL",
+                "evaluationStack": [
+                  {
+                    "type": "Integer",
+                    "value": -5
+                  },
+                  {
+                    "type": "Integer",
+                    "value": 4
+                  },
+                  {
+                    "type": "Integer",
+                    "value": 3
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "actions": [
+            "execute"
+          ],
+          "result": {
+            "state": "HALT",
+            "invocationStack": [],
+            "resultStack": [
+              {
+                "type": "Integer",
+                "value": 2
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "Real test (-3 * 4 % -5)",
+      "script": [
+        "PUSH3",
+        "NEGATE",
+        "PUSH4",
+        "PUSH5",
+        "NEGATE",
+        "MODMUL"
+      ],
+      "steps": [
+        {
+          "actions": [
+            "stepInto",
+            "stepInto",
+            "stepInto",
+            "stepInto",
+            "stepInto"
+          ],
+          "result": {
+            "state": "BREAK",
+            "invocationStack": [
+              {
+                "instructionPointer": 5,
+                "nextInstruction": "MODMUL",
+                "evaluationStack": [
+                  {
+                    "type": "Integer",
+                    "value": -5
+                  },
+                  {
+                    "type": "Integer",
+                    "value": 4
+                  },
+                  {
+                    "type": "Integer",
+                    "value": -3
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "actions": [
+            "execute"
+          ],
+          "result": {
+            "state": "HALT",
+            "invocationStack": [],
+            "resultStack": [
+              {
+                "type": "Integer",
+                "value": -2
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "Real test (3 * -4 % -5)",
+      "script": [
+        "PUSH3",
+        "PUSH4",
+        "NEGATE",
+        "PUSH5",
+        "NEGATE",
+        "MODMUL"
+      ],
+      "steps": [
+        {
+          "actions": [
+            "stepInto",
+            "stepInto",
+            "stepInto",
+            "stepInto",
+            "stepInto"
+          ],
+          "result": {
+            "state": "BREAK",
+            "invocationStack": [
+              {
+                "instructionPointer": 5,
+                "nextInstruction": "MODMUL",
+                "evaluationStack": [
+                  {
+                    "type": "Integer",
+                    "value": -5
+                  },
+                  {
+                    "type": "Integer",
+                    "value": -4
+                  },
+                  {
+                    "type": "Integer",
+                    "value": 3
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "actions": [
+            "execute"
+          ],
+          "result": {
+            "state": "HALT",
+            "invocationStack": [],
+            "resultStack": [
+              {
+                "type": "Integer",
+                "value": -2
+              }
+            ]
+          }
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
# Description

Extend existing testset for MODMUL opcode, no functional chnges. Allows to avoid bugs like https://github.com/nspcc-dev/neo-go/issues/3598.

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Test

# How Has This Been Tested?

- [X] MODMUL.json tests

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
