### PR TITLE
[Core Plugin] experimental plugins

### DIFF
--- a/src/Neo.CLI/CLI/MainService.Plugins.cs
+++ b/src/Neo.CLI/CLI/MainService.Plugins.cs
@@ -47,7 +47,7 @@ namespace Neo.CLI
                 return;
             }
 
-            if (s_expPlugins.Contains(pluginName))
+            if (s_expPlugins.Contains(pluginName, StringComparer.InvariantCultureIgnoreCase))
             {
                 ConsoleHelper.Warning("Plugin is experimental, install with `install exp [plugin]`.");
                 return;
@@ -77,7 +77,7 @@ namespace Neo.CLI
                 return;
             }
 
-            if (!s_expPlugins.Contains(pluginName))
+            if (!s_expPlugins.Contains(pluginName, StringComparer.InvariantCultureIgnoreCase))
             {
                 ConsoleHelper.Warning("Plugin is not experimental.");
                 return;
@@ -288,7 +288,7 @@ namespace Neo.CLI
                     .OrderBy(u => u.name)
                     .ForEach((f) =>
                     {
-                        var exp = s_expPlugins.Contains(f.name) ? "EXP" : "";
+                        var exp = s_expPlugins.Contains(f.name, StringComparer.InvariantCultureIgnoreCase) ? "EXP" : "";
                         if (f.installedPlugin != null)
                         {
                             var tabs = f.name.Length < maxLength ? "\t" : string.Empty;


### PR DESCRIPTION
# Description

For the ease of reviewing and maintaining plugins that are not yet well tested by time, and following what we have disscussed duing the coredev biweekly meeting, we add a new plugin install command `install exp [plugin]` to allow user to install and use those experimental plugins at their own risk. 

Fixes # https://github.com/neo-project/neo/pull/3390

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
