### PR TITLE
[`Fix`]: keep the first parameter name of the `Seek` method the same

### DIFF
--- a/src/Neo/Persistence/IReadOnlyStore.cs
+++ b/src/Neo/Persistence/IReadOnlyStore.cs
@@ -22,10 +22,10 @@ namespace Neo.Persistence
         /// <summary>
         /// Seeks to the entry with the specified key.
         /// </summary>
-        /// <param name="key">The key to be sought.</param>
+        /// <param name="keyOrPrefix">The key(i.e. start key) or prefix to be sought.</param>
         /// <param name="direction">The direction of seek.</param>
         /// <returns>An enumerator containing all the entries after seeking.</returns>
-        IEnumerable<(byte[] Key, byte[] Value)> Seek(byte[] key, SeekDirection direction);
+        IEnumerable<(byte[] Key, byte[] Value)> Seek(byte[] keyOrPrefix, SeekDirection direction);
 
         /// <summary>
         /// Reads a specified entry from the database.

--- a/src/Neo/Persistence/MemorySnapshot.cs
+++ b/src/Neo/Persistence/MemorySnapshot.cs
@@ -54,6 +54,7 @@ namespace Neo.Persistence
             writeBatch[key[..]] = value[..];
         }
 
+        /// <inheritdoc/>
         public IEnumerable<(byte[] Key, byte[] Value)> Seek(byte[] keyOrPrefix, SeekDirection direction = SeekDirection.Forward)
         {
             ByteArrayComparer comparer = direction == SeekDirection.Forward ? ByteArrayComparer.Default : ByteArrayComparer.Reverse;

--- a/src/Neo/Persistence/MemoryStore.cs
+++ b/src/Neo/Persistence/MemoryStore.cs
@@ -47,6 +47,7 @@ namespace Neo.Persistence
             _innerData[key[..]] = value[..];
         }
 
+        /// <inheritdoc/>
         public IEnumerable<(byte[] Key, byte[] Value)> Seek(byte[] keyOrPrefix, SeekDirection direction = SeekDirection.Forward)
         {
             if (direction == SeekDirection.Backward && keyOrPrefix?.Length == 0) yield break;

--- a/src/Plugins/LevelDBStore/IO/Data/LevelDB/Helper.cs
+++ b/src/Plugins/LevelDBStore/IO/Data/LevelDB/Helper.cs
@@ -18,22 +18,21 @@ namespace Neo.IO.Storage.LevelDB
 {
     public static class Helper
     {
-        public static IEnumerable<(byte[], byte[])> Seek(this DB db, ReadOptions options, byte[] prefix, SeekDirection direction)
+        public static IEnumerable<(byte[], byte[])> Seek(this DB db, ReadOptions options, byte[] keyOrPrefix, SeekDirection direction)
         {
             using Iterator it = db.CreateIterator(options);
             if (direction == SeekDirection.Forward)
             {
-                for (it.Seek(prefix); it.Valid(); it.Next())
+                for (it.Seek(keyOrPrefix); it.Valid(); it.Next())
                     yield return new(it.Key(), it.Value());
             }
             else
             {
                 // SeekForPrev
-
-                it.Seek(prefix);
+                it.Seek(keyOrPrefix);
                 if (!it.Valid())
                     it.SeekToLast();
-                else if (it.Key().AsSpan().SequenceCompareTo(prefix) > 0)
+                else if (it.Key().AsSpan().SequenceCompareTo(keyOrPrefix) > 0)
                     it.Prev();
 
                 for (; it.Valid(); it.Prev())

--- a/src/Plugins/LevelDBStore/Plugins/Storage/Snapshot.cs
+++ b/src/Plugins/LevelDBStore/Plugins/Storage/Snapshot.cs
@@ -54,9 +54,10 @@ namespace Neo.Plugins.Storage
             _readOptions.Dispose();
         }
 
-        public IEnumerable<(byte[] Key, byte[] Value)> Seek(byte[] prefix, SeekDirection direction = SeekDirection.Forward)
+        /// <inheritdoc/>
+        public IEnumerable<(byte[] Key, byte[] Value)> Seek(byte[] keyOrPrefix, SeekDirection direction = SeekDirection.Forward)
         {
-            return _db.Seek(_readOptions, prefix, direction);
+            return _db.Seek(_readOptions, keyOrPrefix, direction);
         }
 
         public void Put(byte[] key, byte[] value)

--- a/src/Plugins/LevelDBStore/Plugins/Storage/Store.cs
+++ b/src/Plugins/LevelDBStore/Plugins/Storage/Store.cs
@@ -67,8 +67,9 @@ namespace Neo.Plugins.Storage
             return value != null;
         }
 
-        public IEnumerable<(byte[], byte[])> Seek(byte[] prefix, SeekDirection direction = SeekDirection.Forward) =>
-            _db.Seek(ReadOptions.Default, prefix, direction);
+        /// <inheritdoc/>
+        public IEnumerable<(byte[], byte[])> Seek(byte[] keyOrPrefix, SeekDirection direction = SeekDirection.Forward) =>
+            _db.Seek(ReadOptions.Default, keyOrPrefix, direction);
 
         public IEnumerator<KeyValuePair<byte[], byte[]>> GetEnumerator() =>
             _db.GetEnumerator();

--- a/src/Plugins/RocksDBStore/Plugins/Storage/Snapshot.cs
+++ b/src/Plugins/RocksDBStore/Plugins/Storage/Snapshot.cs
@@ -49,6 +49,7 @@ namespace Neo.Plugins.Storage
             batch.Put(key, value);
         }
 
+        /// <inheritdoc/>
         public IEnumerable<(byte[] Key, byte[] Value)> Seek(byte[] keyOrPrefix, SeekDirection direction)
         {
             if (keyOrPrefix == null) keyOrPrefix = Array.Empty<byte>();

--- a/src/Plugins/RocksDBStore/Plugins/Storage/Store.cs
+++ b/src/Plugins/RocksDBStore/Plugins/Storage/Store.cs
@@ -36,6 +36,7 @@ namespace Neo.Plugins.Storage
             return new Snapshot(db);
         }
 
+        /// <inheritdoc/>
         public IEnumerable<(byte[] Key, byte[] Value)> Seek(byte[] keyOrPrefix, SeekDirection direction = SeekDirection.Forward)
         {
             if (keyOrPrefix == null) keyOrPrefix = Array.Empty<byte>();


### PR DESCRIPTION
# Description

The first parameter of the `Seek` method has different name in different implementations.
The first parameter is a start key, so if the name is `prefix`, it may be misleading.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
