### PR TITLE
[`Fix`]: `HashSizeValue` should be set in implementations of `System.Security.Cryptography.HashAlgorithm`

### DIFF
--- a/src/Neo/Cryptography/Murmur128.cs
+++ b/src/Neo/Cryptography/Murmur128.cs
@@ -12,7 +12,6 @@
 using System;
 using System.Buffers.Binary;
 using System.Runtime.CompilerServices;
-using System.Security.Cryptography;
 
 namespace Neo.Cryptography
 {
@@ -32,7 +31,8 @@ namespace Neo.Cryptography
         private readonly uint seed;
         private int length;
 
-        public override int HashSize => 128;
+        public const int HashSizeInBits = 128;
+        public override int HashSize => HashSizeInBits;
 
         private ulong H1 { get; set; }
         private ulong H2 { get; set; }
@@ -44,6 +44,7 @@ namespace Neo.Cryptography
         public Murmur128(uint seed)
         {
             this.seed = seed;
+            HashSizeValue = HashSizeInBits;
             Initialize();
         }
 

--- a/src/Neo/Cryptography/Murmur32.cs
+++ b/src/Neo/Cryptography/Murmur32.cs
@@ -11,7 +11,6 @@
 
 using System;
 using System.Buffers.Binary;
-using System.Security.Cryptography;
 
 namespace Neo.Cryptography
 {
@@ -31,7 +30,8 @@ namespace Neo.Cryptography
         private uint hash;
         private int length;
 
-        public override int HashSize => 32;
+        public const int HashSizeInBits = 32;
+        public override int HashSize => HashSizeInBits;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Murmur32"/> class with the specified seed.
@@ -40,6 +40,7 @@ namespace Neo.Cryptography
         public Murmur32(uint seed)
         {
             this.seed = seed;
+            HashSizeValue = HashSizeInBits;
             Initialize();
         }
 

--- a/src/Neo/Cryptography/RIPEMD160Managed.cs
+++ b/src/Neo/Cryptography/RIPEMD160Managed.cs
@@ -12,7 +12,6 @@
 using System;
 using System.Runtime.InteropServices;
 using System.Security;
-using System.Security.Cryptography;
 
 namespace Neo.Cryptography
 {
@@ -27,7 +26,8 @@ namespace Neo.Cryptography
         private readonly uint[] _stateMD160;
         private readonly uint[] _blockDWords;
 
-        public override int HashSize => 160;
+        public const int HashSizeInBits = 160;
+        public override int HashSize => HashSizeInBits;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RIPEMD160Managed"/> class.
@@ -38,6 +38,7 @@ namespace Neo.Cryptography
             _blockDWords = new uint[16];
             _buffer = new byte[64];
 
+            HashSizeValue = HashSizeInBits;
             InitializeState();
         }
 

--- a/tests/Neo.UnitTests/Cryptography/UT_Murmur128.cs
+++ b/tests/Neo.UnitTests/Cryptography/UT_Murmur128.cs
@@ -42,5 +42,15 @@ namespace Neo.UnitTests.Cryptography
             array = "718f952132679baa9c5c2aa0d329fd2a".HexToBytes();
             array.Murmur128(123u).ToHexString().ToString().Should().Be("9b4aa747ff0cf4e41b3d96251551c8ae");
         }
+
+        [TestMethod]
+        public void TestTryComputeHash()
+        {
+            var murmur128 = new Murmur128(123u);
+            var buffer = new byte[murmur128.HashSize / 8];
+            var ok = murmur128.TryComputeHash("hello world"u8.ToArray(), buffer, out _);
+            ok.Should().BeTrue();
+            buffer.ToHexString().Should().Be("e0a0632d4f51302c55e3b3e48d28795d");
+        }
     }
 }

--- a/tests/Neo.UnitTests/Cryptography/UT_Murmur32.cs
+++ b/tests/Neo.UnitTests/Cryptography/UT_Murmur32.cs
@@ -12,6 +12,7 @@
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Neo.Cryptography;
+using System.Buffers.Binary;
 
 namespace Neo.UnitTests.Cryptography
 {
@@ -30,6 +31,20 @@ namespace Neo.UnitTests.Cryptography
         {
             byte[] array = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1 };
             array.Murmur32(10u).Should().Be(378574820u);
+        }
+
+        [TestMethod]
+        public void TestTryComputeHash()
+        {
+            var murmur3 = new Murmur32(10u);
+            var buffer = new byte[murmur3.HashSize / 8];
+            var data = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1 };
+
+            var ok = murmur3.TryComputeHash(data, buffer, out _);
+            ok.Should().BeTrue();
+
+            var hash = BinaryPrimitives.ReadUInt32LittleEndian(buffer);
+            hash.Should().Be(378574820u);
         }
     }
 }

--- a/tests/Neo.UnitTests/Cryptography/UT_RIPEMD160Managed.cs
+++ b/tests/Neo.UnitTests/Cryptography/UT_RIPEMD160Managed.cs
@@ -1,0 +1,41 @@
+// Copyright (C) 2015-2024 The Neo Project.
+//
+// UT_RIPEMD160Managed.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.Cryptography;
+using Neo.Extensions;
+
+namespace Neo.UnitTests.Cryptography
+{
+    [TestClass]
+    public class UT_RIPEMD160Managed
+    {
+
+        [TestMethod]
+        public void TestHashCore()
+        {
+            using var ripemd160 = new RIPEMD160Managed();
+            var hash = ripemd160.ComputeHash("hello world"u8.ToArray());
+            hash.ToHexString().Should().Be("98c615784ccb5fe5936fbc0cbe9dfdb408d92f0f");
+        }
+
+        [TestMethod]
+        public void TestTryComputeHash()
+        {
+            using var ripemd160 = new RIPEMD160Managed();
+            var buffer = new byte[ripemd160.HashSize / 8];
+            var ok = ripemd160.TryComputeHash("hello world"u8.ToArray(), buffer, out _);
+            ok.Should().BeTrue();
+            buffer.ToHexString().Should().Be("98c615784ccb5fe5936fbc0cbe9dfdb408d92f0f");
+        }
+    }
+}

--- a/tests/Neo.UnitTests/Cryptography/UT_RIPEMD160Managed.cs
+++ b/tests/Neo.UnitTests/Cryptography/UT_RIPEMD160Managed.cs
@@ -19,7 +19,6 @@ namespace Neo.UnitTests.Cryptography
     [TestClass]
     public class UT_RIPEMD160Managed
     {
-
         [TestMethod]
         public void TestHashCore()
         {


### PR DESCRIPTION
An example:  https://github.com/dotnet/runtime/blob/5535e31a712343a63f5d7d796cd874e563e5ac14/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SHA256.cs#L24

The `TryComputeHash` will throw a `InvalidOperationException` if  the `HashSizeValue` is not set and the `TryFinal` not overridden.


## Type of change

<!-- Please delete options that are not relevant. -->

- [] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
