### PR TITLE
Remove `Trackable.Key` from `DataCache.Trackable`

### DIFF
--- a/src/Neo/Ledger/Blockchain.cs
+++ b/src/Neo/Ledger/Blockchain.cs
@@ -202,7 +202,7 @@ namespace Neo.Ledger
             // Invalidate all the transactions in the memory pool, to avoid any failures when adding new transactions.
             system.MemPool.InvalidateAllTransactions();
 
-            DataCache snapshot = system.StoreView;
+            var snapshot = system.StoreView;
 
             // Add the transactions to the memory pool
             foreach (var tx in transactions)
@@ -246,7 +246,7 @@ namespace Neo.Ledger
 
         private VerifyResult OnNewBlock(Block block)
         {
-            DataCache snapshot = system.StoreView;
+            var snapshot = system.StoreView;
             uint currentHeight = NativeContract.Ledger.CurrentIndex(snapshot);
             uint headerHeight = system.HeaderCache.Last?.Index ?? currentHeight;
             if (block.Index <= currentHeight)
@@ -316,7 +316,7 @@ namespace Neo.Ledger
         {
             if (!system.HeaderCache.Full)
             {
-                DataCache snapshot = system.StoreView;
+                var snapshot = system.StoreView;
                 uint headerHeight = system.HeaderCache.Last?.Index ?? NativeContract.Ledger.CurrentIndex(snapshot);
                 foreach (Header header in headers)
                 {
@@ -332,7 +332,7 @@ namespace Neo.Ledger
 
         private VerifyResult OnNewExtensiblePayload(ExtensiblePayload payload)
         {
-            DataCache snapshot = system.StoreView;
+            var snapshot = system.StoreView;
             extensibleWitnessWhiteList ??= UpdateExtensibleWitnessWhiteList(system.Settings, snapshot);
             if (!payload.Verify(system.Settings, snapshot, extensibleWitnessWhiteList)) return VerifyResult.Invalid;
             system.RelayCache.Add(payload);
@@ -437,7 +437,7 @@ namespace Neo.Ledger
                     all_application_executed.Add(application_executed);
                     transactionStates = engine.GetState<TransactionState[]>();
                 }
-                DataCache clonedSnapshot = snapshot.CloneCache();
+                var clonedSnapshot = snapshot.CloneCache();
                 // Warning: Do not write into variable snapshot directly. Write into variable clonedSnapshot and commit instead.
                 foreach (TransactionState transactionState in transactionStates)
                 {

--- a/src/Neo/Network/P2P/RemoteNode.ProtocolHandler.cs
+++ b/src/Neo/Network/P2P/RemoteNode.ProtocolHandler.cs
@@ -190,7 +190,7 @@ namespace Neo.Network.P2P
         {
             // The default value of payload.Count is -1
             int count = payload.Count < 0 || payload.Count > InvPayload.MaxHashesCount ? InvPayload.MaxHashesCount : payload.Count;
-            DataCache snapshot = system.StoreView;
+            var snapshot = system.StoreView;
             UInt256 hash = payload.HashStart;
             TrimmedBlock state = NativeContract.Ledger.GetTrimmedBlock(snapshot, hash);
             if (state == null) return;
@@ -291,7 +291,7 @@ namespace Neo.Network.P2P
         /// <param name="payload">A GetBlockByIndexPayload including start block index and number of blocks' headers requested.</param>
         private void OnGetHeadersMessageReceived(GetBlockByIndexPayload payload)
         {
-            DataCache snapshot = system.StoreView;
+            var snapshot = system.StoreView;
             if (payload.IndexStart > NativeContract.Ledger.CurrentIndex(snapshot)) return;
             List<Header> headers = new();
             uint count = payload.Count == -1 ? HeadersPayload.MaxHeadersCount : (uint)payload.Count;
@@ -341,13 +341,13 @@ namespace Neo.Network.P2P
             {
                 case InventoryType.Block:
                     {
-                        DataCache snapshot = system.StoreView;
+                        var snapshot = system.StoreView;
                         hashes = hashes.Where(p => !NativeContract.Ledger.ContainsBlock(snapshot, p)).ToArray();
                     }
                     break;
                 case InventoryType.TX:
                     {
-                        DataCache snapshot = system.StoreView;
+                        var snapshot = system.StoreView;
                         hashes = hashes.Where(p => !NativeContract.Ledger.ContainsTransaction(snapshot, p)).ToArray();
                     }
                     break;

--- a/src/Neo/Network/P2P/TaskManager.cs
+++ b/src/Neo/Network/P2P/TaskManager.cs
@@ -345,7 +345,7 @@ namespace Neo.Network.P2P
         {
             if (session.HasTooManyTasks) return;
 
-            DataCache snapshot = system.StoreView;
+            var snapshot = system.StoreView;
 
             // If there are pending tasks of InventoryType.Block we should process them
             if (session.AvailableTasks.Count > 0)

--- a/src/Neo/Persistence/DataCache.cs
+++ b/src/Neo/Persistence/DataCache.cs
@@ -29,13 +29,8 @@ namespace Neo.Persistence
         /// <summary>
         /// Represents an entry in the cache.
         /// </summary>
-        public class Trackable(StorageKey key, StorageItem item, TrackState state)
+        public class Trackable(StorageItem item, TrackState state)
         {
-            /// <summary>
-            /// The key of the entry.
-            /// </summary>
-            public StorageKey Key { get; } = key;
-
             /// <summary>
             /// The data of the entry.
             /// </summary>
@@ -47,8 +42,8 @@ namespace Neo.Persistence
             public TrackState State { get; set; } = state;
         }
 
-        private readonly Dictionary<StorageKey, Trackable> _dictionary = new();
-        private readonly HashSet<StorageKey> _changeSet = new();
+        private readonly Dictionary<StorageKey, Trackable> _dictionary = [];
+        private readonly HashSet<StorageKey> _changeSet = [];
 
         /// <summary>
         /// Reads a specified entry from the cache. If the entry is not in the cache, it will be automatically loaded from the underlying storage.
@@ -69,7 +64,7 @@ namespace Neo.Persistence
                     }
                     else
                     {
-                        trackable = new Trackable(key, GetInternal(key), TrackState.None);
+                        trackable = new Trackable(GetInternal(key), TrackState.None);
                         _dictionary.Add(key, trackable);
                     }
                     return trackable.Item;
@@ -100,7 +95,7 @@ namespace Neo.Persistence
                 }
                 else
                 {
-                    _dictionary[key] = new Trackable(key, value, TrackState.Added);
+                    _dictionary[key] = new Trackable(value, TrackState.Added);
                 }
                 _changeSet.Add(key);
             }
@@ -187,7 +182,7 @@ namespace Neo.Persistence
                 {
                     var item = TryGetInternal(key);
                     if (item == null) return;
-                    _dictionary.Add(key, new Trackable(key, item, TrackState.Deleted));
+                    _dictionary.Add(key, new Trackable(item, TrackState.Deleted));
                     _changeSet.Add(key);
                 }
             }
@@ -257,7 +252,7 @@ namespace Neo.Persistence
         /// <returns>The entries found with the desired range.</returns>
         public IEnumerable<(StorageKey Key, StorageItem Value)> FindRange(byte[] start, byte[] end, SeekDirection direction = SeekDirection.Forward)
         {
-            ByteArrayComparer comparer = direction == SeekDirection.Forward
+            var comparer = direction == SeekDirection.Forward
                 ? ByteArrayComparer.Default
                 : ByteArrayComparer.Reverse;
             foreach (var (key, value) in Seek(start, direction))
@@ -271,12 +266,12 @@ namespace Neo.Persistence
         /// Gets the change set in the cache.
         /// </summary>
         /// <returns>The change set.</returns>
-        public IEnumerable<Trackable> GetChangeSet()
+        public IEnumerable<KeyValuePair<StorageKey, Trackable>> GetChangeSet()
         {
             lock (_dictionary)
             {
-                foreach (StorageKey key in _changeSet)
-                    yield return _dictionary[key];
+                foreach (var key in _changeSet)
+                    yield return new(key, _dictionary[key]);
             }
         }
 
@@ -357,11 +352,11 @@ namespace Neo.Persistence
                     if (item == null)
                     {
                         if (factory == null) return null;
-                        trackable = new Trackable(key, factory(), TrackState.Added);
+                        trackable = new Trackable(factory(), TrackState.Added);
                     }
                     else
                     {
-                        trackable = new Trackable(key, item, TrackState.Changed);
+                        trackable = new Trackable(item, TrackState.Changed);
                     }
                     _dictionary.Add(key, trackable);
                     _changeSet.Add(key);
@@ -406,12 +401,12 @@ namespace Neo.Persistence
                     var item = TryGetInternal(key);
                     if (item == null)
                     {
-                        trackable = new Trackable(key, factory(), TrackState.Added);
+                        trackable = new Trackable(factory(), TrackState.Added);
                         _changeSet.Add(key);
                     }
                     else
                     {
-                        trackable = new Trackable(key, item, TrackState.None);
+                        trackable = new Trackable(item, TrackState.None);
                     }
                     _dictionary.Add(key, trackable);
                 }
@@ -429,7 +424,7 @@ namespace Neo.Persistence
         {
             IEnumerable<(byte[], StorageKey, StorageItem)> cached;
             HashSet<StorageKey> cachedKeySet;
-            ByteArrayComparer comparer = direction == SeekDirection.Forward ? ByteArrayComparer.Default : ByteArrayComparer.Reverse;
+            var comparer = direction == SeekDirection.Forward ? ByteArrayComparer.Default : ByteArrayComparer.Reverse;
             lock (_dictionary)
             {
                 cached = _dictionary
@@ -455,8 +450,8 @@ namespace Neo.Persistence
             using var e1 = cached.GetEnumerator();
             using var e2 = uncached.GetEnumerator();
             (byte[] KeyBytes, StorageKey Key, StorageItem Item) i1, i2;
-            bool c1 = e1.MoveNext();
-            bool c2 = e2.MoveNext();
+            var c1 = e1.MoveNext();
+            var c2 = e2.MoveNext();
             i1 = c1 ? e1.Current : default;
             i2 = c2 ? e2.Current : default;
             while (c1 || c2)
@@ -501,7 +496,7 @@ namespace Neo.Persistence
                 }
                 var value = TryGetInternal(key);
                 if (value == null) return null;
-                _dictionary.Add(key, new Trackable(key, value, TrackState.None));
+                _dictionary.Add(key, new Trackable(value, TrackState.None));
                 return value;
             }
         }

--- a/src/Plugins/RpcServer/RpcServer.SmartContract.cs
+++ b/src/Plugins/RpcServer/RpcServer.SmartContract.cs
@@ -143,16 +143,16 @@ namespace Neo.Plugins.RpcServer
             return json;
         }
 
-        private static JArray ToJson(IEnumerable<DataCache.Trackable> changes)
+        private static JArray ToJson(IEnumerable<KeyValuePair<StorageKey, DataCache.Trackable>> changes)
         {
             JArray array = new();
             foreach (var entry in changes)
             {
                 array.Add(new JObject
                 {
-                    ["state"] = entry.State.ToString(),
+                    ["state"] = entry.Value.State.ToString(),
                     ["key"] = Convert.ToBase64String(entry.Key.ToArray()),
-                    ["value"] = Convert.ToBase64String(entry.Item.Value.ToArray())
+                    ["value"] = Convert.ToBase64String(entry.Value.Item.Value.ToArray())
                 });
             }
             return array;

--- a/src/Plugins/StateService/StatePlugin.cs
+++ b/src/Plugins/StateService/StatePlugin.cs
@@ -100,7 +100,7 @@ namespace Neo.Plugins.StateService
         void ICommittingHandler.Blockchain_Committing_Handler(NeoSystem system, Block block, DataCache snapshot, IReadOnlyList<ApplicationExecuted> applicationExecutedList)
         {
             if (system.Settings.Network != Settings.Default.Network) return;
-            StateStore.Singleton.UpdateLocalStateRootSnapshot(block.Index, snapshot.GetChangeSet().Where(p => p.State != TrackState.None).Where(p => p.Key.Id != NativeContract.Ledger.Id).ToList());
+            StateStore.Singleton.UpdateLocalStateRootSnapshot(block.Index, snapshot.GetChangeSet().Where(p => p.Value.State != TrackState.None).Where(p => p.Key.Id != NativeContract.Ledger.Id).ToList());
         }
 
         void ICommittedHandler.Blockchain_Committed_Handler(NeoSystem system, Block block)

--- a/src/Plugins/StateService/Storage/StateStore.cs
+++ b/src/Plugins/StateService/Storage/StateStore.cs
@@ -16,6 +16,7 @@ using Neo.Network.P2P.Payloads;
 using Neo.Persistence;
 using Neo.Plugins.StateService.Network;
 using Neo.Plugins.StateService.Verification;
+using Neo.SmartContract;
 using System;
 using System.Collections.Generic;
 using System.Threading;
@@ -123,18 +124,18 @@ namespace Neo.Plugins.StateService.Storage
             return true;
         }
 
-        public void UpdateLocalStateRootSnapshot(uint height, List<DataCache.Trackable> change_set)
+        public void UpdateLocalStateRootSnapshot(uint height, IEnumerable<KeyValuePair<StorageKey, DataCache.Trackable>> change_set)
         {
             _state_snapshot = Singleton.GetSnapshot();
             foreach (var item in change_set)
             {
-                switch (item.State)
+                switch (item.Value.State)
                 {
                     case TrackState.Added:
-                        _state_snapshot.Trie.Put(item.Key.ToArray(), item.Item.ToArray());
+                        _state_snapshot.Trie.Put(item.Key.ToArray(), item.Value.Item.ToArray());
                         break;
                     case TrackState.Changed:
-                        _state_snapshot.Trie.Put(item.Key.ToArray(), item.Item.ToArray());
+                        _state_snapshot.Trie.Put(item.Key.ToArray(), item.Value.Item.ToArray());
                         break;
                     case TrackState.Deleted:
                         _state_snapshot.Trie.Delete(item.Key.ToArray());

--- a/src/Plugins/StorageDumper/StorageDumper.cs
+++ b/src/Plugins/StorageDumper/StorageDumper.cs
@@ -94,27 +94,27 @@ namespace Neo.Plugins.StorageDumper
 
         private void OnPersistStorage(uint network, DataCache snapshot)
         {
-            uint blockIndex = NativeContract.Ledger.CurrentIndex(snapshot);
+            var blockIndex = NativeContract.Ledger.CurrentIndex(snapshot);
             if (blockIndex >= Settings.Default!.HeightToBegin)
             {
-                JArray stateChangeArray = new JArray();
+                var stateChangeArray = new JArray();
 
                 foreach (var trackable in snapshot.GetChangeSet())
                 {
                     if (Settings.Default.Exclude.Contains(trackable.Key.Id))
                         continue;
-                    JObject state = new JObject();
-                    switch (trackable.State)
+                    var state = new JObject();
+                    switch (trackable.Value.State)
                     {
                         case TrackState.Added:
                             state["state"] = "Added";
                             state["key"] = Convert.ToBase64String(trackable.Key.ToArray());
-                            state["value"] = Convert.ToBase64String(trackable.Item.ToArray());
+                            state["value"] = Convert.ToBase64String(trackable.Value.Item.ToArray());
                             break;
                         case TrackState.Changed:
                             state["state"] = "Changed";
                             state["key"] = Convert.ToBase64String(trackable.Key.ToArray());
-                            state["value"] = Convert.ToBase64String(trackable.Item.ToArray());
+                            state["value"] = Convert.ToBase64String(trackable.Value.Item.ToArray());
                             break;
                         case TrackState.Deleted:
                             state["state"] = "Deleted";
@@ -124,7 +124,7 @@ namespace Neo.Plugins.StorageDumper
                     stateChangeArray.Add(state);
                 }
 
-                JObject bs_item = new JObject();
+                var bs_item = new JObject();
                 bs_item["block"] = blockIndex;
                 bs_item["size"] = stateChangeArray.Count;
                 bs_item["storage"] = stateChangeArray;

--- a/tests/Neo.UnitTests/Persistence/UT_DataCache.cs
+++ b/tests/Neo.UnitTests/Persistence/UT_DataCache.cs
@@ -91,9 +91,9 @@ namespace Neo.UnitTests.IO.Caching
 
             store.Put(key2.ToArray(), value2.ToArray());
             myDataCache.Delete(key2);
-            Assert.AreEqual(TrackState.Deleted, myDataCache.GetChangeSet().Where(u => u.Key.Equals(key2)).Select(u => u.State).FirstOrDefault());
+            Assert.AreEqual(TrackState.Deleted, myDataCache.GetChangeSet().Where(u => u.Key.Equals(key2)).Select(u => u.Value.State).FirstOrDefault());
             myDataCache.Add(key2, value2);
-            Assert.AreEqual(TrackState.Changed, myDataCache.GetChangeSet().Where(u => u.Key.Equals(key2)).Select(u => u.State).FirstOrDefault());
+            Assert.AreEqual(TrackState.Changed, myDataCache.GetChangeSet().Where(u => u.Key.Equals(key2)).Select(u => u.Value.State).FirstOrDefault());
 
             action = () => myDataCache.Add(key2, value2);
             Assert.ThrowsException<ArgumentException>(action);
@@ -110,16 +110,16 @@ namespace Neo.UnitTests.IO.Caching
             using var myDataCache = new StoreCache(snapshot);
 
             myDataCache.Add(key1, value1);
-            Assert.AreEqual(TrackState.Added, myDataCache.GetChangeSet().Where(u => u.Key.Equals(key1)).Select(u => u.State).FirstOrDefault());
+            Assert.AreEqual(TrackState.Added, myDataCache.GetChangeSet().Where(u => u.Key.Equals(key1)).Select(u => u.Value.State).FirstOrDefault());
 
             myDataCache.Delete(key2);
-            Assert.AreEqual(TrackState.Deleted, myDataCache.GetChangeSet().Where(u => u.Key.Equals(key2)).Select(u => u.State).FirstOrDefault());
+            Assert.AreEqual(TrackState.Deleted, myDataCache.GetChangeSet().Where(u => u.Key.Equals(key2)).Select(u => u.Value.State).FirstOrDefault());
 
-            Assert.AreEqual(TrackState.None, myDataCache.GetChangeSet().Where(u => u.Key.Equals(key3)).Select(u => u.State).FirstOrDefault());
+            Assert.AreEqual(TrackState.None, myDataCache.GetChangeSet().Where(u => u.Key.Equals(key3)).Select(u => u.Value.State).FirstOrDefault());
             myDataCache.Delete(key3);
-            Assert.AreEqual(TrackState.Deleted, myDataCache.GetChangeSet().Where(u => u.Key.Equals(key3)).Select(u => u.State).FirstOrDefault());
+            Assert.AreEqual(TrackState.Deleted, myDataCache.GetChangeSet().Where(u => u.Key.Equals(key3)).Select(u => u.Value.State).FirstOrDefault());
             myDataCache.Add(key3, value4);
-            Assert.AreEqual(TrackState.Changed, myDataCache.GetChangeSet().Where(u => u.Key.Equals(key3)).Select(u => u.State).FirstOrDefault());
+            Assert.AreEqual(TrackState.Changed, myDataCache.GetChangeSet().Where(u => u.Key.Equals(key3)).Select(u => u.Value.State).FirstOrDefault());
 
             // If we use myDataCache after it is committed, it will return wrong result.
             myDataCache.Commit();
@@ -296,16 +296,16 @@ namespace Neo.UnitTests.IO.Caching
         public void TestGetChangeSet()
         {
             myDataCache.Add(key1, value1);
-            Assert.AreEqual(TrackState.Added, myDataCache.GetChangeSet().Where(u => u.Key.Equals(key1)).Select(u => u.State).FirstOrDefault());
+            Assert.AreEqual(TrackState.Added, myDataCache.GetChangeSet().Where(u => u.Key.Equals(key1)).Select(u => u.Value.State).FirstOrDefault());
             myDataCache.Add(key2, value2);
-            Assert.AreEqual(TrackState.Added, myDataCache.GetChangeSet().Where(u => u.Key.Equals(key2)).Select(u => u.State).FirstOrDefault());
+            Assert.AreEqual(TrackState.Added, myDataCache.GetChangeSet().Where(u => u.Key.Equals(key2)).Select(u => u.Value.State).FirstOrDefault());
 
             store.Put(key3.ToArray(), value3.ToArray());
             store.Put(key4.ToArray(), value4.ToArray());
             myDataCache.Delete(key3);
-            Assert.AreEqual(TrackState.Deleted, myDataCache.GetChangeSet().Where(u => u.Key.Equals(key3)).Select(u => u.State).FirstOrDefault());
+            Assert.AreEqual(TrackState.Deleted, myDataCache.GetChangeSet().Where(u => u.Key.Equals(key3)).Select(u => u.Value.State).FirstOrDefault());
             myDataCache.Delete(key4);
-            Assert.AreEqual(TrackState.Deleted, myDataCache.GetChangeSet().Where(u => u.Key.Equals(key4)).Select(u => u.State).FirstOrDefault());
+            Assert.AreEqual(TrackState.Deleted, myDataCache.GetChangeSet().Where(u => u.Key.Equals(key4)).Select(u => u.Value.State).FirstOrDefault());
 
             var items = myDataCache.GetChangeSet();
             int i = 0;
@@ -315,7 +315,7 @@ namespace Neo.UnitTests.IO.Caching
                 StorageKey key = new() { Id = 0, Key = Encoding.UTF8.GetBytes("key" + i) };
                 StorageItem value = new(Encoding.UTF8.GetBytes("value" + i));
                 Assert.AreEqual(key, item.Key);
-                Assert.IsTrue(value.EqualsTo(item.Item));
+                Assert.IsTrue(value.EqualsTo(item.Value.Item));
             }
             Assert.AreEqual(4, i);
         }
@@ -324,11 +324,11 @@ namespace Neo.UnitTests.IO.Caching
         public void TestGetAndChange()
         {
             myDataCache.Add(key1, value1);
-            Assert.AreEqual(TrackState.Added, myDataCache.GetChangeSet().Where(u => u.Key.Equals(key1)).Select(u => u.State).FirstOrDefault());
+            Assert.AreEqual(TrackState.Added, myDataCache.GetChangeSet().Where(u => u.Key.Equals(key1)).Select(u => u.Value.State).FirstOrDefault());
             store.Put(key2.ToArray(), value2.ToArray());
             store.Put(key3.ToArray(), value3.ToArray());
             myDataCache.Delete(key3);
-            Assert.AreEqual(TrackState.Deleted, myDataCache.GetChangeSet().Where(u => u.Key.Equals(key3)).Select(u => u.State).FirstOrDefault());
+            Assert.AreEqual(TrackState.Deleted, myDataCache.GetChangeSet().Where(u => u.Key.Equals(key3)).Select(u => u.Value.State).FirstOrDefault());
 
             StorageItem value_bk_1 = new(Encoding.UTF8.GetBytes("value_bk_1"));
             StorageItem value_bk_2 = new(Encoding.UTF8.GetBytes("value_bk_2"));
@@ -345,11 +345,11 @@ namespace Neo.UnitTests.IO.Caching
         public void TestGetOrAdd()
         {
             myDataCache.Add(key1, value1);
-            Assert.AreEqual(TrackState.Added, myDataCache.GetChangeSet().Where(u => u.Key.Equals(key1)).Select(u => u.State).FirstOrDefault());
+            Assert.AreEqual(TrackState.Added, myDataCache.GetChangeSet().Where(u => u.Key.Equals(key1)).Select(u => u.Value.State).FirstOrDefault());
             store.Put(key2.ToArray(), value2.ToArray());
             store.Put(key3.ToArray(), value3.ToArray());
             myDataCache.Delete(key3);
-            Assert.AreEqual(TrackState.Deleted, myDataCache.GetChangeSet().Where(u => u.Key.Equals(key3)).Select(u => u.State).FirstOrDefault());
+            Assert.AreEqual(TrackState.Deleted, myDataCache.GetChangeSet().Where(u => u.Key.Equals(key3)).Select(u => u.Value.State).FirstOrDefault());
 
             StorageItem value_bk_1 = new(Encoding.UTF8.GetBytes("value_bk_1"));
             StorageItem value_bk_2 = new(Encoding.UTF8.GetBytes("value_bk_2"));
@@ -366,11 +366,11 @@ namespace Neo.UnitTests.IO.Caching
         public void TestTryGet()
         {
             myDataCache.Add(key1, value1);
-            Assert.AreEqual(TrackState.Added, myDataCache.GetChangeSet().Where(u => u.Key.Equals(key1)).Select(u => u.State).FirstOrDefault());
+            Assert.AreEqual(TrackState.Added, myDataCache.GetChangeSet().Where(u => u.Key.Equals(key1)).Select(u => u.Value.State).FirstOrDefault());
             store.Put(key2.ToArray(), value2.ToArray());
             store.Put(key3.ToArray(), value3.ToArray());
             myDataCache.Delete(key3);
-            Assert.AreEqual(TrackState.Deleted, myDataCache.GetChangeSet().Where(u => u.Key.Equals(key3)).Select(u => u.State).FirstOrDefault());
+            Assert.AreEqual(TrackState.Deleted, myDataCache.GetChangeSet().Where(u => u.Key.Equals(key3)).Select(u => u.Value.State).FirstOrDefault());
 
             Assert.IsTrue(myDataCache.TryGet(key1).EqualsTo(value1));
             Assert.IsTrue(myDataCache.TryGet(key2).EqualsTo(value2));

--- a/tests/Neo.UnitTests/SmartContract/Native/UT_NeoToken.cs
+++ b/tests/Neo.UnitTests/SmartContract/Native/UT_NeoToken.cs
@@ -20,6 +20,7 @@ using Neo.UnitTests.Extensions;
 using Neo.VM;
 using Neo.VM.Types;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Numerics;
@@ -1213,17 +1214,17 @@ namespace Neo.UnitTests.SmartContract.Native
             return (result.GetInteger(), true);
         }
 
-        internal static void CheckValidator(ECPoint eCPoint, DataCache.Trackable trackable)
+        internal static void CheckValidator(ECPoint eCPoint, KeyValuePair<StorageKey, DataCache.Trackable> trackable)
         {
-            BigInteger st = trackable.Item;
+            BigInteger st = trackable.Value.Item;
             Assert.AreEqual(0, st);
 
             CollectionAssert.AreEqual(new byte[] { 33 }.Concat(eCPoint.EncodePoint(true)).ToArray(), trackable.Key.Key.ToArray());
         }
 
-        internal static void CheckBalance(byte[] account, DataCache.Trackable trackable, BigInteger balance, BigInteger height, ECPoint voteTo)
+        internal static void CheckBalance(byte[] account, KeyValuePair<StorageKey, DataCache.Trackable> trackable, BigInteger balance, BigInteger height, ECPoint voteTo)
         {
-            var st = (Struct)BinarySerializer.Deserialize(trackable.Item.Value, ExecutionEngineLimits.Default);
+            var st = (Struct)BinarySerializer.Deserialize(trackable.Value.Item.Value, ExecutionEngineLimits.Default);
 
             Assert.AreEqual(3, st.Count);
             CollectionAssert.AreEqual(new Type[] { typeof(Integer), typeof(Integer), typeof(ByteString) }, st.Select(u => u.GetType()).ToArray()); // Balance
@@ -1232,7 +1233,7 @@ namespace Neo.UnitTests.SmartContract.Native
             Assert.AreEqual(height, st[1].GetInteger());  // BalanceHeight
             Assert.AreEqual(voteTo, ECPoint.DecodePoint(st[2].GetSpan(), ECCurve.Secp256r1));  // Votes
 
-            CollectionAssert.AreEqual(new byte[] { 20 }.Concat(account).ToArray(), trackable.Key.Key.ToArray());
+            CollectionAssert.AreEqual(new byte[] { 20 }.Concat(account).ToArray(), trackable.Key.ToArray());
         }
 
         internal static StorageKey CreateStorageKey(byte prefix, byte[] key = null)


### PR DESCRIPTION
# Description

Removed `Trackable.Key` and changed some types to `var`

Key is not needed to be stored in the same state object, it's duplicate data, we already have it in the dictionary, and in the hashset, this will improve the memory and the performance

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Optimization (the change is only an optimization)
- [x] Style (the change is only a code style for better maintenance or standard purpose)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Current

**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
