### PR TITLE
.Net SDK upgraded, but `LangVersion` not.

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <Copyright>2015-2024 The Neo Project</Copyright>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>latest</LangVersion>
     <Authors>The Neo Project</Authors>
     <IsPackable>true</IsPackable>
     <PackageIcon>neo.png</PackageIcon>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <Copyright>2015-2024 The Neo Project</Copyright>
-    <LangVersion>12.0</LangVersion>
+    <LangVersion>13.0</LangVersion>
     <Authors>The Neo Project</Authors>
     <IsPackable>true</IsPackable>
     <PackageIcon>neo.png</PackageIcon>


### PR DESCRIPTION
# Description

When .net is upgraded to .net8(#3180), the C# version is also upgraded. But when  upgraded to .net9(#3576), the C# version was not upgraded.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
