### PR TITLE
[`Add`] More Exceptions - Part 1

### DIFF
--- a/src/Shared/Directory.Build.props
+++ b/src/Shared/Directory.Build.props
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
+  <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+  </PropertyGroup>
+
   <PropertyGroup>
     <VersionPrefix>3.9.0</VersionPrefix>
     <RootNamespace>$(MSBuildProjectName)</RootNamespace>
@@ -27,6 +31,8 @@
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/neo-project/neo.git</RepositoryUrl>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+
+    <OverwriteReadOnlyFiles>true</OverwriteReadOnlyFiles>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Shared/Neo.Build.Core/Exceptions/NeoBuildFileAccessDeniedException.cs
+++ b/src/Shared/Neo.Build.Core/Exceptions/NeoBuildFileAccessDeniedException.cs
@@ -9,11 +9,15 @@
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
+using System.IO;
+
 namespace Neo.Build.Core.Exceptions
 {
     public class NeoBuildFileAccessDeniedException(
-        string filename) : NeoBuildException($"Accessing file '{filename}' was denied.", NeoBuildErrorCodes.General.FileAccessDenied)
+        FileInfo file) : NeoBuildException($"Accessing file '{file}' was denied.", NeoBuildErrorCodes.General.FileAccessDenied)
     {
-        public string Filename => filename;
+        public NeoBuildFileAccessDeniedException(string filename) : this(new FileInfo(filename)) { }
+
+        public FileInfo FileInfo => file;
     }
 }

--- a/src/Shared/Neo.Build.Core/Exceptions/NeoBuildFileNotFoundException.cs
+++ b/src/Shared/Neo.Build.Core/Exceptions/NeoBuildFileNotFoundException.cs
@@ -9,11 +9,15 @@
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
+using System.IO;
+
 namespace Neo.Build.Core.Exceptions
 {
     public class NeoBuildFileNotFoundException(
-        string filename) : NeoBuildException($"File '{filename}' was not found.", NeoBuildErrorCodes.General.FileNotFound)
+        FileInfo filename) : NeoBuildException($"File '{filename}' was not found.", NeoBuildErrorCodes.General.FileNotFound)
     {
-        public string Filename => filename;
+        public NeoBuildFileNotFoundException(string filename) : this(new FileInfo(filename)) { }
+
+        public FileInfo FileInfo => filename;
     }
 }

--- a/src/Shared/Neo.Build.Core/Exceptions/NeoBuildInvalidAddressFormatException.cs
+++ b/src/Shared/Neo.Build.Core/Exceptions/NeoBuildInvalidAddressFormatException.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2025 The Neo Project.
 //
-// NeoBuildPathNotFoundException.cs file belongs to the neo project and is free
+// NeoBuildInvalidAddressFormatException.cs file belongs to the neo project and is free
 // software distributed under the MIT software license, see the
 // accompanying file LICENSE in the main directory of the
 // repository or http://www.opensource.org/licenses/mit-license.php
@@ -9,15 +9,11 @@
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
-using System.IO;
-
 namespace Neo.Build.Core.Exceptions
 {
-    public class NeoBuildPathNotFoundException(
-        DirectoryInfo path) : NeoBuildException($"Path '{path}' was not found.", NeoBuildErrorCodes.General.PathNotFound)
+    public class NeoBuildInvalidAddressFormatException(
+        string message) : NeoBuildException(message, NeoBuildErrorCodes.General.InvalidAddressFormat)
     {
-        public NeoBuildPathNotFoundException(string path) : this(new DirectoryInfo(path)) { }
-
-        public DirectoryInfo PathInfo => path;
+        public NeoBuildInvalidAddressFormatException() : this("Invalid wallet address format.") { }
     }
 }

--- a/src/Shared/Neo.Build.Core/Exceptions/NeoBuildInvalidBinaryFormatException.cs
+++ b/src/Shared/Neo.Build.Core/Exceptions/NeoBuildInvalidBinaryFormatException.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2025 The Neo Project.
 //
-// NeoBuildPathNotFoundException.cs file belongs to the neo project and is free
+// NeoBuildInvalidBinaryFormatException.cs file belongs to the neo project and is free
 // software distributed under the MIT software license, see the
 // accompanying file LICENSE in the main directory of the
 // repository or http://www.opensource.org/licenses/mit-license.php
@@ -9,15 +9,11 @@
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
-using System.IO;
-
 namespace Neo.Build.Core.Exceptions
 {
-    public class NeoBuildPathNotFoundException(
-        DirectoryInfo path) : NeoBuildException($"Path '{path}' was not found.", NeoBuildErrorCodes.General.PathNotFound)
+    public class NeoBuildInvalidBinaryFormatException(
+        string message) : NeoBuildException(message, NeoBuildErrorCodes.General.InvalidBinaryFormat)
     {
-        public NeoBuildPathNotFoundException(string path) : this(new DirectoryInfo(path)) { }
-
-        public DirectoryInfo PathInfo => path;
+        public NeoBuildInvalidBinaryFormatException() : this("Invalid binary format.") { }
     }
 }

--- a/src/Shared/Neo.Build.Core/Exceptions/NeoBuildInvalidBooleanFormatException.cs
+++ b/src/Shared/Neo.Build.Core/Exceptions/NeoBuildInvalidBooleanFormatException.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2025 The Neo Project.
 //
-// NeoBuildPathNotFoundException.cs file belongs to the neo project and is free
+// NeoBuildInvalidBooleanFormatException.cs file belongs to the neo project and is free
 // software distributed under the MIT software license, see the
 // accompanying file LICENSE in the main directory of the
 // repository or http://www.opensource.org/licenses/mit-license.php
@@ -9,15 +9,11 @@
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
-using System.IO;
-
 namespace Neo.Build.Core.Exceptions
 {
-    public class NeoBuildPathNotFoundException(
-        DirectoryInfo path) : NeoBuildException($"Path '{path}' was not found.", NeoBuildErrorCodes.General.PathNotFound)
+    public class NeoBuildInvalidBooleanFormatException(
+        string message) : NeoBuildException(message, NeoBuildErrorCodes.General.InvalidBooleanFormat)
     {
-        public NeoBuildPathNotFoundException(string path) : this(new DirectoryInfo(path)) { }
-
-        public DirectoryInfo PathInfo => path;
+        public NeoBuildInvalidBooleanFormatException() : this("Invalid boolean format.") { }
     }
 }

--- a/src/Shared/Neo.Build.Core/Exceptions/NeoBuildInvalidDateFormatException.cs
+++ b/src/Shared/Neo.Build.Core/Exceptions/NeoBuildInvalidDateFormatException.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2025 The Neo Project.
 //
-// NeoBuildPathNotFoundException.cs file belongs to the neo project and is free
+// NeoBuildInvalidDateFormatException.cs file belongs to the neo project and is free
 // software distributed under the MIT software license, see the
 // accompanying file LICENSE in the main directory of the
 // repository or http://www.opensource.org/licenses/mit-license.php
@@ -9,15 +9,11 @@
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
-using System.IO;
-
 namespace Neo.Build.Core.Exceptions
 {
-    public class NeoBuildPathNotFoundException(
-        DirectoryInfo path) : NeoBuildException($"Path '{path}' was not found.", NeoBuildErrorCodes.General.PathNotFound)
+    public class NeoBuildInvalidDateFormatException(
+        string message) : NeoBuildException(message, NeoBuildErrorCodes.General.InvalidDateFormat)
     {
-        public NeoBuildPathNotFoundException(string path) : this(new DirectoryInfo(path)) { }
-
-        public DirectoryInfo PathInfo => path;
+        public NeoBuildInvalidDateFormatException() : this("Invalid date time format.") { }
     }
 }

--- a/src/Shared/Neo.Build.Core/Exceptions/NeoBuildInvalidECPointFormatException.cs
+++ b/src/Shared/Neo.Build.Core/Exceptions/NeoBuildInvalidECPointFormatException.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2025 The Neo Project.
 //
