### PR TITLE
[`Fix`]: `IStore.Seek` should start from the last key if `keyPrefix` is null or empty

### DIFF
--- a/src/Neo/Persistence/MemoryStore.cs
+++ b/src/Neo/Persistence/MemoryStore.cs
@@ -52,8 +52,6 @@ namespace Neo.Persistence
         /// <inheritdoc/>
         public IEnumerable<(byte[] Key, byte[] Value)> Seek(byte[] keyOrPrefix, SeekDirection direction = SeekDirection.Forward)
         {
-            if (direction == SeekDirection.Backward && keyOrPrefix?.Length == 0) yield break;
-
             var comparer = direction == SeekDirection.Forward ? ByteArrayComparer.Default : ByteArrayComparer.Reverse;
             IEnumerable<KeyValuePair<byte[], byte[]>> records = _innerData;
             if (keyOrPrefix?.Length > 0)

--- a/src/Plugins/LevelDBStore/IO/Data/LevelDB/Helper.cs
+++ b/src/Plugins/LevelDBStore/IO/Data/LevelDB/Helper.cs
@@ -23,17 +23,25 @@ namespace Neo.IO.Storage.LevelDB
             using Iterator it = db.CreateIterator(options);
             if (direction == SeekDirection.Forward)
             {
+                if (keyOrPrefix == null) keyOrPrefix = Array.Empty<byte>();
                 for (it.Seek(keyOrPrefix); it.Valid(); it.Next())
                     yield return new(it.Key(), it.Value());
             }
             else
             {
                 // SeekForPrev
-                it.Seek(keyOrPrefix);
-                if (!it.Valid())
-                    it.SeekToLast();
-                else if (it.Key().AsSpan().SequenceCompareTo(keyOrPrefix) > 0)
-                    it.Prev();
+                if (keyOrPrefix is null || keyOrPrefix.Length == 0)
+                {
+                    it.SeekToLast(); // keyPrefix is null or empty, seek to the last key
+                }
+                else
+                {
+                    it.Seek(keyOrPrefix);
+                    if (!it.Valid())
+                        it.SeekToLast();
+                    else if (it.Key().AsSpan().SequenceCompareTo(keyOrPrefix) > 0)
+                        it.Prev();
+                }
 
                 for (; it.Valid(); it.Prev())
                     yield return new(it.Key(), it.Value());

--- a/src/Plugins/RocksDBStore/Plugins/Storage/Store.cs
+++ b/src/Plugins/RocksDBStore/Plugins/Storage/Store.cs
@@ -43,11 +43,20 @@ namespace Neo.Plugins.Storage
 
             using var it = db.NewIterator();
             if (direction == SeekDirection.Forward)
+            {
                 for (it.Seek(keyOrPrefix); it.Valid(); it.Next())
                     yield return (it.Key(), it.Value());
+            }
             else
-                for (it.SeekForPrev(keyOrPrefix); it.Valid(); it.Prev())
+            {
+                if (keyOrPrefix is null || keyOrPrefix.Length == 0)
+                    it.SeekToLast(); // keyPrefix is null or empty, seek to the last key
+                else
+                    it.SeekForPrev(keyOrPrefix);
+
+                for (; it.Valid(); it.Prev())
                     yield return (it.Key(), it.Value());
+            }
         }
 
         public bool Contains(byte[] key)

--- a/tests/Neo.Plugins.Storage.Tests/StoreTest.cs
+++ b/tests/Neo.Plugins.Storage.Tests/StoreTest.cs
@@ -304,6 +304,40 @@ namespace Neo.Plugins.Storage.Tests
             }
         }
 
+        [TestMethod]
+        public void TestLevelDbSeek()
+        {
+            using var store = levelDbStore.GetStore(path_leveldb);
+            TestSeek(store);
+        }
+
+        [TestMethod]
+        public void TestRocksDbSeek()
+        {
+            using var store = rocksDBStore.GetStore(path_rocksdb);
+            TestSeek(store);
+        }
+
+        private void TestSeek(IStore store)
+        {
+            store.Put(new byte[] { 0xff, 0x01 }, new byte[] { 0x00 });
+            store.Put(new byte[] { 0xff, 0x02 }, new byte[] { 0x01 });
+
+            var entries = store.Seek(null, SeekDirection.Forward).ToArray();
+            Assert.AreEqual(2, entries.Length);
+            CollectionAssert.AreEqual(new byte[] { 0xff, 0x01 }, entries[0].Key);
+            CollectionAssert.AreEqual(new byte[] { 0x00 }, entries[0].Value);
+            CollectionAssert.AreEqual(new byte[] { 0xff, 0x02 }, entries[1].Key);
+            CollectionAssert.AreEqual(new byte[] { 0x01 }, entries[1].Value);
+
+            entries = store.Seek(null, SeekDirection.Backward).ToArray();
+            Assert.AreEqual(2, entries.Length);
+            CollectionAssert.AreEqual(new byte[] { 0xff, 0x02 }, entries[0].Key);
+            CollectionAssert.AreEqual(new byte[] { 0x01 }, entries[0].Value);
+            CollectionAssert.AreEqual(new byte[] { 0xff, 0x01 }, entries[1].Key);
+            CollectionAssert.AreEqual(new byte[] { 0x00 }, entries[1].Value);
+        }
+
         /// <summary>
         /// Test Put
         /// </summary>

--- a/tests/Neo.UnitTests/Persistence/UT_MemoryStore.cs
+++ b/tests/Neo.UnitTests/Persistence/UT_MemoryStore.cs
@@ -73,7 +73,17 @@ namespace Neo.UnitTests.Persistence
             store.Put([0x00, 0x00, 0x04], [0x04]);
 
             var entries = store.Seek(Array.Empty<byte>(), SeekDirection.Backward).ToArray();
-            Assert.AreEqual(entries.Length, 0);
+            Assert.AreEqual(entries.Length, 5);
+            CollectionAssert.AreEqual(new byte[] { 0x00, 0x00, 0x04 }, entries[0].Key);
+            CollectionAssert.AreEqual(new byte[] { 0x04 }, entries[0].Value);
+            CollectionAssert.AreEqual(new byte[] { 0x00, 0x00, 0x03 }, entries[1].Key);
+            CollectionAssert.AreEqual(new byte[] { 0x03 }, entries[1].Value);
+            CollectionAssert.AreEqual(new byte[] { 0x00, 0x00, 0x02 }, entries[2].Key);
+            CollectionAssert.AreEqual(new byte[] { 0x02 }, entries[2].Value);
+            CollectionAssert.AreEqual(new byte[] { 0x00, 0x00, 0x01 }, entries[3].Key);
+            CollectionAssert.AreEqual(new byte[] { 0x01 }, entries[3].Value);
+            CollectionAssert.AreEqual(new byte[] { 0x00, 0x00, 0x00 }, entries[4].Key);
+            CollectionAssert.AreEqual(new byte[] { 0x00 }, entries[4].Value);
         }
 
         [TestMethod]


### PR DESCRIPTION
# Description

`IStore.Seek(keyPrefix, SeekDirection.Forward)` start from the first key if `keyPrefix` is null or empty.

`IStore.Seek(keyPrefix, SeekDirection.Backend)` returns a empty `IEnumerable`.

I think it is bug.

This PR also fixes the different behaviors of different `IStore.Seek` implementations  when `keyPrefix` is null.

Related: #2634 and #2635 

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
