### PR TITLE
Preallocate Memory to reduce memory reallocations in `KeyBuilder`

### DIFF
--- a/src/Neo/SmartContract/KeyBuilder.cs
+++ b/src/Neo/SmartContract/KeyBuilder.cs
@@ -21,15 +21,22 @@ namespace Neo.SmartContract
     /// </summary>
     public class KeyBuilder
     {
-        private readonly MemoryStream stream = new();
+        private readonly MemoryStream stream;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="KeyBuilder"/> class.
         /// </summary>
         /// <param name="id">The id of the contract.</param>
         /// <param name="prefix">The prefix of the key.</param>
-        public KeyBuilder(int id, byte prefix)
+        /// <param name="capacityHint">
+        /// The initial capacity of the stream.
+        /// It is better to set this to the expected size of the key(not including the id and prefix).
+        /// </param>
+        public KeyBuilder(int id, byte prefix, int capacityHint = 0)
         {
+            var prefixSize = sizeof(int) + sizeof(byte);
+            stream = capacityHint > 0 ? new MemoryStream(prefixSize + capacityHint) : new MemoryStream(prefixSize);
+
             var data = new byte[sizeof(int)];
             BinaryPrimitives.WriteInt32LittleEndian(data, id);
 

--- a/src/Neo/SmartContract/Native/NativeContract.cs
+++ b/src/Neo/SmartContract/Native/NativeContract.cs
@@ -347,9 +347,9 @@ namespace Neo.SmartContract.Native
             return engine.CheckWitnessInternal(committeeMultiSigAddr);
         }
 
-        private protected KeyBuilder CreateStorageKey(byte prefix)
+        private protected KeyBuilder CreateStorageKey(byte prefix, int capacityHint = 0)
         {
-            return new KeyBuilder(Id, prefix);
+            return new KeyBuilder(Id, prefix, capacityHint);
         }
 
         /// <summary>

--- a/tests/Neo.UnitTests/SmartContract/UT_KeyBuilder.cs
+++ b/tests/Neo.UnitTests/SmartContract/UT_KeyBuilder.cs
@@ -22,7 +22,6 @@ namespace Neo.UnitTests.SmartContract
         public void Test()
         {
             var key = new KeyBuilder(1, 2);
-
             Assert.AreEqual("0100000002", key.ToArray().ToHexString());
 
             key = new KeyBuilder(1, 2);
@@ -41,6 +40,13 @@ namespace Neo.UnitTests.SmartContract
             key = new KeyBuilder(1, 0);
             key = key.AddBigEndian(1);
             Assert.AreEqual("010000000000000001", key.ToArray().ToHexString());
+
+            key = new KeyBuilder(1, 2, 20);
+            Assert.AreEqual("0100000002", key.ToArray().ToHexString());
+
+            key = new KeyBuilder(1, 2, 40);
+            key = key.Add(new byte[] { 3, 4 });
+            Assert.AreEqual("01000000020304", key.ToArray().ToHexString());
         }
     }
 }


### PR DESCRIPTION
# Description

Preallocate `MemoryStream` in `KeyBuilder` to reduce memory reallocations.
And add a part of the capacity parameters of `keyBuilder` construction.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
