### PR TITLE
Fix: dec `m` iff `AddSignature` succeed

### DIFF
--- a/src/Neo/Wallets/Wallet.cs
+++ b/src/Neo/Wallets/Wallet.cs
@@ -616,10 +616,13 @@ namespace Neo.Wallets
                         {
                             account = GetAccount(point);
                             if (account?.HasKey != true) continue;
+
                             KeyPair key = account.GetKey();
                             byte[] signature = context.Verifiable.Sign(key, context.Network);
-                            fSuccess |= context.AddSignature(multiSigContract, key.PublicKey, signature);
-                            if (fSuccess) m--;
+                            var ok = context.AddSignature(multiSigContract, key.PublicKey, signature);
+                            if (ok) m--;
+
+                            fSuccess |= ok;
                             if (context.Completed || m <= 0) break;
                         }
                         continue;


### PR DESCRIPTION
# Description

If `fSucess` is already true(because of previous operations), the m  will always decrease even if `AddSignature` failed.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
