### PR TITLE
Fix comment: `DataCache.GetInternal` throws `KeyNotFoundException` on key not exists

### DIFF
--- a/src/Neo/Persistence/ClonedCache.cs
+++ b/src/Neo/Persistence/ClonedCache.cs
@@ -38,6 +38,7 @@ namespace Neo.Persistence
             return innerCache.Contains(key);
         }
 
+        /// <inheritdoc/>
         protected override StorageItem GetInternal(StorageKey key)
         {
             return innerCache[key].Clone();

--- a/src/Neo/Persistence/DataCache.cs
+++ b/src/Neo/Persistence/DataCache.cs
@@ -310,7 +310,8 @@ namespace Neo.Persistence
         /// Reads a specified entry from the underlying storage.
         /// </summary>
         /// <param name="key">The key of the entry.</param>
-        /// <returns>The data of the entry. Or <see langword="null"/> if the entry doesn't exist.</returns>
+        /// <returns>The data of the entry. Or throw <see cref="KeyNotFoundException"/> if the entry doesn't exist.</returns>
+        /// <exception cref="KeyNotFoundException">If the entry doesn't exist.</exception>
         protected abstract StorageItem GetInternal(StorageKey key);
 
         /// <summary>

--- a/src/Neo/Persistence/SnapshotCache.cs
+++ b/src/Neo/Persistence/SnapshotCache.cs
@@ -61,6 +61,7 @@ namespace Neo.Persistence
             snapshot?.Dispose();
         }
 
+        /// <inheritdoc/>
         protected override StorageItem GetInternal(StorageKey key)
         {
             byte[] value = store.TryGet(key.ToArray());


### PR DESCRIPTION
# Description

Fix comment on `DataCache.GetInternal`

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
