### PR TITLE
OpCode.NZ handles null

### DIFF
--- a/src/Neo.VM/JumpTable/JumpTable.Numeric.cs
+++ b/src/Neo.VM/JumpTable/JumpTable.Numeric.cs
@@ -321,8 +321,13 @@ namespace Neo.VM
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public virtual void Nz(ExecutionEngine engine, Instruction instruction)
         {
-            var x = engine.Pop().GetInteger();
-            engine.Push(!x.IsZero);
+            //var x = engine.Pop().GetInteger();
+            //engine.Push(!x.IsZero);
+            var x = engine.Pop();
+            if (x is Neo.VM.Types.Null)
+                engine.Push(true);
+            else
+                engine.Push(!x.GetInteger().IsZero);
         }
 
         /// <summary>


### PR DESCRIPTION
# Description

It's almost impossible to utilize OpCode.NZ, because null != 0 is not handled in OpCode.NZ. It throws Exception for null.
Hardfork required.

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Not tested for now

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
