### PR TITLE
[`Fix`]: `keyPrefix` in `DataCache.Find` can be all 0xff.

### DIFF
--- a/tests/Neo.UnitTests/Persistence/UT_DataCache.cs
+++ b/tests/Neo.UnitTests/Persistence/UT_DataCache.cs
@@ -182,12 +182,12 @@ namespace Neo.UnitTests.IO.Caching
             items = myDataCache.Find(new byte[] { });
             items.Count().Should().Be(4);
 
-            // null and empty with the backwards direction start from the last key
-            items = myDataCache.Find(null, SeekDirection.Backward);
-            // no exception, and results check will be added later.
+            // null and empty with the backwards direction -> miserably fails.
+            Action action = () => myDataCache.Find(null, SeekDirection.Backward);
+            action.Should().Throw<ArgumentException>();
 
-            items = myDataCache.Find(new byte[] { }, SeekDirection.Backward);
-            // no exception, and results check will be added later.
+            action = () => myDataCache.Find(new byte[] { }, SeekDirection.Backward);
+            action.Should().Throw<ArgumentException>();
 
             items = myDataCache.Find(k1, SeekDirection.Backward);
             key1.Should().Be(items.ElementAt(0).Key);
@@ -430,11 +430,12 @@ namespace Neo.UnitTests.IO.Caching
             items.Length.Should().Be(1);
             items[0].Key.ToArray().Should().BeEquivalentTo(k3.ToArray());
 
-            items = dataCache.Find(null, SeekDirection.Backward).ToArray();
-            items.Length.Should().Be(3);
-            items[0].Key.ToArray().Should().BeEquivalentTo(k3.ToArray());
-            items[1].Key.ToArray().Should().BeEquivalentTo(k2.ToArray());
-            items[2].Key.ToArray().Should().BeEquivalentTo(k1.ToArray());
+            // null and empty are not supported for backwards direction now.
+            Action action = () => myDataCache.Find(null, SeekDirection.Backward);
+            action.Should().Throw<ArgumentException>();
+
+            action = () => myDataCache.Find(new byte[] { }, SeekDirection.Backward);
+            action.Should().Throw<ArgumentException>();
 
             items = dataCache.Find([0xff, 0xff, 0xff, 0xff, 0xff], SeekDirection.Backward).ToArray();
             items.Length.Should().Be(1);

--- a/tests/Neo.UnitTests/Persistence/UT_DataCache.cs
+++ b/tests/Neo.UnitTests/Persistence/UT_DataCache.cs
@@ -182,12 +182,12 @@ namespace Neo.UnitTests.IO.Caching
             items = myDataCache.Find(new byte[] { });
             items.Count().Should().Be(4);
 
-            // null and empty with the backwards direction -> miserably fails.
-            // Action action = () => myDataCache.Find(null, SeekDirection.Backward);
-            // action.Should().Throw<ArgumentException>();
+            // null and empty with the backwards direction start from the last key
+            items = myDataCache.Find(null, SeekDirection.Backward);
+            // no exception, and results check will be added later.
 
-            // action = () => myDataCache.Find(new byte[] { }, SeekDirection.Backward);
-            // action.Should().Throw<ArgumentException>();
+            items = myDataCache.Find(new byte[] { }, SeekDirection.Backward);
+            // no exception, and results check will be added later.
 
             items = myDataCache.Find(k1, SeekDirection.Backward);
             key1.Should().Be(items.ElementAt(0).Key);
@@ -439,7 +439,7 @@ namespace Neo.UnitTests.IO.Caching
             items = dataCache.Find([0xff, 0xff, 0xff, 0xff, 0xff], SeekDirection.Backward).ToArray();
             items.Length.Should().Be(1);
             items[0].Key.ToArray().Should().BeEquivalentTo(k3.ToArray());
-        
+
             items = dataCache.Find([0xff], SeekDirection.Backward).ToArray();
             items.Length.Should().Be(3);
             items[0].Key.ToArray().Should().BeEquivalentTo(k3.ToArray());


### PR DESCRIPTION
# Description

1. `DataCache.Find(keyPrefix, SeekDirection.Forward)` start from the first key if keyPrefix is null or empty.
  But `DataCache.Find(keyPrefix, SeekDirection.Backword)` throws an Exception.
  It's better to keep a similar logic with different `SeekDirection`.

2. Allow all 0xff `keyPrefix`.

This PR depends on #3680

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