-// NeoBuildPathNotFoundException.cs file belongs to the neo project and is free
+// NeoBuildInvalidECPointFormatException.cs file belongs to the neo project and is free
 // software distributed under the MIT software license, see the
 // accompanying file LICENSE in the main directory of the
 // repository or http://www.opensource.org/licenses/mit-license.php
@@ -9,15 +9,11 @@
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
-using System.IO;
-
 namespace Neo.Build.Core.Exceptions
 {
-    public class NeoBuildPathNotFoundException(
-        DirectoryInfo path) : NeoBuildException($"Path '{path}' was not found.", NeoBuildErrorCodes.General.PathNotFound)
+    public class NeoBuildInvalidECPointFormatException(
+        string message) : NeoBuildException(message, NeoBuildErrorCodes.General.InvalidECPointFormat)
     {
-        public NeoBuildPathNotFoundException(string path) : this(new DirectoryInfo(path)) { }
-
-        public DirectoryInfo PathInfo => path;
+        public NeoBuildInvalidECPointFormatException() : this("Invalid elliptic curve point format.") { }
     }
 }

--- a/src/Shared/Neo.Build.Core/Exceptions/NeoBuildInvalidEncodingFormatException.cs
+++ b/src/Shared/Neo.Build.Core/Exceptions/NeoBuildInvalidEncodingFormatException.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2025 The Neo Project.
 //
-// NeoBuildPathNotFoundException.cs file belongs to the neo project and is free
+// NeoBuildInvalidEncodingFormatException.cs file belongs to the neo project and is free
 // software distributed under the MIT software license, see the
 // accompanying file LICENSE in the main directory of the
 // repository or http://www.opensource.org/licenses/mit-license.php
@@ -9,15 +9,11 @@
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
-using System.IO;
-
 namespace Neo.Build.Core.Exceptions
 {
-    public class NeoBuildPathNotFoundException(
-        DirectoryInfo path) : NeoBuildException($"Path '{path}' was not found.", NeoBuildErrorCodes.General.PathNotFound)
+    public class NeoBuildInvalidEncodingFormatException(
+        string message) : NeoBuildException(message, NeoBuildErrorCodes.General.InvalidEncodingFormat)
     {
-        public NeoBuildPathNotFoundException(string path) : this(new DirectoryInfo(path)) { }
-
-        public DirectoryInfo PathInfo => path;
+        public NeoBuildInvalidEncodingFormatException() : this("Invalid encoding format.") { }
     }
 }

--- a/src/Shared/Neo.Build.Core/Exceptions/NeoBuildInvalidFileFormatException.cs
+++ b/src/Shared/Neo.Build.Core/Exceptions/NeoBuildInvalidFileFormatException.cs
@@ -9,11 +9,15 @@
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
+using System.IO;
+
 namespace Neo.Build.Core.Exceptions
 {
     public class NeoBuildInvalidFileFormatException(
-        string filename) : NeoBuildException($"File '{filename}' is not in the correct format.", NeoBuildErrorCodes.General.InvalidFileFormat)
+        FileInfo filename) : NeoBuildException($"File '{filename}' is not in the correct format.", NeoBuildErrorCodes.General.InvalidFileFormat)
     {
-        public string Filename => filename;
+        public NeoBuildInvalidFileFormatException(string filename) : this(new FileInfo(filename)) { }
+
+        public FileInfo FileInfo => filename;
     }
 }

--- a/src/Shared/Neo.Build.Core/Exceptions/NeoBuildInvalidHash256FormatException.cs
+++ b/src/Shared/Neo.Build.Core/Exceptions/NeoBuildInvalidHash256FormatException.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2025 The Neo Project.
 //
-// NeoBuildPathNotFoundException.cs file belongs to the neo project and is free
+// NeoBuildInvalidHash256FormatException.cs file belongs to the neo project and is free
 // software distributed under the MIT software license, see the
 // accompanying file LICENSE in the main directory of the
 // repository or http://www.opensource.org/licenses/mit-license.php
@@ -9,15 +9,11 @@
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
-using System.IO;
-
 namespace Neo.Build.Core.Exceptions
 {
-    public class NeoBuildPathNotFoundException(
-        DirectoryInfo path) : NeoBuildException($"Path '{path}' was not found.", NeoBuildErrorCodes.General.PathNotFound)
+    public class NeoBuildInvalidHash256FormatException(
+        string message) : NeoBuildException(message, NeoBuildErrorCodes.General.InvalidHash256Format)
     {
-        public NeoBuildPathNotFoundException(string path) : this(new DirectoryInfo(path)) { }
-
-        public DirectoryInfo PathInfo => path;
+        public NeoBuildInvalidHash256FormatException() : this("Invalid Hash256 format.") { }
     }
 }

--- a/src/Shared/Neo.Build.Core/Exceptions/NeoBuildInvalidHexFormatException.cs
+++ b/src/Shared/Neo.Build.Core/Exceptions/NeoBuildInvalidHexFormatException.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2025 The Neo Project.
 //
-// NeoBuildPathNotFoundException.cs file belongs to the neo project and is free
+// NeoBuildInvalidHexFormatException.cs file belongs to the neo project and is free
 // software distributed under the MIT software license, see the
 // accompanying file LICENSE in the main directory of the
 // repository or http://www.opensource.org/licenses/mit-license.php
@@ -9,15 +9,11 @@
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
-using System.IO;
-
 namespace Neo.Build.Core.Exceptions
 {
-    public class NeoBuildPathNotFoundException(
-        DirectoryInfo path) : NeoBuildException($"Path '{path}' was not found.", NeoBuildErrorCodes.General.PathNotFound)
+    public class NeoBuildInvalidHexFormatException(
+        string message) : NeoBuildException(message, NeoBuildErrorCodes.General.InvalidHexFormat)
     {
-        public NeoBuildPathNotFoundException(string path) : this(new DirectoryInfo(path)) { }
-
-        public DirectoryInfo PathInfo => path;
+        public NeoBuildInvalidHexFormatException() : this("Invalid hex string format.") { }
     }
 }

--- a/src/Shared/Neo.Build.Core/Exceptions/NeoBuildInvalidJsonFormatException.cs
+++ b/src/Shared/Neo.Build.Core/Exceptions/NeoBuildInvalidJsonFormatException.cs
@@ -1,0 +1,23 @@
+// Copyright (C) 2015-2025 The Neo Project.
+//
+// NeoBuildInvalidJsonFormatException.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using System.Text.Json;
+
+namespace Neo.Build.Core.Exceptions
+{
+    public class NeoBuildInvalidJsonFormatException(
+        JsonException jsonException) : NeoBuildException(jsonException.Message, NeoBuildErrorCodes.General.InvalidJsonFormat)
+    {
+        public long? BytePositionInLine => jsonException.BytePositionInLine;
+        public long? LineNumber => jsonException.LineNumber;
+        public string? Path => jsonException.Path;
+    }
+}

--- a/src/Shared/Neo.Build.Core/Exceptions/NeoBuildInvalidNumberFormatException.cs
+++ b/src/Shared/Neo.Build.Core/Exceptions/NeoBuildInvalidNumberFormatException.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2025 The Neo Project.
 //
-// NeoBuildPathNotFoundException.cs file belongs to the neo project and is free
+// NeoBuildInvalidNumberFormatException.cs file belongs to the neo project and is free
 // software distributed under the MIT software license, see the
 // accompanying file LICENSE in the main directory of the
 // repository or http://www.opensource.org/licenses/mit-license.php
