### PR TITLE
fix: Same maps should have the same hash-code

### DIFF
--- a/src/Neo.VM/Types/Map.cs
+++ b/src/Neo.VM/Types/Map.cs
@@ -181,5 +181,18 @@ namespace Neo.VM.Types
                 throw new ArgumentException($"MaxKeySize exceed: {key.Size}");
             return dictionary.TryGetValue(key, out value);
         }
+
+        /// <summary>
+        /// Gets the hash code of the map.
+        /// </summary>
+        /// <returns>The hash code of the map.</returns>
+        public override int GetHashCode()
+        {
+            var keysHashCode = 0;
+            // only keys are used.
+            foreach (var item in Keys)
+                keysHashCode ^= item.GetHashCode();
+            return HashCode.Combine(Count, (int)Type, keysHashCode);
+        }
     }
 }

--- a/tests/Neo.VM.Tests/UT_StackItem.cs
+++ b/tests/Neo.VM.Tests/UT_StackItem.cs
@@ -96,7 +96,9 @@ namespace Neo.Test
             itemC = new Map { [true] = false, [0] = 2 };
 
             Assert.IsTrue(itemA.GetHashCode() == itemB.GetHashCode());
-            Assert.IsTrue(itemA.GetHashCode() != itemC.GetHashCode());
+
+            // It is OK for different maps to have the same hashcode.
+            // Assert.IsTrue(itemA.GetHashCode() != itemC.GetHashCode());
 
             // Test CompoundType GetHashCode for subitems
             var junk = new Array { true, false, 0 };
@@ -105,7 +107,7 @@ namespace Neo.Test
             itemC = new Map { [true] = junk, [0] = 2 };
 
             Assert.IsTrue(itemA.GetHashCode() == itemB.GetHashCode());
-            Assert.IsTrue(itemA.GetHashCode() != itemC.GetHashCode());
+            // Assert.IsTrue(itemA.GetHashCode() != itemC.GetHashCode());
 
             itemA = new InteropInterface(123);
             itemB = new InteropInterface(123);
@@ -121,6 +123,17 @@ namespace Neo.Test
 
             Assert.IsTrue(itemA.GetHashCode() == itemB.GetHashCode());
             Assert.IsTrue(itemA.GetHashCode() != itemC.GetHashCode());
+
+            var map1 = new Map();
+            map1[1] = 2;
+            map1[3] = 4;
+
+            var map2 = new Map();
+            map2[3] = 4;
+            map2[1] = 2;
+
+            // Same maps should have the same hashcode.
+            Assert.AreEqual(map1.GetHashCode(), map2.GetHashCode());
         }
 
         [TestMethod]


### PR DESCRIPTION
There is such a cause here:
```csharp
            var map1 = new Map();
            map1[1] = 2;
            map1[3] = 4;

            var map2 = new Map();
            map2[3] = 4;
            map2[1] = 2;
        
            Assert.AreEqual(map1.GetHashCode(), map2.GetHashCode());
```
Assert.AreEqual will be failed.
Because VM.Map uses `OrderedDictionary` internally, but OrderedDictionary is not **ordered**.

Should `OrderedDictionary` should be renamed?  Like  `LinkedDictionary`.
It's easy to misunderstand what this `Ordered` means.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
