### PR TITLE
P2P: fix `UnknownCapability`validation and maintainig

### DIFF
--- a/src/Neo/Network/P2P/Capabilities/UnknownCapability.cs
+++ b/src/Neo/Network/P2P/Capabilities/UnknownCapability.cs
@@ -48,7 +48,7 @@ namespace Neo.Network.P2P.Capabilities
 
         protected override void SerializeWithoutType(BinaryWriter writer)
         {
-            throw new InvalidOperationException("Unknown capability can't be serialized");
+            writer.WriteVarBytes(Data.Span);
         }
     }
 }

--- a/src/Neo/Network/P2P/Payloads/NetworkAddressWithTime.cs
+++ b/src/Neo/Network/P2P/Payloads/NetworkAddressWithTime.cs
@@ -75,7 +75,10 @@ namespace Neo.Network.P2P.Payloads
             Capabilities = new NodeCapability[reader.ReadVarInt(VersionPayload.MaxCapabilities)];
             for (int x = 0, max = Capabilities.Length; x < max; x++)
                 Capabilities[x] = NodeCapability.DeserializeFrom(ref reader);
-            if (Capabilities.Select(p => p.Type).Distinct().Count() != Capabilities.Length)
+            // Verify that no duplicating capabilities are included. Unknown capabilities are not
+            // taken into account but still preserved to be able to share through the network.
+            var capabilities = Capabilities.Where(c => c is not UnknownCapability);
+            if (capabilities.Select(p => p.Type).Distinct().Count() != capabilities.Count())
                 throw new FormatException();
         }
 

--- a/src/Neo/Network/P2P/Payloads/VersionPayload.cs
+++ b/src/Neo/Network/P2P/Payloads/VersionPayload.cs
@@ -99,8 +99,8 @@ namespace Neo.Network.P2P.Payloads
             Capabilities = new NodeCapability[reader.ReadVarInt(MaxCapabilities)];
             for (int x = 0, max = Capabilities.Length; x < max; x++)
                 Capabilities[x] = NodeCapability.DeserializeFrom(ref reader);
-            Capabilities = Capabilities.Where(c => c is not UnknownCapability).ToArray();
-            if (Capabilities.Select(p => p.Type).Distinct().Count() != Capabilities.Length)
+            var capabilities = Capabilities.Where(c => c is not UnknownCapability);
+            if (capabilities.Select(p => p.Type).Distinct().Count() != capabilities.Count())
                 throw new FormatException();
         }
 

--- a/tests/Neo.UnitTests/Network/P2P/Capabilities/UT_UnknownCapability.cs
+++ b/tests/Neo.UnitTests/Network/P2P/Capabilities/UT_UnknownCapability.cs
@@ -30,7 +30,7 @@ namespace Neo.UnitTests.Network.P2P.Capabilities
             var capab = (NodeCapability)NodeCapability.DeserializeFrom(ref br);
 
             Assert.IsTrue(capab is UnknownCapability);
-            Assert.ThrowsException<InvalidOperationException>(() => capab.ToArray());
+            CollectionAssert.AreEqual(buffer, capab.ToArray());
         }
     }
 }

--- a/tests/Neo.UnitTests/Network/P2P/Payloads/UT_NetworkAddressWithTime.cs
+++ b/tests/Neo.UnitTests/Network/P2P/Payloads/UT_NetworkAddressWithTime.cs
@@ -10,6 +10,7 @@
 // modifications are permitted.
 
 using FluentAssertions;
+using FluentAssertions.Equivalency;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Neo.Extensions;
 using Neo.IO;
@@ -40,7 +41,7 @@ namespace Neo.UnitTests.Network.P2P.Payloads
         [TestMethod]
         public void DeserializeAndSerialize()
         {
-            var test = NetworkAddressWithTime.Create(IPAddress.Any, 1, new NodeCapability[] { new ServerCapability(NodeCapabilityType.TcpServer, 22) });
+            var test = NetworkAddressWithTime.Create(IPAddress.Any, 1, new NodeCapability[] { new ServerCapability(NodeCapabilityType.TcpServer, 22), new UnknownCapability(NodeCapabilityType.Extension0), new UnknownCapability(NodeCapabilityType.Extension0) });
             var clone = test.ToArray().AsSerializable<NetworkAddressWithTime>();
 
             CollectionAssert.AreEqual(test.Capabilities.ToByteArray(), clone.Capabilities.ToByteArray());

--- a/tests/Neo.UnitTests/Network/P2P/Payloads/UT_VersionPayload.cs
+++ b/tests/Neo.UnitTests/Network/P2P/Payloads/UT_VersionPayload.cs
@@ -58,8 +58,8 @@ namespace Neo.UnitTests.Network.P2P.Payloads
             buf = buf.Concat(new byte[] { 0x10, 0x01, 0x00, 0x00, 0x00 }).ToArray(); // FullNode capability, 0x01 index.
 
             clone = buf.AsSerializable<VersionPayload>();
-            Assert.AreEqual(2, clone.Capabilities.Length);
-            Assert.AreEqual(0, clone.Capabilities.OfType<UnknownCapability>().Count());
+            Assert.AreEqual(4, clone.Capabilities.Length);
+            Assert.AreEqual(2, clone.Capabilities.OfType<UnknownCapability>().Count());
         }
     }
 }


### PR DESCRIPTION
# Description

This PR fixes peer discovery mechanism for the nodes with at least one `UnknownCapability` included into the list of node's capabilities.

Follow the logic implemented in https://github.com/nspcc-dev/neo-go/pull/3778: the node will relay `UnknownCapability` information through the network even if it's not known to the node itself. @roman-khimov, you may argue with the last commit, but I consider first and second commits as a must-have, otherwise discovery won't work for the nodes with `UnknownCapability` (which is not the problem for NeoGo).

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [X] Unit tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
