### PR TITLE
ApplicationEngine helper to get engine error info

### DIFF
--- a/src/Neo/SmartContract/ApplicationEngine.Helper.cs
+++ b/src/Neo/SmartContract/ApplicationEngine.Helper.cs
@@ -1,0 +1,58 @@
+// Copyright (C) 2015-2024 The Neo Project.
+//
+// ApplicationEngine.Helper.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Neo.SmartContract.Native;
+using Neo.VM;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Neo.SmartContract
+{
+    public partial class ApplicationEngine : ExecutionEngine
+    {
+        public string GetEngineErrorInfo()
+        {
+            if (State != VMState.FAULT || FaultException == null)
+                return null;
+            StringBuilder traceback = new();
+            try
+            {
+                if (CallingScriptHash != null)
+                    traceback.AppendLine($"CallingScriptHash={CallingScriptHash}[{NativeContract.ContractManagement.GetContract(SnapshotCache, CallingScriptHash)?.Manifest.Name}]");
+            }
+            catch { }
+            try
+            {
+                traceback.AppendLine($"CurrentScriptHash={CurrentScriptHash}[{NativeContract.ContractManagement.GetContract(SnapshotCache, CurrentScriptHash)?.Manifest.Name}]");
+            }
+            catch { }
+            try
+            {
+                traceback.AppendLine($"EntryScriptHash={EntryScriptHash}");
+            }
+            catch { }
+
+            foreach (ExecutionContext context in InvocationStack.Reverse())
+            {
+                UInt160 contextScriptHash = context.GetScriptHash();
+                string contextContractName = NativeContract.ContractManagement.GetContract(SnapshotCache, contextScriptHash)?.Manifest.Name;
+                traceback.AppendLine($"\tInstructionPointer={context.InstructionPointer}, OpCode {context.CurrentInstruction?.OpCode}, Script Length={context.Script.Length} {contextScriptHash}[{contextContractName}]");
+            }
+            Exception baseException = FaultException.GetBaseException();
+            traceback.AppendLine(baseException.StackTrace);
+            traceback.AppendLine(baseException.Message);
+
+            return traceback.ToString();
+        }
+    }
+}

--- a/tests/Neo.UnitTests/SmartContract/UT_ApplicationEngine.cs
+++ b/tests/Neo.UnitTests/SmartContract/UT_ApplicationEngine.cs
@@ -167,8 +167,15 @@ namespace Neo.UnitTests.SmartContract
                 };
                 var currentScriptHash = engine.EntryScriptHash;
 
+                Assert.IsNull(engine.GetEngineErrorInfo());
                 Assert.AreEqual(VMState.FAULT, engine.Execute());
                 Assert.IsTrue(engine.FaultException.ToString().Contains($"Cannot Call Method disallowed Of Contract {scriptHash.ToString()}"));
+                string traceback = engine.GetEngineErrorInfo();
+                Assert.IsTrue(traceback.Contains($"Cannot Call Method disallowed Of Contract {scriptHash.ToString()}"));
+                Assert.IsTrue(traceback.Contains("CurrentScriptHash"));
+                Assert.IsTrue(traceback.Contains("EntryScriptHash"));
+                Assert.IsTrue(traceback.Contains("InstructionPointer"));
+                Assert.IsTrue(traceback.Contains("OpCode SYSCALL, Script Length="));
             }
 
             // Allowed method call.


### PR DESCRIPTION
# Description

Get string that describes the exception and stack of execution context in a FAULTed application engine. Downstream tool, especially blockchain explorers, can conveniently get the error info when needed.

## Type of change

- [x] Style (the change is only a code style for better maintenance or standard purpose)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

No specific additional tests. Just called `GetEngineErrorInfo` in existing tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
