### PR TITLE
Fix and optimize `DataCache.Commit`

### DIFF
--- a/src/Neo/Persistence/DataCache.cs
+++ b/src/Neo/Persistence/DataCache.cs
@@ -125,7 +125,6 @@ namespace Neo.Persistence
         /// </summary>
         public virtual void Commit()
         {
-            LinkedList<StorageKey> deletedItem = new();
             lock (dictionary)
             {
                 foreach (var key in changeSet)
@@ -143,13 +142,9 @@ namespace Neo.Persistence
                             break;
                         case TrackState.Deleted:
                             DeleteInternal(key);
-                            deletedItem.AddFirst(key);
+                            dictionary.Remove(key);
                             break;
                     }
-                }
-                foreach (var key in deletedItem)
-                {
-                    dictionary.Remove(key);
                 }
                 changeSet.Clear();
             }


### PR DESCRIPTION
# Description

`Commit` doesn't lock `dictionary` for whole logic, only during the iteration of `GetChangeSet`.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Current tests

**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
