### PR TITLE
fix: concurrency conflict because of Memory Order

### DIFF
--- a/src/Neo/Wallets/NEP6/NEP6Wallet.cs
+++ b/src/Neo/Wallets/NEP6/NEP6Wallet.cs
@@ -20,6 +20,7 @@ using System.Runtime.InteropServices;
 using System.Security;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Neo.Wallets.NEP6
@@ -93,6 +94,7 @@ namespace Neo.Wallets.NEP6
             scrypt = ScryptParameters.FromJson((JObject)wallet["scrypt"]);
             accounts = ((JArray)wallet["accounts"]).Select(p => NEP6Account.FromJson((JObject)p, this)).ToDictionary(p => p.ScriptHash);
             extra = wallet["extra"];
+            Thread.MemoryBarrier();
             if (!VerifyPasswordInternal(password.GetClearText()))
                 throw new InvalidOperationException("Wrong password.");
         }

--- a/src/Neo/Wallets/NEP6/NEP6Wallet.cs
+++ b/src/Neo/Wallets/NEP6/NEP6Wallet.cs
@@ -72,6 +72,7 @@ namespace Neo.Wallets.NEP6
                 accounts = new Dictionary<UInt160, NEP6Account>();
                 extra = JToken.Null;
             }
+            Thread.MemoryBarrier();
         }
 
         /// <summary>
@@ -85,6 +86,7 @@ namespace Neo.Wallets.NEP6
         {
             this.password = password.ToSecureString();
             LoadFromJson(json, out Scrypt, out accounts, out extra);
+            Thread.MemoryBarrier();
         }
 
         private void LoadFromJson(JObject wallet, out ScryptParameters scrypt, out Dictionary<UInt160, NEP6Account> accounts, out JToken extra)
@@ -94,7 +96,6 @@ namespace Neo.Wallets.NEP6
             scrypt = ScryptParameters.FromJson((JObject)wallet["scrypt"]);
             accounts = ((JArray)wallet["accounts"]).Select(p => NEP6Account.FromJson((JObject)p, this)).ToDictionary(p => p.ScriptHash);
             extra = wallet["extra"];
-            Thread.MemoryBarrier();
             if (!VerifyPasswordInternal(password.GetClearText()))
                 throw new InvalidOperationException("Wrong password.");
         }

--- a/src/Plugins/SQLiteWallet/SQLiteWallet.cs
+++ b/src/Plugins/SQLiteWallet/SQLiteWallet.cs
@@ -318,6 +318,7 @@ class SQLiteWallet : Wallet
             account.Contract = contract;
             account.Key = new KeyPair(GetPrivateKeyFromNEP2(db_contract.Account.Nep2key, masterKey, ProtocolSettings.AddressVersion, scrypt.N, scrypt.R, scrypt.P));
         }
+        Thread.MemoryBarrier();
         return accounts;
     }
 


### PR DESCRIPTION
# Description

Wallets may created later after the process started, and these Wallets implementations use lock to protect inner structures, however, no proper synchronization is used when the object is initialized.

According to the C# memory model, a thread may see a partial constructed object or there are some inflight operations when another thread is creating an Object(especially the CPU with relax consistency model).

https://learn.microsoft.com/en-us/archive/msdn-magazine/2012/december/csharp-the-csharp-memory-model-in-theory-and-practice#thread-communication-patterns

## Type of change
- [ ] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
