### PR TITLE
Fix: remove residual `FluentAssertions`

### DIFF
--- a/tests/Neo.UnitTests/Cryptography/UT_MerkleTreeNode.cs
+++ b/tests/Neo.UnitTests/Cryptography/UT_MerkleTreeNode.cs
@@ -9,7 +9,6 @@
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Neo.Cryptography;
 using System.Text;

--- a/tests/Neo.UnitTests/Cryptography/UT_Murmur32.cs
+++ b/tests/Neo.UnitTests/Cryptography/UT_Murmur32.cs
@@ -9,7 +9,6 @@
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Neo.Cryptography;
 using System.Buffers.Binary;


### PR DESCRIPTION
# Description

An issue from #3703

Some `FluentAssertions` not deleted.


## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