@@ -9,15 +9,11 @@
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
-using System.IO;
-
 namespace Neo.Build.Core.Exceptions
 {
-    public class NeoBuildPathNotFoundException(
-        DirectoryInfo path) : NeoBuildException($"Path '{path}' was not found.", NeoBuildErrorCodes.General.PathNotFound)
+    public class NeoBuildInvalidNumberFormatException(
+        string message) : NeoBuildException(message, NeoBuildErrorCodes.General.InvalidNumberFormat)
     {
-        public NeoBuildPathNotFoundException(string path) : this(new DirectoryInfo(path)) { }
-
-        public DirectoryInfo PathInfo => path;
+        public NeoBuildInvalidNumberFormatException() : this("Invalid number format.") { }
     }
 }

--- a/src/Shared/Neo.Build.Core/Exceptions/NeoBuildInvalidScriptHashFormatException.cs
+++ b/src/Shared/Neo.Build.Core/Exceptions/NeoBuildInvalidScriptHashFormatException.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2025 The Neo Project.
 //
-// NeoBuildPathNotFoundException.cs file belongs to the neo project and is free
+// NeoBuildInvalidScriptHashFormatException.cs file belongs to the neo project and is free
 // software distributed under the MIT software license, see the
 // accompanying file LICENSE in the main directory of the
 // repository or http://www.opensource.org/licenses/mit-license.php
@@ -9,15 +9,11 @@
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
-using System.IO;
-
 namespace Neo.Build.Core.Exceptions
 {
-    public class NeoBuildPathNotFoundException(
-        DirectoryInfo path) : NeoBuildException($"Path '{path}' was not found.", NeoBuildErrorCodes.General.PathNotFound)
+    public class NeoBuildInvalidScriptHashFormatException(
+        string message) : NeoBuildException(message, NeoBuildErrorCodes.General.InvalidScriptHashFormat)
     {
-        public NeoBuildPathNotFoundException(string path) : this(new DirectoryInfo(path)) { }
-
-        public DirectoryInfo PathInfo => path;
+        public NeoBuildInvalidScriptHashFormatException() : this("Invalid scriptHash format.") { }
     }
 }

--- a/src/Shared/Neo.Build.Core/Exceptions/NeoBuildInvalidVersionFormatException.cs
+++ b/src/Shared/Neo.Build.Core/Exceptions/NeoBuildInvalidVersionFormatException.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2025 The Neo Project.
 //
-// NeoBuildPathNotFoundException.cs file belongs to the neo project and is free
+// NeoBuildInvalidVersionFormatException.cs file belongs to the neo project and is free
 // software distributed under the MIT software license, see the
 // accompanying file LICENSE in the main directory of the
 // repository or http://www.opensource.org/licenses/mit-license.php
@@ -9,15 +9,11 @@
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
-using System.IO;
-
 namespace Neo.Build.Core.Exceptions
 {
-    public class NeoBuildPathNotFoundException(
-        DirectoryInfo path) : NeoBuildException($"Path '{path}' was not found.", NeoBuildErrorCodes.General.PathNotFound)
+    public class NeoBuildInvalidVersionFormatException(
+        string message) : NeoBuildException(message, NeoBuildErrorCodes.General.InvalidVersionFormat)
     {
-        public NeoBuildPathNotFoundException(string path) : this(new DirectoryInfo(path)) { }
-
-        public DirectoryInfo PathInfo => path;
+        public NeoBuildInvalidVersionFormatException() : this("Invalid version format.") { }
     }
 }

--- a/src/Shared/Neo.Build.Core/Neo.Build.Core.csproj
+++ b/src/Shared/Neo.Build.Core/Neo.Build.Core.csproj
@@ -6,7 +6,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <InternalsVisibleTo Include="$(RootNamespace).Tests"/>
+    <InternalsVisibleTo Include="$(RootNamespace).Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Text.Json" Version="9.0.2" />
   </ItemGroup>
 
 </Project>

--- a/tests/Neo.Build.Core.Tests/Exceptions/UT_NeoBuildFileAccessDeniedException.cs
+++ b/tests/Neo.Build.Core.Tests/Exceptions/UT_NeoBuildFileAccessDeniedException.cs
@@ -33,7 +33,7 @@ namespace Neo.Build.Core.Tests.Exceptions
             Assert.AreEqual($"{NeoBuildErrorCodes.StringPrefix}{(uint)exception.ExitCode:d04}", exception.ErrorCode);
             Assert.AreEqual($"Error {exception.ErrorCode} {expectedMessage}", exception.Message);
             Assert.AreEqual(exception.Message, $"{exception}");
-            Assert.AreEqual(expectedFilename, exception.Filename);
+            Assert.AreEqual(expectedFilename, $"{exception.FileInfo}");
 
             // INeoBuildException
             Assert.AreEqual(NeoBuildErrorCodes.General.FileAccessDenied, exceptionInterface.ExitCode);

--- a/tests/Neo.Build.Core.Tests/Exceptions/UT_NeoBuildInvalidAddressFormatException.cs
+++ b/tests/Neo.Build.Core.Tests/Exceptions/UT_NeoBuildInvalidAddressFormatException.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2025 The Neo Project.
 //
-// UT_NeoBuildFileNotFoundException.cs file belongs to the neo project and is free
+// UT_NeoBuildInvalidAddressFormatException.cs file belongs to the neo project and is free
 // software distributed under the MIT software license, see the
 // accompanying file LICENSE in the main directory of the
 // repository or http://www.opensource.org/licenses/mit-license.php
