### PR TITLE
Add argument null check for `ToHexString` to keep same behavior between different .net versions

### DIFF
--- a/src/Neo.Extensions/ByteExtensions.cs
+++ b/src/Neo.Extensions/ByteExtensions.cs
@@ -50,12 +50,16 @@ namespace Neo.Extensions
         /// </summary>
         /// <param name="value">The byte array to convert.</param>
         /// <returns>The converted hex <see cref="string"/>.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="value"/> is null.</exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string ToHexString(this byte[] value)
         {
 #if NET9_0_OR_GREATER
             return Convert.ToHexStringLower(value);
 #else
+            if (value is null)
+                throw new ArgumentNullException(nameof(value));
+
             return string.Create(value.Length * 2, value, (span, bytes) =>
             {
                 for (var i = 0; i < bytes.Length; i++)
@@ -74,11 +78,15 @@ namespace Neo.Extensions
         /// <param name="value">The byte array to convert.</param>
         /// <param name="reverse">Indicates whether it should be converted in the reversed byte order.</param>
         /// <returns>The converted hex <see cref="string"/>.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="value"/> is null.</exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string ToHexString(this byte[] value, bool reverse = false)
         {
             if (!reverse)
                 return ToHexString(value);
+
+            if (value is null)
+                throw new ArgumentNullException(nameof(value));
 
             return string.Create(value.Length * 2, value, (span, bytes) =>
             {

--- a/tests/Neo.Extensions.Tests/UT_ByteExtensions.cs
+++ b/tests/Neo.Extensions.Tests/UT_ByteExtensions.cs
@@ -26,6 +26,9 @@ namespace Neo.Extensions.Tests
         {
             byte[] nullStr = null;
             Assert.ThrowsException<ArgumentNullException>(() => nullStr.ToHexString());
+            Assert.ThrowsException<ArgumentNullException>(() => nullStr.ToHexString(false));
+            Assert.ThrowsException<ArgumentNullException>(() => nullStr.ToHexString(true));
+
             byte[] empty = Array.Empty<byte>();
             empty.ToHexString().Should().Be("");
             empty.ToHexString(false).Should().Be("");


### PR DESCRIPTION

`ToHexString` throws `ArgumentNullException` when net9, and throws `NullReferenceException` when before net9.
It's better to keep consistent behavior.

I've checked all the places where it is called, and it looks like this change doesn't affect the program's behavior.

# Description

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
