### PR TITLE
[Neo Core Memory Pool] fix flooding attack

### DIFF
--- a/src/Neo/Ledger/VerifyResult.cs
+++ b/src/Neo/Ledger/VerifyResult.cs
@@ -91,6 +91,11 @@ namespace Neo.Ledger
         /// <summary>
         /// Indicates that the <see cref="IInventory"/> failed to verify due to other reasons.
         /// </summary>
-        Unknown
+        Unknown,
+
+        /// <summary>
+        /// Indicates that the <see cref="Transaction"/> failed to add into the memory pool due to rate limitation exceeded.
+        /// </summary>
+        RateLimitExceeded
     }
 }


### PR DESCRIPTION
# Description

This one is to replace https://github.com/neo-project/neo/pull/3364, in 3364 i proposed a solution as smart throttler, which is not favored by core dev team, thus in this pr, i propose a much simpler solution that will set a minumum transaction fee barrier when the memory pool is over half filled. and the bar will by dynamicly updated based on the congestion factor.

When the memorypool is full, you have to pay 0.1 GAS to add a transaction. 

Fixes # https://github.com/neo-project/neo/issues/2862

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
