### PR TITLE
use `MemoryExtenions.SequenceEqual`  for better performance

### DIFF
--- a/src/Neo.Cryptography.BLS12_381/Fp.cs
+++ b/src/Neo.Cryptography.BLS12_381/Fp.cs
@@ -9,6 +9,7 @@
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
+using Neo.Extensions;
 using System.Buffers.Binary;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
@@ -152,11 +153,7 @@ namespace Neo.Cryptography.BLS12_381
 
         public override string ToString()
         {
-            var output = string.Empty;
-            foreach (var b in ToArray())
-                output += b.ToString("x2");
-
-            return "0x" + output;
+            return "0x" + ToArray().ToHexString();
         }
 
         public bool LexicographicallyLargest()

--- a/src/Neo.Extensions/ByteArrayEqualityComparer.cs
+++ b/src/Neo.Extensions/ByteArrayEqualityComparer.cs
@@ -11,7 +11,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Neo.Extensions
 {
@@ -24,7 +23,7 @@ namespace Neo.Extensions
             if (ReferenceEquals(x, y)) return true;
             if (x is null || y is null || x.Length != y.Length) return false;
 
-            return x.SequenceEqual(y);
+            return x.AsSpan().SequenceEqual(y.AsSpan());
         }
 
         public int GetHashCode(byte[] obj)


### PR DESCRIPTION
# Description

`MemoryExtenions.SequenceEqual` is faster then  `SequenceEqual` in `System.Linq`.


## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
