### PR TITLE
[`Fix`]: Behavior when `keyPrefix` is null in different `IStore.Seek` impls.

### DIFF
--- a/src/Neo/Persistence/IReadOnlyStore.cs
+++ b/src/Neo/Persistence/IReadOnlyStore.cs
@@ -24,7 +24,7 @@ namespace Neo.Persistence
         /// </summary>
         /// <param name="keyOrPrefix">The key(i.e. start key) or prefix to be sought.</param>
         /// <param name="direction">The direction of seek.</param>
-        /// <returns>An enumerator containing all the entries after(Forward) or before(Backward) seeking.</returns>
+        /// <returns>An enumerator containing all the entries after (Forward) or before(Backward) seeking.</returns>
         IEnumerable<(byte[] Key, byte[] Value)> Seek(byte[] keyOrPrefix, SeekDirection direction);
 
         /// <summary>

--- a/src/Neo/Persistence/IReadOnlyStore.cs
+++ b/src/Neo/Persistence/IReadOnlyStore.cs
@@ -24,7 +24,7 @@ namespace Neo.Persistence
         /// </summary>
         /// <param name="keyOrPrefix">The key(i.e. start key) or prefix to be sought.</param>
         /// <param name="direction">The direction of seek.</param>
-        /// <returns>An enumerator containing all the entries after seeking.</returns>
+        /// <returns>An enumerator containing all the entries after(Forward) or before(Backward) seeking.</returns>
         IEnumerable<(byte[] Key, byte[] Value)> Seek(byte[] keyOrPrefix, SeekDirection direction);
 
         /// <summary>

--- a/src/Plugins/LevelDBStore/IO/Data/LevelDB/Helper.cs
+++ b/src/Plugins/LevelDBStore/IO/Data/LevelDB/Helper.cs
@@ -20,7 +20,7 @@ namespace Neo.IO.Storage.LevelDB
     {
         public static IEnumerable<(byte[], byte[])> Seek(this DB db, ReadOptions options, byte[] keyOrPrefix, SeekDirection direction)
         {
-            if (keyOrPrefix == null) keyOrPrefix = Array.Empty<byte>();
+            if (keyOrPrefix == null) keyOrPrefix = [];
 
             using Iterator it = db.CreateIterator(options);
             if (direction == SeekDirection.Forward)

--- a/src/Plugins/LevelDBStore/IO/Data/LevelDB/Helper.cs
+++ b/src/Plugins/LevelDBStore/IO/Data/LevelDB/Helper.cs
@@ -20,6 +20,8 @@ namespace Neo.IO.Storage.LevelDB
     {
         public static IEnumerable<(byte[], byte[])> Seek(this DB db, ReadOptions options, byte[] keyOrPrefix, SeekDirection direction)
         {
+            if (keyOrPrefix == null) keyOrPrefix = Array.Empty<byte>();
+
             using Iterator it = db.CreateIterator(options);
             if (direction == SeekDirection.Forward)
             {

--- a/tests/Neo.Plugins.Storage.Tests/StoreTest.cs
+++ b/tests/Neo.Plugins.Storage.Tests/StoreTest.cs
@@ -301,6 +301,20 @@ namespace Neo.Plugins.Storage.Tests
                 CollectionAssert.AreEqual(new byte[] { 0x01 }, entries[0].Value);
                 CollectionAssert.AreEqual(new byte[] { 0x00, 0x00, 0x00 }, entries[1].Key);
                 CollectionAssert.AreEqual(new byte[] { 0x00 }, entries[1].Value);
+
+                // Seek null
+                entries = store.Seek(null, SeekDirection.Forward).ToArray();
+                Assert.AreEqual(3, entries.Length);
+                CollectionAssert.AreEqual(new byte[] { 0x00, 0x00, 0x00 }, entries[0].Key);
+                CollectionAssert.AreEqual(new byte[] { 0x00, 0x00, 0x01 }, entries[1].Key);
+                CollectionAssert.AreEqual(new byte[] { 0x00, 0x01, 0x02 }, entries[2].Key);
+
+                // Seek empty
+                entries = store.Seek([], SeekDirection.Forward).ToArray();
+                Assert.AreEqual(3, entries.Length);
+                CollectionAssert.AreEqual(new byte[] { 0x00, 0x00, 0x00 }, entries[0].Key);
+                CollectionAssert.AreEqual(new byte[] { 0x00, 0x00, 0x01 }, entries[1].Key);
+                CollectionAssert.AreEqual(new byte[] { 0x00, 0x01, 0x02 }, entries[2].Key);
             }
         }
 


### PR DESCRIPTION
# Description

`LevelDbStore.Seek` will throw an unexpected exception  if `keyPrefix` is null.

But `RocksDb.Store` and `MemoryStore` will seek to the first key if `keyPrefix` is null.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
