### PR TITLE
[Core P2P] fix the bug

### DIFF
--- a/src/Neo/Network/P2P/RemoteNode.cs
+++ b/src/Neo/Network/P2P/RemoteNode.cs
@@ -234,7 +234,11 @@ namespace Neo.Network.P2P
         private void SendMessage(Message message)
         {
             ack = false;
-            SendData(ByteString.FromBytes(message.ToArray(Version.AllowCompression)));
+            // Here it is possible that we dont have the Version message yet,
+            // so we need to send the message uncompressed
+            SendData(message.Command == MessageCommand.Version
+                ? ByteString.FromBytes(message.ToArray())
+                : ByteString.FromBytes(message.ToArray(Version.AllowCompression)));
             sentCommands[(byte)message.Command] = true;
         }
 

--- a/src/Neo/Network/P2P/RemoteNode.cs
+++ b/src/Neo/Network/P2P/RemoteNode.cs
@@ -236,9 +236,7 @@ namespace Neo.Network.P2P
             ack = false;
             // Here it is possible that we dont have the Version message yet,
             // so we need to send the message uncompressed
-            SendData(message.Command == MessageCommand.Version
-                ? ByteString.FromBytes(message.ToArray())
-                : ByteString.FromBytes(message.ToArray(Version.AllowCompression)));
+            SendData(ByteString.FromBytes(message.ToArray(Version?.AllowCompression ?? false)));
             sentCommands[(byte)message.Command] = true;
         }
 


### PR DESCRIPTION
# Description

There is a bug in the P2P as introduced in https://github.com/neo-project/neo/pull/3655, previously we can send the Version to remote node before having the remote Version, but in that pr, it enforced using Version while its still Null, causing Null Object exception. 

Close #3694

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
