### PR TITLE
public class Unsafe

### DIFF
--- a/src/Neo.VM/Unsafe.cs
+++ b/src/Neo.VM/Unsafe.cs
@@ -14,7 +14,7 @@ using System.Runtime.CompilerServices;
 
 namespace Neo.VM
 {
-    unsafe internal static class Unsafe
+    unsafe public static class Unsafe
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool NotZero(ReadOnlySpan<byte> x)


### PR DESCRIPTION
# Description

Setting class Unsafe to public. For .nef assembly data flow analysis, I am trying to write a symbolic VM that inherits the existing components of Neo.VM to the best.

## Type of change

- [x] Style (the change is only a code style for better maintenance or standard purpose)

# How Has This Been Tested?
No additional test

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
