### PR TITLE
Add canonical `TryGet` style in `IReadOnlyStore`

### DIFF
--- a/src/Neo/Persistence/IReadOnlyStore.cs
+++ b/src/Neo/Persistence/IReadOnlyStore.cs
@@ -9,6 +9,7 @@
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
+using System;
 using System.Collections.Generic;
 
 namespace Neo.Persistence
@@ -31,7 +32,16 @@ namespace Neo.Persistence
         /// </summary>
         /// <param name="key">The key of the entry.</param>
         /// <returns>The data of the entry. Or <see langword="null"/> if it doesn't exist.</returns>
+        /// <seealso cref="TryGet(byte[], out byte[])"/>. Obsolete it later for avoiding complier warning.
         byte[] TryGet(byte[] key);
+
+        /// <summary>
+        /// Reads a specified entry from the database.
+        /// </summary>
+        /// <param name="key">The key of the entry.</param>
+        /// <param name="value">The data of the entry.</param>
+        /// <returns><see langword="true"/> if the entry exists; otherwise, <see langword="false"/>.</returns>
+        bool TryGet(byte[] key, out byte[] value);
 
         /// <summary>
         /// Determines whether the database contains the specified entry.

--- a/src/Neo/Persistence/MemorySnapshot.cs
+++ b/src/Neo/Persistence/MemorySnapshot.cs
@@ -69,6 +69,11 @@ namespace Neo.Persistence
             return value?[..];
         }
 
+        public bool TryGet(byte[] key, out byte[] value)
+        {
+            return immutableData.TryGetValue(key, out value);
+        }
+
         public bool Contains(byte[] key)
         {
             return immutableData.ContainsKey(key);

--- a/src/Neo/Persistence/MemoryStore.cs
+++ b/src/Neo/Persistence/MemoryStore.cs
@@ -67,6 +67,12 @@ namespace Neo.Persistence
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool TryGet(byte[] key, out byte[] value)
+        {
+            return _innerData.TryGetValue(key, out value);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Contains(byte[] key)
         {
             return _innerData.ContainsKey(key);

--- a/src/Plugins/LevelDBStore/Plugins/Storage/Snapshot.cs
+++ b/src/Plugins/LevelDBStore/Plugins/Storage/Snapshot.cs
@@ -65,5 +65,11 @@ namespace Neo.Plugins.Storage
         {
             return db.Get(options, key);
         }
+
+        public bool TryGet(byte[] key, out byte[] value)
+        {
+            value = db.Get(options, key);
+            return value != null;
+        }
     }
 }

--- a/src/Plugins/LevelDBStore/Plugins/Storage/Store.cs
+++ b/src/Plugins/LevelDBStore/Plugins/Storage/Store.cs
@@ -63,5 +63,11 @@ namespace Neo.Plugins.Storage
         {
             return db.Get(ReadOptions.Default, key);
         }
+
+        public bool TryGet(byte[] key, out byte[] value)
+        {
+            value = db.Get(ReadOptions.Default, key);
+            return value != null;
+        }
     }
 }

--- a/src/Plugins/RocksDBStore/Plugins/Storage/Snapshot.cs
+++ b/src/Plugins/RocksDBStore/Plugins/Storage/Snapshot.cs
@@ -73,6 +73,12 @@ namespace Neo.Plugins.Storage
             return db.Get(key, readOptions: options);
         }
 
+        public bool TryGet(byte[] key, out byte[] value)
+        {
+            value = db.Get(key, readOptions: options);
+            return value != null;
+        }
+
         public void Dispose()
         {
             snapshot.Dispose();

--- a/src/Plugins/RocksDBStore/Plugins/Storage/Store.cs
+++ b/src/Plugins/RocksDBStore/Plugins/Storage/Store.cs
@@ -59,6 +59,12 @@ namespace Neo.Plugins.Storage
             return db.Get(key);
         }
 
+        public bool TryGet(byte[] key, out byte[] value)
+        {
+            value = db.Get(key);
+            return value != null;
+        }
+
         public void Delete(byte[] key)
         {
             db.Remove(key);

--- a/tests/Neo.Cryptography.MPTTrie.Tests/Cryptography/MPTTrie/UT_Trie.cs
+++ b/tests/Neo.Cryptography.MPTTrie.Tests/Cryptography/MPTTrie/UT_Trie.cs
@@ -52,6 +52,11 @@ namespace Neo.Cryptography.MPTTrie.Tests
             return null;
         }
 
+        public bool TryGet(byte[] key, out byte[] value)
+        {
+            return store.TryGetValue(StoreKey(key), out value);
+        }
+
         public void Dispose() { throw new System.NotImplementedException(); }
 
         public int Size => store.Count;

--- a/tests/Neo.Plugins.Storage.Tests/StoreTest.cs
+++ b/tests/Neo.Plugins.Storage.Tests/StoreTest.cs
@@ -85,6 +85,8 @@ namespace Neo.Plugins.Storage.Tests
             snapshot.Put(testKey, testValue);
             // Data saved to the leveldb snapshot shall not be visible to the store
             Assert.IsNull(snapshot.TryGet(testKey));
