### PR TITLE
Revert "[Remove] obsolete `WsServer`"

### DIFF
--- a/src/Neo/Network/P2P/Capabilities/NodeCapability.cs
+++ b/src/Neo/Network/P2P/Capabilities/NodeCapability.cs
@@ -56,7 +56,9 @@ namespace Neo.Network.P2P.Capabilities
             NodeCapabilityType type = (NodeCapabilityType)reader.ReadByte();
             NodeCapability capability = type switch
             {
-                NodeCapabilityType.TcpServer => new ServerCapability(type),
+#pragma warning disable CS0612 // Type or member is obsolete
+                NodeCapabilityType.TcpServer or NodeCapabilityType.WsServer => new ServerCapability(type),
+#pragma warning restore CS0612 // Type or member is obsolete
                 NodeCapabilityType.FullNode => new FullNodeCapability(),
                 _ => throw new FormatException(),
             };

--- a/src/Neo/Network/P2P/Capabilities/NodeCapabilityType.cs
+++ b/src/Neo/Network/P2P/Capabilities/NodeCapabilityType.cs
@@ -9,6 +9,8 @@
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
+using System;
+
 namespace Neo.Network.P2P.Capabilities
 {
     /// <summary>
@@ -22,6 +24,12 @@ namespace Neo.Network.P2P.Capabilities
         /// Indicates that the node is listening on a Tcp port.
         /// </summary>
         TcpServer = 0x01,
+
+        /// <summary>
+        /// Indicates that the node is listening on a WebSocket port.
+        /// </summary>
+        [Obsolete]
+        WsServer = 0x02,
 
         #endregion
 

--- a/src/Neo/Network/P2P/Capabilities/ServerCapability.cs
+++ b/src/Neo/Network/P2P/Capabilities/ServerCapability.cs
@@ -32,11 +32,13 @@ namespace Neo.Network.P2P.Capabilities
         /// <summary>
         /// Initializes a new instance of the <see cref="ServerCapability"/> class.
         /// </summary>
-        /// <param name="type">The type of the <see cref="ServerCapability"/>. It must be <see cref="NodeCapabilityType.TcpServer"/></param>
+        /// <param name="type">The type of the <see cref="ServerCapability"/>. It must be <see cref="NodeCapabilityType.TcpServer"/> or <see cref="NodeCapabilityType.WsServer"/></param>
         /// <param name="port">The port that the node is listening on.</param>
         public ServerCapability(NodeCapabilityType type, ushort port = 0) : base(type)
         {
-            if (type != NodeCapabilityType.TcpServer)
+#pragma warning disable CS0612 // Type or member is obsolete
+            if (type != NodeCapabilityType.TcpServer && type != NodeCapabilityType.WsServer)
+#pragma warning restore CS0612 // Type or member is obsolete
             {
                 throw new ArgumentException(nameof(type));
             }

--- a/tests/Neo.UnitTests/Network/P2P/Capabilities/UT_ServerCapability.cs
+++ b/tests/Neo.UnitTests/Network/P2P/Capabilities/UT_ServerCapability.cs
@@ -26,12 +26,18 @@ namespace Neo.UnitTests.Network.P2P.Capabilities
         {
             var test = new ServerCapability(NodeCapabilityType.TcpServer) { Port = 1 };
             test.Size.Should().Be(3);
+
+#pragma warning disable CS0612 // Type or member is obsolete
+            test = new ServerCapability(NodeCapabilityType.WsServer) { Port = 2 };
+#pragma warning restore CS0612 // Type or member is obsolete
+            test.Size.Should().Be(3);
         }
 
         [TestMethod]
         public void DeserializeAndSerialize()
         {
-            var test = new ServerCapability(NodeCapabilityType.TcpServer) { Port = 2 };
+#pragma warning disable CS0612 // Type or member is obsolete
+            var test = new ServerCapability(NodeCapabilityType.WsServer) { Port = 2 };
             var buffer = test.ToArray();
 
             var br = new MemoryReader(buffer);
@@ -40,13 +46,21 @@ namespace Neo.UnitTests.Network.P2P.Capabilities
             Assert.AreEqual(test.Port, clone.Port);
             Assert.AreEqual(test.Type, clone.Type);
 
-            clone = new ServerCapability(NodeCapabilityType.TcpServer, 123);
+            clone = new ServerCapability(NodeCapabilityType.WsServer, 123);
+#pragma warning restore CS0612 // Type or member is obsolete
             br = new MemoryReader(buffer);
             ((ISerializable)clone).Deserialize(ref br);
 
             Assert.AreEqual(test.Port, clone.Port);
             Assert.AreEqual(test.Type, clone.Type);
 
+            clone = new ServerCapability(NodeCapabilityType.TcpServer, 123);
+
+            Assert.ThrowsException<FormatException>(() =>
+            {
+                var br2 = new MemoryReader(buffer);
+                ((ISerializable)clone).Deserialize(ref br2);
+            });
             Assert.ThrowsException<ArgumentException>(() =>
             {
                 _ = new ServerCapability(NodeCapabilityType.FullNode);


### PR DESCRIPTION
We will have to wait until next release to remove this, once its out of the system and nodes stop sending it.

Reverts neo-project/neo#3582

Closes #3602