### PR TITLE
Fix `GetAndChange` warnings

### DIFF
--- a/src/Neo/Persistence/DataCache.cs
+++ b/src/Neo/Persistence/DataCache.cs
@@ -316,7 +316,7 @@ namespace Neo.Persistence
         /// <param name="key">The key of the entry.</param>
         /// <param name="factory">A delegate used to create the entry if it doesn't exist. If the entry already exists, the factory will not be used.</param>
         /// <returns>The cached data. Or <see langword="null"/> if it doesn't exist and the <paramref name="factory"/> is not provided.</returns>
-        public StorageItem? GetAndChange(StorageKey key, Func<StorageItem>? factory = null)
+        public StorageItem? GetAndChange(StorageKey key, [NotNullIfNotNull(nameof(factory))] Func<StorageItem>? factory)
         {
             lock (_dictionary)
             {

--- a/src/Neo/Persistence/DataCache.cs
+++ b/src/Neo/Persistence/DataCache.cs
@@ -316,7 +316,7 @@ namespace Neo.Persistence
         /// <param name="key">The key of the entry.</param>
         /// <param name="factory">A delegate used to create the entry if it doesn't exist. If the entry already exists, the factory will not be used.</param>
         /// <returns>The cached data. Or <see langword="null"/> if it doesn't exist and the <paramref name="factory"/> is not provided.</returns>
-        public StorageItem? GetAndChange(StorageKey key, [NotNullIfNotNull(nameof(factory))] Func<StorageItem>? factory)
+        public StorageItem? GetAndChange(StorageKey key, [NotNullIfNotNull(nameof(factory))] Func<StorageItem>? factory = null)
         {
             lock (_dictionary)
             {


### PR DESCRIPTION
# Description

Fix warnings related to https://github.com/neo-project/neo-devpack-dotnet/pull/1288/files#r1935149446
Reference: https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/attributes/nullable-analysis

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Optimization (the change is only an optimization)
- [x] Style (the change is only a code style for better maintenance or standard purpose)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Not required

**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
