### PR TITLE
[Fixed] Dotnet version for DevContainer

### DIFF
--- a/.devcontainer/devcontainer.dockerfile
+++ b/.devcontainer/devcontainer.dockerfile
@@ -1,3 +1,4 @@
-FROM mcr.microsoft.com/devcontainers/dotnet:9.0-noble
+FROM mcr.microsoft.com/dotnet/sdk:9.0.101-noble
+
 # Install the libleveldb-dev package 
 RUN apt-get update && apt-get install -y libleveldb-dev

--- a/.devcontainer/devcontainer.dockerfile
+++ b/.devcontainer/devcontainer.dockerfile
@@ -1,3 +1,5 @@
+# https://github.com/dotnet/dotnet-docker/blob/main/README.sdk.md
+# https://mcr.microsoft.com/en-us/artifact/mar/dotnet/sdk/tags <-- this shows all images
 FROM mcr.microsoft.com/dotnet/sdk:9.0.101-noble
 
 # Install the libleveldb-dev package 


### PR DESCRIPTION
# Description

The version of `dotnet` was wrong for the `devcontainer`.

![image](https://github.com/user-attachments/assets/2d379d47-b089-4eea-a611-c04db1dfa735)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
- Locally


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
