### PR TITLE
OpCodes: extend MODPOW tests with negative base/exp/mod

### DIFF
--- a/tests/Neo.VM.Tests/Tests/OpCodes/Arithmetic/MODPOW.json
+++ b/tests/Neo.VM.Tests/Tests/OpCodes/Arithmetic/MODPOW.json
@@ -140,6 +140,350 @@
           }
         }
       ]
+    },
+    {
+      "name": "(3 ^ 4) % 5 == 1",
+      "script": [
+        "PUSH3",
+        "PUSH4",
+        "PUSH5",
+        "MODPOW"
+      ],
+      "steps": [
+        {
+          "actions": [
+            "stepInto",
+            "stepInto",
+            "stepInto"
+          ],
+          "result": {
+            "state": "BREAK",
+            "invocationStack": [
+              {
+                "instructionPointer": 3,
+                "nextInstruction": "MODPOW",
+                "evaluationStack": [
+                  {
+                    "type": "Integer",
+                    "value": 5
+                  },
+                  {
+                    "type": "Integer",
+                    "value": 4
+                  },
+                  {
+                    "type": "Integer",
+                    "value": 3
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "actions": [
+            "execute"
+          ],
+          "result": {
+            "state": "HALT",
+            "invocationStack": [],
+            "resultStack": [
+              {
+                "type": "Integer",
+                "value": 1
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "(-1 ^ 3) % 3 == -1",
+      "script": [
+        "PUSHM1",
+        "PUSH3",
+        "PUSH3",
+        "MODPOW"
+      ],
+      "steps": [
+        {
+          "actions": [
+            "stepInto",
+            "stepInto",
+            "stepInto"
+          ],
+          "result": {
+            "state": "BREAK",
+            "invocationStack": [
+              {
+                "instructionPointer": 3,
+                "nextInstruction": "MODPOW",
+                "evaluationStack": [
+                  {
+                    "type": "Integer",
+                    "value": 3
+                  },
+                  {
+                    "type": "Integer",
+                    "value": 3
+                  },
+                  {
+                    "type": "Integer",
+                    "value": -1
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "actions": [
+            "execute"
+          ],
+          "result": {
+            "state": "HALT",
+            "invocationStack": [],
+            "resultStack": [
+              {
+                "type": "Integer",
+                "value": -1
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "(-1 ^ 3) % -3 == -1",
+      "script": [
+        "PUSHM1",
+        "PUSH3",
+        "PUSH3",
+        "NEGATE",
+        "MODPOW"
+      ],
+      "steps": [
+        {
+          "actions": [
+            "stepInto",
+            "stepInto",
+            "stepInto",
+            "stepInto"
+          ],
+          "result": {
+            "state": "BREAK",
+            "invocationStack": [
+              {
+                "instructionPointer": 4,
+                "nextInstruction": "MODPOW",
+                "evaluationStack": [
+                  {
+                    "type": "Integer",
+                    "value": -3
+                  },
+                  {
+                    "type": "Integer",
+                    "value": 3
+                  },
+                  {
+                    "type": "Integer",
+                    "value": -1
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "actions": [
+            "execute"
+          ],
+          "result": {
+            "state": "HALT",
+            "invocationStack": [],
+            "resultStack": [
+              {
+                "type": "Integer",
+                "value": -1
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "(-3 ^ 5) % -5 == -3",
+      "script": [
+        "PUSH3",
+        "NEGATE",
+        "PUSH5",
+        "PUSH5",
+        "NEGATE",
+        "MODPOW"
+      ],
+      "steps": [
+        {
+          "actions": [
+            "stepInto",
+            "stepInto",
+            "stepInto",
+            "stepInto",
+            "stepInto"
+          ],
+          "result": {
+            "state": "BREAK",
+            "invocationStack": [
+              {
+                "instructionPointer": 5,
+                "nextInstruction": "MODPOW",
+                "evaluationStack": [
+                  {
+                    "type": "Integer",
+                    "value": -5
+                  },
+                  {
+                    "type": "Integer",
+                    "value": 5
+                  },
+                  {
+                    "type": "Integer",
+                    "value": -3
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "actions": [
+            "execute"
+          ],
+          "result": {
+            "state": "HALT",
+            "invocationStack": [],
+            "resultStack": [
+              {
+                "type": "Integer",
+                "value": -3
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "(3 ^ 4) % -5 == 1",
+      "script": [
+        "PUSH3",
+        "PUSH4",
+        "PUSH5",
+        "NEGATE",
+        "MODPOW"
+      ],
+      "steps": [
+        {
+          "actions": [
+            "stepInto",
+            "stepInto",
+            "stepInto",
+            "stepInto"
+          ],
+          "result": {
+            "state": "BREAK",
+            "invocationStack": [
+              {
+                "instructionPointer": 4,
+                "nextInstruction": "MODPOW",
+                "evaluationStack": [
+                  {
+                    "type": "Integer",
+                    "value": -5
+                  },
+                  {
+                    "type": "Integer",
+                    "value": 4
+                  },
+                  {
+                    "type": "Integer",
+                    "value": 3
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "actions": [
+            "execute"
+          ],
+          "result": {
+            "state": "HALT",
+            "invocationStack": [],
+            "resultStack": [
+              {
+                "type": "Integer",
+                "value": 1
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "(5 ^ -1) % 4 == 1",
+      "script": [
+        "PUSH5",
+        "PUSHM1",
+        "PUSH4",
+        "MODPOW"
+      ],
+      "steps": [
+        {
+          "actions": [
+            "stepInto",
+            "stepInto",
+            "stepInto"
+          ],
+          "result": {
+            "state": "BREAK",
+            "invocationStack": [
+              {
+                "instructionPointer": 3,
+                "nextInstruction": "MODPOW",
+                "evaluationStack": [
+                  {
+                    "type": "Integer",
+                    "value": 4
+                  },
+                  {
+                    "type": "Integer",
+                    "value": -1
+                  },
+                  {
+                    "type": "Integer",
+                    "value": 5
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "actions": [
+            "execute"
+          ],
+          "result": {
+            "state": "HALT",
+            "invocationStack": [],
+            "resultStack": [
+              {
+                "type": "Integer",
+                "value": 1
+              }
+            ]
+          }
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
# Description

We need to ensure that NeoGo VM behaviour is compatible, ref. https://github.com/nspcc-dev/neo-go/pull/3649. Similar to https://github.com/neo-project/neo/pull/3513.

## Type of change

- [X] Unit test.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
