### PR TITLE
fix: `Object.Equals` shouldn't throw any `Exception`

### DIFF
--- a/benchmarks/Neo.Benchmarks/OldUInt160.cs
+++ b/benchmarks/Neo.Benchmarks/OldUInt160.cs
@@ -78,7 +78,7 @@ namespace Neo
         public override bool Equals(object obj)
         {
             if (ReferenceEquals(obj, this)) return true;
-            return Equals(obj as OldUInt160);
+            return obj is OldUInt160 other && Equals(other);
         }
 
         public bool Equals(OldUInt160 other)

--- a/src/Neo/Network/P2P/Payloads/Block.cs
+++ b/src/Neo/Network/P2P/Payloads/Block.cs
@@ -108,7 +108,7 @@ namespace Neo.Network.P2P.Payloads
 
         public override bool Equals(object obj)
         {
-            return Equals(obj as Block);
+            return obj is Block other && Equals(other);
         }
 
         public override int GetHashCode()

--- a/src/Neo/Network/P2P/Payloads/Header.cs
+++ b/src/Neo/Network/P2P/Payloads/Header.cs
@@ -180,7 +180,7 @@ namespace Neo.Network.P2P.Payloads
 
         public override bool Equals(object obj)
         {
-            return Equals(obj as Header);
+            return obj is Header other && Equals(other);
         }
 
         public override int GetHashCode()

--- a/src/Neo/Network/P2P/Payloads/Transaction.cs
+++ b/src/Neo/Network/P2P/Payloads/Transaction.cs
@@ -254,7 +254,7 @@ namespace Neo.Network.P2P.Payloads
 
         public override bool Equals(object obj)
         {
-            return Equals(obj as Transaction);
+            return obj is Transaction other && Equals(other);
         }
 
         void IInteroperable.FromStackItem(StackItem stackItem)

--- a/src/Neo/UInt160.cs
+++ b/src/Neo/UInt160.cs
@@ -84,7 +84,7 @@ namespace Neo
         public override bool Equals(object obj)
         {
             if (ReferenceEquals(obj, this)) return true;
-            return Equals(obj as UInt160);
+            return obj is UInt160 other && Equals(other);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Neo/UInt256.cs
+++ b/src/Neo/UInt256.cs
@@ -84,7 +84,7 @@ namespace Neo
         public override bool Equals(object obj)
         {
             if (ReferenceEquals(obj, this)) return true;
-            return Equals(obj as UInt256);
+            return obj is UInt256 other && Equals(other);
         }
 
         public bool Equals(UInt256 other)

--- a/src/Neo/Wallets/KeyPair.cs
+++ b/src/Neo/Wallets/KeyPair.cs
@@ -68,7 +68,7 @@ namespace Neo.Wallets
 
         public override bool Equals(object obj)
         {
-            return Equals(obj as KeyPair);
+            return obj is KeyPair other && Equals(other);
         }
 
         /// <summary>

--- a/src/Plugins/SQLiteWallet/VerificationContract.cs
+++ b/src/Plugins/SQLiteWallet/VerificationContract.cs
@@ -41,7 +41,7 @@ class VerificationContract : SmartContract.Contract, IEquatable<VerificationCont
 
     public override bool Equals(object obj)
     {
-        return Equals(obj as VerificationContract);
+        return obj is VerificationContract other && Equals(other);
     }
 
     public override int GetHashCode()

--- a/tests/Neo.UnitTests/Network/P2P/Payloads/UT_Block.cs
+++ b/tests/Neo.UnitTests/Network/P2P/Payloads/UT_Block.cs
@@ -170,6 +170,8 @@ namespace Neo.UnitTests.Network.P2P.Payloads
             TestUtils.SetupBlockWithValues(null, uut, prevHash, out _, out _, out _, out _, out _, out _, out _, 0);
 
             uut.Equals(newBlock).Should().BeFalse();
+
+            uut.Equals("0").Should().BeFalse();
         }
 
         [TestMethod]

--- a/tests/Neo.UnitTests/Network/P2P/Payloads/UT_Header.cs
+++ b/tests/Neo.UnitTests/Network/P2P/Payloads/UT_Header.cs
@@ -114,9 +114,10 @@ namespace Neo.UnitTests.Network.P2P.Payloads
         }
 
         [TestMethod]
-        public void Equals_Null()
+        public void Equals_Other()
         {
             uut.Equals(null).Should().BeFalse();
+            uut.Equals("0").Should().BeFalse();
         }
 
 

--- a/tests/Neo.UnitTests/Network/P2P/Payloads/UT_Transaction.cs
+++ b/tests/Neo.UnitTests/Network/P2P/Payloads/UT_Transaction.cs
@@ -1289,5 +1289,13 @@ namespace Neo.UnitTests.Network.P2P.Payloads
             var result = tx.VerifyStateIndependent(settings);
             Assert.AreEqual(VerifyResult.Succeed, result);
         }
+
+        [TestMethod]
+        public void TestTransaction_Equals()
+        {
+            uut.Equals(null).Should().BeFalse();
+            uut.Equals("0").Should().BeFalse();
+            uut.Equals(uut).Should().BeTrue();
+        }
     }
 }

--- a/tests/Neo.UnitTests/UT_UInt160.cs
+++ b/tests/Neo.UnitTests/UT_UInt160.cs
@@ -126,5 +126,12 @@ namespace Neo.UnitTests.IO
             Assert.AreEqual(true, UInt160.Zero <= UInt160.Zero);
             Assert.IsTrue(UInt160.Zero >= "0x0000000000000000000000000000000000000000");
         }
+
+        [TestMethod]
+        public void TestUInt160_Equals()
+        {
+            var a = new UInt160();
+            Assert.IsFalse(a.Equals((object)"0"));
+        }
     }
 }

--- a/tests/Neo.UnitTests/UT_UInt256.cs
+++ b/tests/Neo.UnitTests/UT_UInt256.cs
@@ -98,6 +98,8 @@ namespace Neo.UnitTests.IO
             object temp3 = new();
             Assert.AreEqual(false, temp1.Equals(temp2));
             Assert.AreEqual(false, temp1.Equals(temp3));
+
+            Assert.IsFalse(temp1.Equals((object)"0"));
         }
 
         [TestMethod]

--- a/tests/Neo.UnitTests/Wallets/UT_KeyPair.cs
+++ b/tests/Neo.UnitTests/Wallets/UT_KeyPair.cs
@@ -70,6 +70,8 @@ namespace Neo.UnitTests.Wallets
             KeyPair keyPair4 = new KeyPair(privateKey1);
             KeyPair keyPair5 = new KeyPair(privateKey2);
             keyPair4.Equals(keyPair5).Should().BeFalse();
+
+            keyPair4.Equals("0").Should().BeFalse();
         }
 
         [TestMethod]


### PR DESCRIPTION
# Description

A partial fix of #3560 

## Type of change
- [ ] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
