### PR TITLE
Transaction: ensure standard witness scripts are properly verified

### DIFF
--- a/src/Neo/Network/P2P/Payloads/Transaction.cs
+++ b/src/Neo/Network/P2P/Payloads/Transaction.cs
@@ -426,7 +426,7 @@ namespace Neo.Network.P2P.Payloads
             UInt160[] hashes = GetScriptHashesForVerifying(null);
             for (int i = 0; i < hashes.Length; i++)
             {
-                if (IsSignatureContract(witnesses[i].VerificationScript.Span) && IsSingleSignatureInvocationScript(witnesses[i].InvocationScript, out ReadOnlyMemory<byte> signature))
+                if (IsSignatureContract(witnesses[i].VerificationScript.Span) && IsSingleSignatureInvocationScript(witnesses[i].InvocationScript, out var signature))
                 {
                     if (hashes[i] != witnesses[i].ScriptHash) return VerifyResult.Invalid;
                     var pubkey = witnesses[i].VerificationScript.Span[2..35];
@@ -440,7 +440,7 @@ namespace Neo.Network.P2P.Payloads
                         return VerifyResult.Invalid;
                     }
                 }
-                else if (IsMultiSigContract(witnesses[i].VerificationScript.Span, out var m, out ECPoint[] points) && IsMultiSignatureInvocationScript(m, witnesses[i].InvocationScript, out ReadOnlyMemory<byte>[] signatures))
+                else if (IsMultiSigContract(witnesses[i].VerificationScript.Span, out var m, out ECPoint[] points) && IsMultiSignatureInvocationScript(m, witnesses[i].InvocationScript, out var signatures))
                 {
                     if (hashes[i] != witnesses[i].ScriptHash) return VerifyResult.Invalid;
                     var n = points.Length;

--- a/src/Neo/Network/P2P/Payloads/Transaction.cs
+++ b/src/Neo/Network/P2P/Payloads/Transaction.cs
@@ -441,7 +441,7 @@ namespace Neo.Network.P2P.Payloads
                         return VerifyResult.Invalid;
                     }
                 }
-                else if (IsMultiSigContract(witness.VerificationScript.Span, out var m, out var points) && IsMultiSignatureInvocationScript(m, witness.InvocationScript, out var signatures))
+                else if (IsMultiSigContract(witness.VerificationScript.Span, out var m, out ECPoint[] points) && IsMultiSignatureInvocationScript(m, witness.InvocationScript, out var signatures))
                 {
                     if (hashes[i] != witness.ScriptHash) return VerifyResult.Invalid;
                     var n = points.Length;

--- a/src/Neo/Network/P2P/Payloads/Transaction.cs
+++ b/src/Neo/Network/P2P/Payloads/Transaction.cs
@@ -426,10 +426,11 @@ namespace Neo.Network.P2P.Payloads
             UInt160[] hashes = GetScriptHashesForVerifying(null);
             for (int i = 0; i < hashes.Length; i++)
             {
-                if (IsSignatureContract(witnesses[i].VerificationScript.Span) && IsSingleSignatureInvocationScript(witnesses[i].InvocationScript, out var signature))
+                var witness = witnesses[i];
+                if (IsSignatureContract(witness.VerificationScript.Span) && IsSingleSignatureInvocationScript(witness.InvocationScript, out var signature))
                 {
-                    if (hashes[i] != witnesses[i].ScriptHash) return VerifyResult.Invalid;
-                    var pubkey = witnesses[i].VerificationScript.Span[2..35];
+                    if (hashes[i] != witness.ScriptHash) return VerifyResult.Invalid;
+                    var pubkey = witness.VerificationScript.Span[2..35];
                     try
                     {
                         if (!Crypto.VerifySignature(this.GetSignData(settings.Network), signature.Span, pubkey, ECCurve.Secp256r1))
@@ -440,9 +441,9 @@ namespace Neo.Network.P2P.Payloads
                         return VerifyResult.Invalid;
                     }
                 }
-                else if (IsMultiSigContract(witnesses[i].VerificationScript.Span, out var m, out ECPoint[] points) && IsMultiSignatureInvocationScript(m, witnesses[i].InvocationScript, out var signatures))
+                else if (IsMultiSigContract(witness.VerificationScript.Span, out var m, out var points) && IsMultiSignatureInvocationScript(m, witness.InvocationScript, out var signatures))
                 {
-                    if (hashes[i] != witnesses[i].ScriptHash) return VerifyResult.Invalid;
+                    if (hashes[i] != witness.ScriptHash) return VerifyResult.Invalid;
                     var n = points.Length;
                     var message = this.GetSignData(settings.Network);
                     try

--- a/src/Neo/Network/P2P/Payloads/Transaction.cs
+++ b/src/Neo/Network/P2P/Payloads/Transaction.cs
@@ -390,9 +390,9 @@ namespace Neo.Network.P2P.Payloads
             uint execFeeFactor = NativeContract.Policy.GetExecFeeFactor(snapshot);
             for (int i = 0; i < hashes.Length; i++)
             {
-                if (IsSignatureContract(witnesses[i].VerificationScript.Span))
+                if (IsSignatureContract(witnesses[i].VerificationScript.Span) && IsSingleSignatureInvocationScript(witnesses[i].InvocationScript, out var _))
                     netFeeDatoshi -= execFeeFactor * SignatureContractCost();
-                else if (IsMultiSigContract(witnesses[i].VerificationScript.Span, out int m, out int n))
+                else if (IsMultiSigContract(witnesses[i].VerificationScript.Span, out int m, out int n) && IsMultiSignatureInvocationScript(m, witnesses[i].InvocationScript, out var _))
                 {
                     netFeeDatoshi -= execFeeFactor * MultiSignatureContractCost(m, n);
                 }


### PR DESCRIPTION
Problem:

Invocation scripts of standard witnesses considered to be invalid if not following the `PUSHDATA1 signature` pattern. Consider the following example of transaction witness:

Invocation script:
`CDkMQMPzMFVACq4PjnjbH8wB5/3ajfp7JaGo9MLyo25OPNTNIeo2WsYWZZ6wjUvGSlzd8FjMMdu4WXHU2KoUMo9Fkkk=` which is:
```
NEO-GO-VM 0 > ops
INDEX    OPCODE       PARAMETER
0        PUSHT            <<
1        ASSERT
2        PUSHDATA1    c3f33055400aae0f8e78db1fcc01e7fdda8dfa7b25a1a8f4c2f2a36e4e3cd4cd21ea365ac616659eb08d4bc64a5cddf058cc31dbb85971d4d8aa14328f459249
```

Verification script:
`DCEDzfbXTXxymUH2d9SQNI8aYHgF4wZ2xi6MTYCqM7cw+dBBVuezJw==` which is:
```
NEO-GO-VM 0 > ops
INDEX    OPCODE       PARAMETER
0        PUSHDATA1    03cdf6d74d7c729941f677d490348f1a607805e30676c62e8c4d80aa33b730f9d0    <<
35       SYSCALL      System.Crypto.CheckSig (56e7b327)
```

As you can see, verification script has the form of standard signature contract, and invocation script is just some side VM script that should be properly executed to check transaction's witness (it differs from standard invocation script in that it has `PUSHT` and `ASSERT` in the start of the script). The problem is that VerifyStateIndependent treats this invocation script as invalid and aborts transaction witness verification.

Solution:
Check if Invocation witness script matches the expected standard SignatureContract or MultiSigContract witness. If not, then do not consider this witness as "standard".

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [X] Test_VerifyStateIndependent

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
