### PR TITLE
Lower Timeout for the Akka System

### DIFF
--- a/src/Neo/NeoSystem.cs
+++ b/src/Neo/NeoSystem.cs
@@ -221,7 +221,7 @@ namespace Neo
             using Inbox inbox = Inbox.Create(ActorSystem);
             inbox.Watch(actor);
             ActorSystem.Stop(actor);
-            inbox.Receive(TimeSpan.FromSeconds(15));
+            inbox.Receive(TimeSpan.FromSeconds(30));
         }
 
         /// <summary>

--- a/src/Neo/NeoSystem.cs
+++ b/src/Neo/NeoSystem.cs
@@ -221,7 +221,7 @@ namespace Neo
             using Inbox inbox = Inbox.Create(ActorSystem);
             inbox.Watch(actor);
             ActorSystem.Stop(actor);
-            inbox.Receive(TimeSpan.FromMinutes(5));
+            inbox.Receive(TimeSpan.FromSeconds(15));
         }
 
         /// <summary>


### PR DESCRIPTION
# Description

Lower the timeout of the blocking thread for the `NeoSystem`. 5 mins is to way too long to wait for the application to exit. In this case the `neo-cli`.

** Side Note:** _You can use `ActorSystem.stop` with an Akka `Inbox`, but it's important to understand that stopping the `ActorSystem` will effectively stop all actors within it, including the actor that manages the Inbox, rendering it unusable; therefore, you should typically focus on stopping the specific actor associated with the Inbox if you want to gracefully shut down its functionality while keeping the `ActorSystem` running for other actors._

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
