### PR TITLE
Fixed `GetVarSize`

### DIFF
--- a/src/Neo.Extensions/UnsafeData.cs
+++ b/src/Neo.Extensions/UnsafeData.cs
@@ -18,14 +18,16 @@ namespace Neo.Extensions
         /// </summary>
         /// <param name="value">The length of the data.</param>
         /// <returns>The size of variable-length of the data.</returns>
-        public static int GetVarSize(int value)
+        public static int GetVarSize(long value)
         {
             if (value < 0xFD)
                 return sizeof(byte);
-            else if (value <= 0xFFFF)
+            else if (value <= ushort.MaxValue)
                 return sizeof(byte) + sizeof(ushort);
-            else
+            else if (value <= uint.MaxValue)
                 return sizeof(byte) + sizeof(uint);
+            else
+                return sizeof(byte) + sizeof(ulong);
         }
     }
 }


### PR DESCRIPTION
# Description

- fixed `GetVarSize` -- was not computing `ulong` aka `0xff` `VarInt`

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