@@ -15,33 +15,31 @@ using System;
 namespace Neo.Build.Core.Tests.Exceptions
 {
     [TestClass]
-    public class UT_NeoBuildFileNotFoundException
+    public class UT_NeoBuildInvalidAddressFormatException
     {
         [TestMethod]
         public void TestIsPropertiesSet()
         {
-            var expectedFilename = "/path/to/filename";
-            var expectedMessage = $"File '{expectedFilename}' was not found.";
+            var expectedMessage = "Invalid wallet address format.";
 
-            var exception = new NeoBuildFileNotFoundException(expectedFilename);
+            var exception = new NeoBuildInvalidAddressFormatException();
             var exceptionInterface = exception as INeoBuildException;
             var exceptionBase = exception as Exception;
 
-            // NeoBuildFileNotFoundException
-            Assert.AreEqual(NeoBuildErrorCodes.General.FileNotFound, exception.ExitCode);
+            // NeoBuildInvalidAddressFormatException
+            Assert.AreEqual(NeoBuildErrorCodes.General.InvalidAddressFormat, exception.ExitCode);
             Assert.AreEqual(exception.ExitCode, exception.HResult);
             Assert.AreEqual($"{NeoBuildErrorCodes.StringPrefix}{(uint)exception.ExitCode:d04}", exception.ErrorCode);
             Assert.AreEqual($"Error {exception.ErrorCode} {expectedMessage}", exception.Message);
             Assert.AreEqual(exception.Message, $"{exception}");
-            Assert.AreEqual(expectedFilename, $"{exception.FileInfo}");
 
             // INeoBuildException
-            Assert.AreEqual(NeoBuildErrorCodes.General.FileNotFound, exceptionInterface.ExitCode);
+            Assert.AreEqual(NeoBuildErrorCodes.General.InvalidAddressFormat, exceptionInterface.ExitCode);
             Assert.AreEqual($"{NeoBuildErrorCodes.StringPrefix}{(uint)exceptionInterface.ExitCode:d04}", exceptionInterface.ErrorCode);
             Assert.AreEqual($"Error {exceptionInterface.ErrorCode} {expectedMessage}", exceptionInterface.Message);
 
             // System.Exception
-            Assert.AreEqual(NeoBuildErrorCodes.General.FileNotFound, exceptionBase.HResult);
+            Assert.AreEqual(NeoBuildErrorCodes.General.InvalidAddressFormat, exceptionBase.HResult);
             Assert.AreEqual($"Error {NeoBuildErrorCodes.StringPrefix}{(uint)exceptionBase.HResult} {expectedMessage}", exceptionBase.Message);
             Assert.AreEqual(exception.Message, $"{exceptionBase}");
         }

--- a/tests/Neo.Build.Core.Tests/Exceptions/UT_NeoBuildInvalidBinaryFormatException.cs
+++ b/tests/Neo.Build.Core.Tests/Exceptions/UT_NeoBuildInvalidBinaryFormatException.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2025 The Neo Project.
 //
-// UT_NeoBuildFileNotFoundException.cs file belongs to the neo project and is free
+// UT_NeoBuildInvalidBinaryFormatException.cs file belongs to the neo project and is free
 // software distributed under the MIT software license, see the
 // accompanying file LICENSE in the main directory of the
 // repository or http://www.opensource.org/licenses/mit-license.php
@@ -15,33 +15,31 @@ using System;
 namespace Neo.Build.Core.Tests.Exceptions
 {
     [TestClass]
-    public class UT_NeoBuildFileNotFoundException
+    public class UT_NeoBuildInvalidBinaryFormatException
     {
         [TestMethod]
         public void TestIsPropertiesSet()
         {
-            var expectedFilename = "/path/to/filename";
-            var expectedMessage = $"File '{expectedFilename}' was not found.";
+            var expectedMessage = "Invalid binary format.";
 
-            var exception = new NeoBuildFileNotFoundException(expectedFilename);
+            var exception = new NeoBuildInvalidBinaryFormatException();
             var exceptionInterface = exception as INeoBuildException;
             var exceptionBase = exception as Exception;
 
-            // NeoBuildFileNotFoundException
-            Assert.AreEqual(NeoBuildErrorCodes.General.FileNotFound, exception.ExitCode);
+            // NeoBuildInvalidBinaryFormatException
+            Assert.AreEqual(NeoBuildErrorCodes.General.InvalidBinaryFormat, exception.ExitCode);
             Assert.AreEqual(exception.ExitCode, exception.HResult);
             Assert.AreEqual($"{NeoBuildErrorCodes.StringPrefix}{(uint)exception.ExitCode:d04}", exception.ErrorCode);
             Assert.AreEqual($"Error {exception.ErrorCode} {expectedMessage}", exception.Message);
             Assert.AreEqual(exception.Message, $"{exception}");
-            Assert.AreEqual(expectedFilename, $"{exception.FileInfo}");
 
             // INeoBuildException
-            Assert.AreEqual(NeoBuildErrorCodes.General.FileNotFound, exceptionInterface.ExitCode);
+            Assert.AreEqual(NeoBuildErrorCodes.General.InvalidBinaryFormat, exceptionInterface.ExitCode);
             Assert.AreEqual($"{NeoBuildErrorCodes.StringPrefix}{(uint)exceptionInterface.ExitCode:d04}", exceptionInterface.ErrorCode);
             Assert.AreEqual($"Error {exceptionInterface.ErrorCode} {expectedMessage}", exceptionInterface.Message);
 
             // System.Exception
-            Assert.AreEqual(NeoBuildErrorCodes.General.FileNotFound, exceptionBase.HResult);
+            Assert.AreEqual(NeoBuildErrorCodes.General.InvalidBinaryFormat, exceptionBase.HResult);
             Assert.AreEqual($"Error {NeoBuildErrorCodes.StringPrefix}{(uint)exceptionBase.HResult} {expectedMessage}", exceptionBase.Message);
             Assert.AreEqual(exception.Message, $"{exceptionBase}");
         }

--- a/tests/Neo.Build.Core.Tests/Exceptions/UT_NeoBuildInvalidBooleanFormatException.cs
+++ b/tests/Neo.Build.Core.Tests/Exceptions/UT_NeoBuildInvalidBooleanFormatException.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2025 The Neo Project.
 //
-// UT_NeoBuildFileNotFoundException.cs file belongs to the neo project and is free
+// UT_NeoBuildInvalidBooleanFormatException.cs file belongs to the neo project and is free
 // software distributed under the MIT software license, see the
 // accompanying file LICENSE in the main directory of the
 // repository or http://www.opensource.org/licenses/mit-license.php
@@ -15,33 +15,31 @@ using System;
 namespace Neo.Build.Core.Tests.Exceptions
 {
     [TestClass]
-    public class UT_NeoBuildFileNotFoundException
+    public class UT_NeoBuildInvalidBooleanFormatException
     {
         [TestMethod]
         public void TestIsPropertiesSet()
         {
-            var expectedFilename = "/path/to/filename";
-            var expectedMessage = $"File '{expectedFilename}' was not found.";
+            var expectedMessage = "Invalid boolean format.";
 
-            var exception = new NeoBuildFileNotFoundException(expectedFilename);
+            var exception = new NeoBuildInvalidBooleanFormatException();
             var exceptionInterface = exception as INeoBuildException;
             var exceptionBase = exception as Exception;
 
-            // NeoBuildFileNotFoundException
-            Assert.AreEqual(NeoBuildErrorCodes.General.FileNotFound, exception.ExitCode);
+            // NeoBuildInvalidBooleanFormatException
+            Assert.AreEqual(NeoBuildErrorCodes.General.InvalidBooleanFormat, exception.ExitCode);
             Assert.AreEqual(exception.ExitCode, exception.HResult);
             Assert.AreEqual($"{NeoBuildErrorCodes.StringPrefix}{(uint)exception.ExitCode:d04}", exception.ErrorCode);
             Assert.AreEqual($"Error {exception.ErrorCode} {expectedMessage}", exception.Message);
             Assert.AreEqual(exception.Message, $"{exception}");
-            Assert.AreEqual(expectedFilename, $"{exception.FileInfo}");
 
             // INeoBuildException
-            Assert.AreEqual(NeoBuildErrorCodes.General.FileNotFound, exceptionInterface.ExitCode);
+            Assert.AreEqual(NeoBuildErrorCodes.General.InvalidBooleanFormat, exceptionInterface.ExitCode);
             Assert.AreEqual($"{NeoBuildErrorCodes.StringPrefix}{(uint)exceptionInterface.ExitCode:d04}", exceptionInterface.ErrorCode);
             Assert.AreEqual($"Error {exceptionInterface.ErrorCode} {expectedMessage}", exceptionInterface.Message);
 
             // System.Exception
-            Assert.AreEqual(NeoBuildErrorCodes.General.FileNotFound, exceptionBase.HResult);
+            Assert.AreEqual(NeoBuildErrorCodes.General.InvalidBooleanFormat, exceptionBase.HResult);
             Assert.AreEqual($"Error {NeoBuildErrorCodes.StringPrefix}{(uint)exceptionBase.HResult} {expectedMessage}", exceptionBase.Message);
             Assert.AreEqual(exception.Message, $"{exceptionBase}");
         }

--- a/tests/Neo.Build.Core.Tests/Exceptions/UT_NeoBuildInvalidDateFormatException.cs
+++ b/tests/Neo.Build.Core.Tests/Exceptions/UT_NeoBuildInvalidDateFormatException.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2025 The Neo Project.
 //
-// UT_NeoBuildFileNotFoundException.cs file belongs to the neo project and is free
+// UT_NeoBuildInvalidDateFormatException.cs file belongs to the neo project and is free
 // software distributed under the MIT software license, see the
 // accompanying file LICENSE in the main directory of the
 // repository or http://www.opensource.org/licenses/mit-license.php
@@ -15,33 +15,31 @@ using System;
 namespace Neo.Build.Core.Tests.Exceptions
 {
     [TestClass]
-    public class UT_NeoBuildFileNotFoundException
+    public class UT_NeoBuildInvalidDateFormatException
     {
         [TestMethod]
         public void TestIsPropertiesSet()
         {
-            var expectedFilename = "/path/to/filename";
-            var expectedMessage = $"File '{expectedFilename}' was not found.";
+            var expectedMessage = "Invalid date time format.";
 
-            var exception = new NeoBuildFileNotFoundException(expectedFilename);
+            var exception = new NeoBuildInvalidDateFormatException();
             var exceptionInterface = exception as INeoBuildException;
             var exceptionBase = exception as Exception;
 
-            // NeoBuildFileNotFoundException
-            Assert.AreEqual(NeoBuildErrorCodes.General.FileNotFound, exception.ExitCode);
+            // NeoBuildInvalidScriptHashFormatException
+            Assert.AreEqual(NeoBuildErrorCodes.General.InvalidDateFormat, exception.ExitCode);
             Assert.AreEqual(exception.ExitCode, exception.HResult);
             Assert.AreEqual($"{NeoBuildErrorCodes.StringPrefix}{(uint)exception.ExitCode:d04}", exception.ErrorCode);
             Assert.AreEqual($"Error {exception.ErrorCode} {expectedMessage}", exception.Message);
             Assert.AreEqual(exception.Message, $"{exception}");
-            Assert.AreEqual(expectedFilename, $"{exception.FileInfo}");
 
             // INeoBuildException
-            Assert.AreEqual(NeoBuildErrorCodes.General.FileNotFound, exceptionInterface.ExitCode);
+            Assert.AreEqual(NeoBuildErrorCodes.General.InvalidDateFormat, exceptionInterface.ExitCode);
             Assert.AreEqual($"{NeoBuildErrorCodes.StringPrefix}{(uint)exceptionInterface.ExitCode:d04}", exceptionInterface.ErrorCode);
             Assert.AreEqual($"Error {exceptionInterface.ErrorCode} {expectedMessage}", exceptionInterface.Message);
 
             // System.Exception
-            Assert.AreEqual(NeoBuildErrorCodes.General.FileNotFound, exceptionBase.HResult);
+            Assert.AreEqual(NeoBuildErrorCodes.General.InvalidDateFormat, exceptionBase.HResult);
             Assert.AreEqual($"Error {NeoBuildErrorCodes.StringPrefix}{(uint)exceptionBase.HResult} {expectedMessage}", exceptionBase.Message);
             Assert.AreEqual(exception.Message, $"{exceptionBase}");
         }

--- a/tests/Neo.Build.Core.Tests/Exceptions/UT_NeoBuildInvalidECPointFormatException.cs
+++ b/tests/Neo.Build.Core.Tests/Exceptions/UT_NeoBuildInvalidECPointFormatException.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2025 The Neo Project.
 //
-// UT_NeoBuildFileNotFoundException.cs file belongs to the neo project and is free
+// UT_NeoBuildInvalidECPointFormatException.cs file belongs to the neo project and is free
 // software distributed under the MIT software license, see the
 // accompanying file LICENSE in the main directory of the
 // repository or http://www.opensource.org/licenses/mit-license.php
@@ -15,33 +15,31 @@ using System;
 namespace Neo.Build.Core.Tests.Exceptions
 {
     [TestClass]
-    public class UT_NeoBuildFileNotFoundException
+    public class UT_NeoBuildInvalidECPointFormatException
     {
         [TestMethod]
         public void TestIsPropertiesSet()
         {
-            var expectedFilename = "/path/to/filename";
-            var expectedMessage = $"File '{expectedFilename}' was not found.";
+            var expectedMessage = "Invalid elliptic curve point format.";
 
-            var exception = new NeoBuildFileNotFoundException(expectedFilename);
+            var exception = new NeoBuildInvalidECPointFormatException();
             var exceptionInterface = exception as INeoBuildException;
             var exceptionBase = exception as Exception;
 
-            // NeoBuildFileNotFoundException
-            Assert.AreEqual(NeoBuildErrorCodes.General.FileNotFound, exception.ExitCode);
+            // NeoBuildInvalidECPointFormatException
+            Assert.AreEqual(NeoBuildErrorCodes.General.InvalidECPointFormat, exception.ExitCode);
             Assert.AreEqual(exception.ExitCode, exception.HResult);
             Assert.AreEqual($"{NeoBuildErrorCodes.StringPrefix}{(uint)exception.ExitCode:d04}", exception.ErrorCode);
             Assert.AreEqual($"Error {exception.ErrorCode} {expectedMessage}", exception.Message);
             Assert.AreEqual(exception.Message, $"{exception}");
-            Assert.AreEqual(expectedFilename, $"{exception.FileInfo}");
 
             // INeoBuildException
-            Assert.AreEqual(NeoBuildErrorCodes.General.FileNotFound, exceptionInterface.ExitCode);
+            Assert.AreEqual(NeoBuildErrorCodes.General.InvalidECPointFormat, exceptionInterface.ExitCode);
             Assert.AreEqual($"{NeoBuildErrorCodes.StringPrefix}{(uint)exceptionInterface.ExitCode:d04}", exceptionInterface.ErrorCode);
             Assert.AreEqual($"Error {exceptionInterface.ErrorCode} {expectedMessage}", exceptionInterface.Message);
 
             // System.Exception
-            Assert.AreEqual(NeoBuildErrorCodes.General.FileNotFound, exceptionBase.HResult);
+            Assert.AreEqual(NeoBuildErrorCodes.General.InvalidECPointFormat, exceptionBase.HResult);
             Assert.AreEqual($"Error {NeoBuildErrorCodes.StringPrefix}{(uint)exceptionBase.HResult} {expectedMessage}", exceptionBase.Message);
             Assert.AreEqual(exception.Message, $"{exceptionBase}");
         }

--- a/tests/Neo.Build.Core.Tests/Exceptions/UT_NeoBuildInvalidEncodingFormatException.cs
+++ b/tests/Neo.Build.Core.Tests/Exceptions/UT_NeoBuildInvalidEncodingFormatException.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2025 The Neo Project.
 //
-// UT_NeoBuildFileNotFoundException.cs file belongs to the neo project and is free
+// UT_NeoBuildInvalidEncodingFormatException.cs file belongs to the neo project and is free
 // software distributed under the MIT software license, see the
 // accompanying file LICENSE in the main directory of the
 // repository or http://www.opensource.org/licenses/mit-license.php
@@ -15,33 +15,31 @@ using System;
 namespace Neo.Build.Core.Tests.Exceptions
 {
     [TestClass]
-    public class UT_NeoBuildFileNotFoundException
+    public class UT_NeoBuildInvalidEncodingFormatException
     {
         [TestMethod]
         public void TestIsPropertiesSet()
         {
-            var expectedFilename = "/path/to/filename";
-            var expectedMessage = $"File '{expectedFilename}' was not found.";
+            var expectedMessage = "Invalid encoding format.";
 
-            var exception = new NeoBuildFileNotFoundException(expectedFilename);
+            var exception = new NeoBuildInvalidEncodingFormatException();
             var exceptionInterface = exception as INeoBuildException;
             var exceptionBase = exception as Exception;
 
-            // NeoBuildFileNotFoundException
-            Assert.AreEqual(NeoBuildErrorCodes.General.FileNotFound, exception.ExitCode);
+            // NeoBuildInvalidEncodingFormatException
+            Assert.AreEqual(NeoBuildErrorCodes.General.InvalidEncodingFormat, exception.ExitCode);
             Assert.AreEqual(exception.ExitCode, exception.HResult);
             Assert.AreEqual($"{NeoBuildErrorCodes.StringPrefix}{(uint)exception.ExitCode:d04}", exception.ErrorCode);
             Assert.AreEqual($"Error {exception.ErrorCode} {expectedMessage}", exception.Message);
             Assert.AreEqual(exception.Message, $"{exception}");
-            Assert.AreEqual(expectedFilename, $"{exception.FileInfo}");
 
             // INeoBuildException
-            Assert.AreEqual(NeoBuildErrorCodes.General.FileNotFound, exceptionInterface.ExitCode);
+            Assert.AreEqual(NeoBuildErrorCodes.General.InvalidEncodingFormat, exceptionInterface.ExitCode);
             Assert.AreEqual($"{NeoBuildErrorCodes.StringPrefix}{(uint)exceptionInterface.ExitCode:d04}", exceptionInterface.ErrorCode);
             Assert.AreEqual($"Error {exceptionInterface.ErrorCode} {expectedMessage}", exceptionInterface.Message);
 
             // System.Exception
-            Assert.AreEqual(NeoBuildErrorCodes.General.FileNotFound, exceptionBase.HResult);
+            Assert.AreEqual(NeoBuildErrorCodes.General.InvalidEncodingFormat, exceptionBase.HResult);
             Assert.AreEqual($"Error {NeoBuildErrorCodes.StringPrefix}{(uint)exceptionBase.HResult} {expectedMessage}", exceptionBase.Message);
             Assert.AreEqual(exception.Message, $"{exceptionBase}");
         }

--- a/tests/Neo.Build.Core.Tests/Exceptions/UT_NeoBuildInvalidFileFormatException.cs
+++ b/tests/Neo.Build.Core.Tests/Exceptions/UT_NeoBuildInvalidFileFormatException.cs
@@ -33,7 +33,7 @@ namespace Neo.Build.Core.Tests.Exceptions
             Assert.AreEqual($"{NeoBuildErrorCodes.StringPrefix}{(uint)exception.ExitCode:d04}", exception.ErrorCode);
             Assert.AreEqual($"Error {exception.ErrorCode} {expectedMessage}", exception.Message);
             Assert.AreEqual(exception.Message, $"{exception}");
-            Assert.AreEqual(expectedFilename, exception.Filename);
+            Assert.AreEqual(expectedFilename, $"{exception.FileInfo}");
 
             // INeoBuildException
             Assert.AreEqual(NeoBuildErrorCodes.General.InvalidFileFormat, exceptionInterface.ExitCode);

--- a/tests/Neo.Build.Core.Tests/Exceptions/UT_NeoBuildInvalidHash256FormatException.cs
+++ b/tests/Neo.Build.Core.Tests/Exceptions/UT_NeoBuildInvalidHash256FormatException.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2025 The Neo Project.
 //
-// UT_NeoBuildFileNotFoundException.cs file belongs to the neo project and is free
+// UT_NeoBuildInvalidHash256FormatException.cs file belongs to the neo project and is free
 // software distributed under the MIT software license, see the
 // accompanying file LICENSE in the main directory of the
 // repository or http://www.opensource.org/licenses/mit-license.php
@@ -15,33 +15,31 @@ using System;
 namespace Neo.Build.Core.Tests.Exceptions
 {
     [TestClass]
-    public class UT_NeoBuildFileNotFoundException
+    public class UT_NeoBuildInvalidHash256FormatException
     {
         [TestMethod]
         public void TestIsPropertiesSet()
         {
-            var expectedFilename = "/path/to/filename";
-            var expectedMessage = $"File '{expectedFilename}' was not found.";
+            var expectedMessage = "Invalid Hash256 format.";
 
-            var exception = new NeoBuildFileNotFoundException(expectedFilename);
+            var exception = new NeoBuildInvalidHash256FormatException();
             var exceptionInterface = exception as INeoBuildException;
             var exceptionBase = exception as Exception;
 
-            // NeoBuildFileNotFoundException
-            Assert.AreEqual(NeoBuildErrorCodes.General.FileNotFound, exception.ExitCode);
+            // NeoBuildInvalidHash256FormatException
+            Assert.AreEqual(NeoBuildErrorCodes.General.InvalidHash256Format, exception.ExitCode);
             Assert.AreEqual(exception.ExitCode, exception.HResult);
             Assert.AreEqual($"{NeoBuildErrorCodes.StringPrefix}{(uint)exception.ExitCode:d04}", exception.ErrorCode);
             Assert.AreEqual($"Error {exception.ErrorCode} {expectedMessage}", exception.Message);
             Assert.AreEqual(exception.Message, $"{exception}");
-            Assert.AreEqual(expectedFilename, $"{exception.FileInfo}");
 
             // INeoBuildException
-            Assert.AreEqual(NeoBuildErrorCodes.General.FileNotFound, exceptionInterface.ExitCode);
+            Assert.AreEqual(NeoBuildErrorCodes.General.InvalidHash256Format, exceptionInterface.ExitCode);
             Assert.AreEqual($"{NeoBuildErrorCodes.StringPrefix}{(uint)exceptionInterface.ExitCode:d04}", exceptionInterface.ErrorCode);
             Assert.AreEqual($"Error {exceptionInterface.ErrorCode} {expectedMessage}", exceptionInterface.Message);
 
             // System.Exception
-            Assert.AreEqual(NeoBuildErrorCodes.General.FileNotFound, exceptionBase.HResult);
+            Assert.AreEqual(NeoBuildErrorCodes.General.InvalidHash256Format, exceptionBase.HResult);
             Assert.AreEqual($"Error {NeoBuildErrorCodes.StringPrefix}{(uint)exceptionBase.HResult} {expectedMessage}", exceptionBase.Message);
             Assert.AreEqual(exception.Message, $"{exceptionBase}");
         }

--- a/tests/Neo.Build.Core.Tests/Exceptions/UT_NeoBuildInvalidHexFormatException.cs
+++ b/tests/Neo.Build.Core.Tests/Exceptions/UT_NeoBuildInvalidHexFormatException.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2025 The Neo Project.
 //
-// UT_NeoBuildFileNotFoundException.cs file belongs to the neo project and is free
+// UT_NeoBuildInvalidHexFormatException.cs file belongs to the neo project and is free
 // software distributed under the MIT software license, see the
 // accompanying file LICENSE in the main directory of the
 // repository or http://www.opensource.org/licenses/mit-license.php
@@ -15,33 +15,31 @@ using System;
 namespace Neo.Build.Core.Tests.Exceptions
 {
     [TestClass]
-    public class UT_NeoBuildFileNotFoundException
+    public class UT_NeoBuildInvalidHexFormatException
     {
         [TestMethod]
         public void TestIsPropertiesSet()
         {
-            var expectedFilename = "/path/to/filename";
-            var expectedMessage = $"File '{expectedFilename}' was not found.";
+            var expectedMessage = "Invalid hex string format.";
 
-            var exception = new NeoBuildFileNotFoundException(expectedFilename);
+            var exception = new NeoBuildInvalidHexFormatException();
             var exceptionInterface = exception as INeoBuildException;
             var exceptionBase = exception as Exception;
 
-            // NeoBuildFileNotFoundException
-            Assert.AreEqual(NeoBuildErrorCodes.General.FileNotFound, exception.ExitCode);
+            // NeoBuildInvalidHexFormatException
+            Assert.AreEqual(NeoBuildErrorCodes.General.InvalidHexFormat, exception.ExitCode);
             Assert.AreEqual(exception.ExitCode, exception.HResult);
             Assert.AreEqual($"{NeoBuildErrorCodes.StringPrefix}{(uint)exception.ExitCode:d04}", exception.ErrorCode);
             Assert.AreEqual($"Error {exception.ErrorCode} {expectedMessage}", exception.Message);
             Assert.AreEqual(exception.Message, $"{exception}");
-            Assert.AreEqual(expectedFilename, $"{exception.FileInfo}");
 
             // INeoBuildException
-            Assert.AreEqual(NeoBuildErrorCodes.General.FileNotFound, exceptionInterface.ExitCode);
+            Assert.AreEqual(NeoBuildErrorCodes.General.InvalidHexFormat, exceptionInterface.ExitCode);
             Assert.AreEqual($"{NeoBuildErrorCodes.StringPrefix}{(uint)exceptionInterface.ExitCode:d04}", exceptionInterface.ErrorCode);
             Assert.AreEqual($"Error {exceptionInterface.ErrorCode} {expectedMessage}", exceptionInterface.Message);
 
             // System.Exception
-            Assert.AreEqual(NeoBuildErrorCodes.General.FileNotFound, exceptionBase.HResult);
+            Assert.AreEqual(NeoBuildErrorCodes.General.InvalidHexFormat, exceptionBase.HResult);
             Assert.AreEqual($"Error {NeoBuildErrorCodes.StringPrefix}{(uint)exceptionBase.HResult} {expectedMessage}", exceptionBase.Message);
             Assert.AreEqual(exception.Message, $"{exceptionBase}");
         }

--- a/tests/Neo.Build.Core.Tests/Exceptions/UT_NeoBuildInvalidJsonFormatException.cs
+++ b/tests/Neo.Build.Core.Tests/Exceptions/UT_NeoBuildInvalidJsonFormatException.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2025 The Neo Project.
 //
-// UT_NeoBuildFileNotFoundException.cs file belongs to the neo project and is free
+// UT_NeoBuildInvalidJsonFormatException.cs file belongs to the neo project and is free
 // software distributed under the MIT software license, see the
 // accompanying file LICENSE in the main directory of the
 // repository or http://www.opensource.org/licenses/mit-license.php
@@ -11,37 +11,41 @@
 
 using Neo.Build.Core.Exceptions;
 using System;
+using System.Text.Json;
 
 namespace Neo.Build.Core.Tests.Exceptions
 {
     [TestClass]
-    public class UT_NeoBuildFileNotFoundException
+    public class UT_NeoBuildInvalidJsonFormatException
     {
         [TestMethod]
         public void TestIsPropertiesSet()
         {
-            var expectedFilename = "/path/to/filename";
-            var expectedMessage = $"File '{expectedFilename}' was not found.";
+            var expectedPath = "json/path/to/path/";
+            var expectedMessage = $"Invalid JSON format.";
+            var expectedException = new JsonException(expectedMessage, expectedPath, 0, 0);
 
-            var exception = new NeoBuildFileNotFoundException(expectedFilename);
+            var exception = new NeoBuildInvalidJsonFormatException(expectedException);
             var exceptionInterface = exception as INeoBuildException;
             var exceptionBase = exception as Exception;
 
-            // NeoBuildFileNotFoundException
-            Assert.AreEqual(NeoBuildErrorCodes.General.FileNotFound, exception.ExitCode);
+            // NeoBuildInvalidJsonFormatException
+            Assert.AreEqual(NeoBuildErrorCodes.General.InvalidJsonFormat, exception.ExitCode);
             Assert.AreEqual(exception.ExitCode, exception.HResult);
             Assert.AreEqual($"{NeoBuildErrorCodes.StringPrefix}{(uint)exception.ExitCode:d04}", exception.ErrorCode);
             Assert.AreEqual($"Error {exception.ErrorCode} {expectedMessage}", exception.Message);
             Assert.AreEqual(exception.Message, $"{exception}");
-            Assert.AreEqual(expectedFilename, $"{exception.FileInfo}");
+            Assert.AreEqual(0, exception.BytePositionInLine);
+            Assert.AreEqual(0, exception.LineNumber);
+            Assert.AreEqual(expectedPath, exception.Path);
 
             // INeoBuildException
-            Assert.AreEqual(NeoBuildErrorCodes.General.FileNotFound, exceptionInterface.ExitCode);
+            Assert.AreEqual(NeoBuildErrorCodes.General.InvalidJsonFormat, exceptionInterface.ExitCode);
             Assert.AreEqual($"{NeoBuildErrorCodes.StringPrefix}{(uint)exceptionInterface.ExitCode:d04}", exceptionInterface.ErrorCode);
             Assert.AreEqual($"Error {exceptionInterface.ErrorCode} {expectedMessage}", exceptionInterface.Message);
 
             // System.Exception
-            Assert.AreEqual(NeoBuildErrorCodes.General.FileNotFound, exceptionBase.HResult);
+            Assert.AreEqual(NeoBuildErrorCodes.General.InvalidJsonFormat, exceptionBase.HResult);
             Assert.AreEqual($"Error {NeoBuildErrorCodes.StringPrefix}{(uint)exceptionBase.HResult} {expectedMessage}", exceptionBase.Message);
             Assert.AreEqual(exception.Message, $"{exceptionBase}");
         }

--- a/tests/Neo.Build.Core.Tests/Exceptions/UT_NeoBuildInvalidNumberFormatException.cs
+++ b/tests/Neo.Build.Core.Tests/Exceptions/UT_NeoBuildInvalidNumberFormatException.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2025 The Neo Project.
 //
-// UT_NeoBuildFileNotFoundException.cs file belongs to the neo project and is free
+// UT_NeoBuildInvalidNumberFormatException.cs file belongs to the neo project and is free
 // software distributed under the MIT software license, see the
 // accompanying file LICENSE in the main directory of the
 // repository or http://www.opensource.org/licenses/mit-license.php
@@ -15,33 +15,31 @@ using System;
 namespace Neo.Build.Core.Tests.Exceptions
 {
     [TestClass]
-    public class UT_NeoBuildFileNotFoundException
+    public class UT_NeoBuildInvalidNumberFormatException
     {
         [TestMethod]
         public void TestIsPropertiesSet()
         {
-            var expectedFilename = "/path/to/filename";
-            var expectedMessage = $"File '{expectedFilename}' was not found.";
+            var expectedMessage = "Invalid number format.";
 
-            var exception = new NeoBuildFileNotFoundException(expectedFilename);
+            var exception = new NeoBuildInvalidNumberFormatException();
             var exceptionInterface = exception as INeoBuildException;
             var exceptionBase = exception as Exception;
 
-            // NeoBuildFileNotFoundException
-            Assert.AreEqual(NeoBuildErrorCodes.General.FileNotFound, exception.ExitCode);
+            // NeoBuildInvalidNumberFormatException
+            Assert.AreEqual(NeoBuildErrorCodes.General.InvalidNumberFormat, exception.ExitCode);
             Assert.AreEqual(exception.ExitCode, exception.HResult);
             Assert.AreEqual($"{NeoBuildErrorCodes.StringPrefix}{(uint)exception.ExitCode:d04}", exception.ErrorCode);
             Assert.AreEqual($"Error {exception.ErrorCode} {expectedMessage}", exception.Message);
             Assert.AreEqual(exception.Message, $"{exception}");
-            Assert.AreEqual(expectedFilename, $"{exception.FileInfo}");
 
             // INeoBuildException
-            Assert.AreEqual(NeoBuildErrorCodes.General.FileNotFound, exceptionInterface.ExitCode);
+            Assert.AreEqual(NeoBuildErrorCodes.General.InvalidNumberFormat, exceptionInterface.ExitCode);
             Assert.AreEqual($"{NeoBuildErrorCodes.StringPrefix}{(uint)exceptionInterface.ExitCode:d04}", exceptionInterface.ErrorCode);
             Assert.AreEqual($"Error {exceptionInterface.ErrorCode} {expectedMessage}", exceptionInterface.Message);
 
             // System.Exception
-            Assert.AreEqual(NeoBuildErrorCodes.General.FileNotFound, exceptionBase.HResult);
+            Assert.AreEqual(NeoBuildErrorCodes.General.InvalidNumberFormat, exceptionBase.HResult);
             Assert.AreEqual($"Error {NeoBuildErrorCodes.StringPrefix}{(uint)exceptionBase.HResult} {expectedMessage}", exceptionBase.Message);
             Assert.AreEqual(exception.Message, $"{exceptionBase}");
         }

--- a/tests/Neo.Build.Core.Tests/Exceptions/UT_NeoBuildInvalidScriptHashFormatException.cs
+++ b/tests/Neo.Build.Core.Tests/Exceptions/UT_NeoBuildInvalidScriptHashFormatException.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2025 The Neo Project.
 //
-// UT_NeoBuildFileNotFoundException.cs file belongs to the neo project and is free
+// UT_NeoBuildInvalidScriptHashFormatException.cs file belongs to the neo project and is free
 // software distributed under the MIT software license, see the
 // accompanying file LICENSE in the main directory of the
 // repository or http://www.opensource.org/licenses/mit-license.php
@@ -15,33 +15,31 @@ using System;
 namespace Neo.Build.Core.Tests.Exceptions
 {
     [TestClass]
-    public class UT_NeoBuildFileNotFoundException
+    public class UT_NeoBuildInvalidScriptHashFormatException
     {
         [TestMethod]
         public void TestIsPropertiesSet()
         {
-            var expectedFilename = "/path/to/filename";
-            var expectedMessage = $"File '{expectedFilename}' was not found.";
+            var expectedMessage = "Invalid scriptHash format.";
 
-            var exception = new NeoBuildFileNotFoundException(expectedFilename);
+            var exception = new NeoBuildInvalidScriptHashFormatException();
             var exceptionInterface = exception as INeoBuildException;
             var exceptionBase = exception as Exception;
 
-            // NeoBuildFileNotFoundException
-            Assert.AreEqual(NeoBuildErrorCodes.General.FileNotFound, exception.ExitCode);
+            // NeoBuildInvalidScriptHashFormatException
+            Assert.AreEqual(NeoBuildErrorCodes.General.InvalidScriptHashFormat, exception.ExitCode);
             Assert.AreEqual(exception.ExitCode, exception.HResult);
             Assert.AreEqual($"{NeoBuildErrorCodes.StringPrefix}{(uint)exception.ExitCode:d04}", exception.ErrorCode);
             Assert.AreEqual($"Error {exception.ErrorCode} {expectedMessage}", exception.Message);
             Assert.AreEqual(exception.Message, $"{exception}");
-            Assert.AreEqual(expectedFilename, $"{exception.FileInfo}");
 
             // INeoBuildException
-            Assert.AreEqual(NeoBuildErrorCodes.General.FileNotFound, exceptionInterface.ExitCode);
+            Assert.AreEqual(NeoBuildErrorCodes.General.InvalidScriptHashFormat, exceptionInterface.ExitCode);
             Assert.AreEqual($"{NeoBuildErrorCodes.StringPrefix}{(uint)exceptionInterface.ExitCode:d04}", exceptionInterface.ErrorCode);
             Assert.AreEqual($"Error {exceptionInterface.ErrorCode} {expectedMessage}", exceptionInterface.Message);
 
             // System.Exception
-            Assert.AreEqual(NeoBuildErrorCodes.General.FileNotFound, exceptionBase.HResult);
+            Assert.AreEqual(NeoBuildErrorCodes.General.InvalidScriptHashFormat, exceptionBase.HResult);
             Assert.AreEqual($"Error {NeoBuildErrorCodes.StringPrefix}{(uint)exceptionBase.HResult} {expectedMessage}", exceptionBase.Message);
             Assert.AreEqual(exception.Message, $"{exceptionBase}");
         }

--- a/tests/Neo.Build.Core.Tests/Exceptions/UT_NeoBuildInvalidVersionFormatException.cs
+++ b/tests/Neo.Build.Core.Tests/Exceptions/UT_NeoBuildInvalidVersionFormatException.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2025 The Neo Project.
 //
-// UT_NeoBuildFileNotFoundException.cs file belongs to the neo project and is free
+// UT_NeoBuildInvalidVersionFormatException.cs file belongs to the neo project and is free
 // software distributed under the MIT software license, see the
 // accompanying file LICENSE in the main directory of the
 // repository or http://www.opensource.org/licenses/mit-license.php
@@ -15,33 +15,31 @@ using System;
 namespace Neo.Build.Core.Tests.Exceptions
 {
     [TestClass]
-    public class UT_NeoBuildFileNotFoundException
+    public class UT_NeoBuildInvalidVersionFormatException
     {
         [TestMethod]
         public void TestIsPropertiesSet()
         {
-            var expectedFilename = "/path/to/filename";
-            var expectedMessage = $"File '{expectedFilename}' was not found.";
+            var expectedMessage = "Invalid version format.";
 
-            var exception = new NeoBuildFileNotFoundException(expectedFilename);
+            var exception = new NeoBuildInvalidVersionFormatException();
             var exceptionInterface = exception as INeoBuildException;
             var exceptionBase = exception as Exception;
 
-            // NeoBuildFileNotFoundException
-            Assert.AreEqual(NeoBuildErrorCodes.General.FileNotFound, exception.ExitCode);
+            // NeoBuildInvalidVersionFormatException
+            Assert.AreEqual(NeoBuildErrorCodes.General.InvalidVersionFormat, exception.ExitCode);
             Assert.AreEqual(exception.ExitCode, exception.HResult);
             Assert.AreEqual($"{NeoBuildErrorCodes.StringPrefix}{(uint)exception.ExitCode:d04}", exception.ErrorCode);
             Assert.AreEqual($"Error {exception.ErrorCode} {expectedMessage}", exception.Message);
             Assert.AreEqual(exception.Message, $"{exception}");
-            Assert.AreEqual(expectedFilename, $"{exception.FileInfo}");
 
             // INeoBuildException
-            Assert.AreEqual(NeoBuildErrorCodes.General.FileNotFound, exceptionInterface.ExitCode);
+            Assert.AreEqual(NeoBuildErrorCodes.General.InvalidVersionFormat, exceptionInterface.ExitCode);
             Assert.AreEqual($"{NeoBuildErrorCodes.StringPrefix}{(uint)exceptionInterface.ExitCode:d04}", exceptionInterface.ErrorCode);
             Assert.AreEqual($"Error {exceptionInterface.ErrorCode} {expectedMessage}", exceptionInterface.Message);
 
             // System.Exception
-            Assert.AreEqual(NeoBuildErrorCodes.General.FileNotFound, exceptionBase.HResult);
+            Assert.AreEqual(NeoBuildErrorCodes.General.InvalidVersionFormat, exceptionBase.HResult);
             Assert.AreEqual($"Error {NeoBuildErrorCodes.StringPrefix}{(uint)exceptionBase.HResult} {expectedMessage}", exceptionBase.Message);
             Assert.AreEqual(exception.Message, $"{exceptionBase}");
         }

--- a/tests/Neo.Build.Core.Tests/Exceptions/UT_NeoBuildPathNotFoundException.cs
+++ b/tests/Neo.Build.Core.Tests/Exceptions/UT_NeoBuildPathNotFoundException.cs
@@ -33,7 +33,7 @@ namespace Neo.Build.Core.Tests.Exceptions
             Assert.AreEqual($"{NeoBuildErrorCodes.StringPrefix}{(uint)exception.ExitCode:d04}", exception.ErrorCode);
             Assert.AreEqual($"Error {exception.ErrorCode} {expectedMessage}", exception.Message);
             Assert.AreEqual(exception.Message, $"{exception}");
-            Assert.AreEqual(expectedPath, exception.Path);
+            Assert.AreEqual(expectedPath, $"{exception.PathInfo}");
 
             // INeoBuildException
             Assert.AreEqual(NeoBuildErrorCodes.General.PathNotFound, exceptionInterface.ExitCode);

--- a/tests/Neo.Build.Core.Tests/Neo.Build.Core.Tests.csproj
+++ b/tests/Neo.Build.Core.Tests/Neo.Build.Core.Tests.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <OutputType>Exe</OutputType>
     <TargetFramework>net9.0</TargetFramework>
+    <EnableMSTestRunner>true</EnableMSTestRunner>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.7.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.7.3" />
+    <PackageReference Include="MSTest" Version="3.7.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
# Change Log

- Added all the exception from error codes in `NeoBuildErrorCodes.General`.
- Changed `filename` types to use `FileInfo` instead of `string`.
- Changed `Path` types to use `DirectoryInfo` instead of `string`.

# Blocks
- #3771 
- #3772 

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
- [x] Unit Testing

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
