### PR TITLE
fix: concurrency conflict in NEP6Wallet.ToJson

### DIFF
--- a/src/Neo/Wallets/NEP6/NEP6Wallet.cs
+++ b/src/Neo/Wallets/NEP6/NEP6Wallet.cs
@@ -293,10 +293,10 @@ namespace Neo.Wallets.NEP6
         /// </summary>
         public JObject ToJson()
         {
-            JObject[] values;
+            NEP6Account[] accountValues;
             lock (accounts)
             {
-                values = accounts.Values.Select(p => p.ToJson()).ToArray();
+                accountValues = accounts.Values.ToArray();
             }
 
             return new()
@@ -304,7 +304,7 @@ namespace Neo.Wallets.NEP6
                 ["name"] = name,
                 ["version"] = version.ToString(),
                 ["scrypt"] = Scrypt.ToJson(),
-                ["accounts"] = values,
+                ["accounts"] = accountValues.Select(p => p.ToJson()).ToArray(),
                 ["extra"] = extra
             };
         }

--- a/src/Neo/Wallets/NEP6/NEP6Wallet.cs
+++ b/src/Neo/Wallets/NEP6/NEP6Wallet.cs
@@ -293,12 +293,18 @@ namespace Neo.Wallets.NEP6
         /// </summary>
         public JObject ToJson()
         {
+            JObject[] values;
+            lock (accounts)
+            {
+                values = accounts.Values.Select(p => p.ToJson()).ToArray();
+            }
+
             return new()
             {
                 ["name"] = name,
                 ["version"] = version.ToString(),
                 ["scrypt"] = Scrypt.ToJson(),
-                ["accounts"] = accounts.Values.Select(p => p.ToJson()).ToArray(),
+                ["accounts"] = values,
                 ["extra"] = extra
             };
         }


### PR DESCRIPTION
# Description

The `accounts` in NEP6Wallet.ToJson should be locked when read it. (the existing UTs have covered this method).
## Type of change

- [ ] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