+            Assert.IsFalse(snapshot.TryGet(testKey, out var got));
+            Assert.IsNull(got);
 
             // Value is in the write batch, not visible to the store and snapshot
             Assert.AreEqual(false, snapshot.Contains(testKey));
@@ -94,7 +96,13 @@ namespace Neo.Plugins.Storage.Tests
 
             // After commit, the data shall be visible to the store but not to the snapshot
             Assert.IsNull(snapshot.TryGet(testKey));
+            Assert.IsFalse(snapshot.TryGet(testKey, out got));
+            Assert.IsNull(got);
+
             CollectionAssert.AreEqual(testValue, store.TryGet(testKey));
+            Assert.IsTrue(store.TryGet(testKey, out got));
+            CollectionAssert.AreEqual(testValue, got);
+
             Assert.AreEqual(false, snapshot.Contains(testKey));
             Assert.AreEqual(true, store.Contains(testKey));
 
@@ -154,7 +162,12 @@ namespace Neo.Plugins.Storage.Tests
             snapshot.Put(testKey, testValue);
             // Data saved to the leveldb snapshot shall not be visible
             Assert.IsNull(snapshot.TryGet(testKey));
+            Assert.IsFalse(snapshot.TryGet(testKey, out var got));
+            Assert.IsNull(got);
+
             Assert.IsNull(store.TryGet(testKey));
+            Assert.IsFalse(store.TryGet(testKey, out got));
+            Assert.IsNull(got);
 
             // Value is in the write batch, not visible to the store and snapshot
             Assert.AreEqual(false, snapshot.Contains(testKey));
@@ -164,7 +177,13 @@ namespace Neo.Plugins.Storage.Tests
 
             // After commit, the data shall be visible to the store but not to the snapshot
             Assert.IsNull(snapshot.TryGet(testKey));
+            Assert.IsFalse(snapshot.TryGet(testKey, out got));
+            Assert.IsNull(got);
+
             CollectionAssert.AreEqual(testValue, store.TryGet(testKey));
+            Assert.IsTrue(store.TryGet(testKey, out got));
+            CollectionAssert.AreEqual(testValue, got);
+
             Assert.AreEqual(false, snapshot.Contains(testKey));
             Assert.AreEqual(true, store.Contains(testKey));
 

--- a/tests/Neo.UnitTests/Persistence/UT_MemorySnapshot.cs
+++ b/tests/Neo.UnitTests/Persistence/UT_MemorySnapshot.cs
@@ -97,6 +97,14 @@ public class UT_MemorySnapshot
         Assert.IsNull(_snapshot.TryGet(key1));
         CollectionAssert.AreEqual(value1, snapshot2.TryGet(key1));
 
+        Assert.IsFalse(_snapshot.TryGet(key1, out var value2));
+
+        Assert.IsTrue(snapshot2.TryGet(key1, out value2));
+        CollectionAssert.AreEqual(value1, value2);
+
+        Assert.IsTrue(_memoryStore.TryGet(key1, out value2));
+        CollectionAssert.AreEqual(value1, value2);
+
         _snapshot.Delete(key1);
 
         // Deleted value can not being found from the snapshot but can still get from the store and snapshot2

--- a/tests/Neo.UnitTests/Persistence/UT_MemoryStore.cs
+++ b/tests/Neo.UnitTests/Persistence/UT_MemoryStore.cs
@@ -51,6 +51,9 @@ namespace Neo.UnitTests.Persistence
 
             store.Delete([1]);
             Assert.AreEqual(null, store.TryGet([1]));
+            Assert.IsFalse(store.TryGet([1], out var got));
+            Assert.AreEqual(null, got);
+
             store.Put([1], [1, 2, 3]);
             CollectionAssert.AreEqual(new byte[] { 1, 2, 3 }, store.TryGet([1]));
 
@@ -79,13 +82,18 @@ namespace Neo.UnitTests.Persistence
             var store = _neoSystem.StoreView;
             var key = new StorageKey(Encoding.UTF8.GetBytes("testKey"));
             var value = new StorageItem(Encoding.UTF8.GetBytes("testValue"));
+
             store.Add(key, value);
             store.Commit();
+
             var result = store.TryGet(key);
             // The StoreView is a readonly view of the store, here it will have value in the cache
             Assert.AreEqual("testValue", Encoding.UTF8.GetString(result.Value.ToArray()));
-            // But the value will  not be written to the underlying store even its committed.
+
+            // But the value will not be written to the underlying store even its committed.
             Assert.IsNull(_memoryStore.TryGet(key.ToArray()));
+            Assert.IsFalse(_memoryStore.TryGet(key.ToArray(), out var got));
+            Assert.AreEqual(null, got);
         }
 
         [TestMethod]


### PR DESCRIPTION
# Description

The canonical TryXXX style in C# is 
```csharp
public bool TryXXX(key KeyType, out value ValueType) {
   // ...
}
```

This PR is to add a TryGet meeting to canonical style.
In order to avoid too many changes, only the method has been added here, and nothing else has been changed. 

## Type of change

- [ ] Optimization (the change is only an optimization)
- [x] Style (the change is only a code style for better maintenance or standard purpose)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
