### PR TITLE
[Fix] `ECPoint.GetHashCode`

### DIFF
--- a/src/Neo/Cryptography/ECC/ECCurve.cs
+++ b/src/Neo/Cryptography/ECC/ECCurve.cs
@@ -11,6 +11,7 @@
 
 using Neo.Extensions;
 using Org.BouncyCastle.Crypto.Parameters;
+using System;
 using System.Globalization;
 using System.Numerics;
 
@@ -40,6 +41,7 @@ namespace Neo.Cryptography.ECC
         /// </summary>
         public readonly ECDomainParameters BouncyCastleDomainParams;
         internal readonly int ExpectedECPointLength;
+        private readonly int _hashCode;
 
         private ECCurve(BigInteger Q, BigInteger A, BigInteger B, BigInteger N, byte[] G, string curveName)
         {
@@ -52,6 +54,7 @@ namespace Neo.Cryptography.ECC
             this.G = ECPoint.DecodePoint(G, this);
             BouncyCastleCurve = Org.BouncyCastle.Asn1.Sec.SecNamedCurves.GetByName(curveName);
             BouncyCastleDomainParams = new ECDomainParameters(BouncyCastleCurve.Curve, BouncyCastleCurve.G, BouncyCastleCurve.N, BouncyCastleCurve.H);
+            _hashCode = HashCode.Combine(Q.GetHashCode(), A.GetHashCode(), B.GetHashCode(), N.GetHashCode(), curveName, G.Murmur32((uint)G.Length));
         }
 
         /// <summary>
@@ -79,5 +82,10 @@ namespace Neo.Cryptography.ECC
             ("04" + "6B17D1F2E12C4247F8BCE6E563A440F277037D812DEB33A0F4A13945D898C296" + "4FE342E2FE1A7F9B8EE7EB4A7C0F9E162BCE33576B315ECECBB6406837BF51F5").HexToBytes(),
             "secp256r1"
         );
+
+        public override int GetHashCode()
+        {
+            return _hashCode;
+        }
     }
 }

--- a/src/Neo/Cryptography/ECC/ECCurve.cs
+++ b/src/Neo/Cryptography/ECC/ECCurve.cs
@@ -54,7 +54,7 @@ namespace Neo.Cryptography.ECC
             this.G = ECPoint.DecodePoint(G, this);
             BouncyCastleCurve = Org.BouncyCastle.Asn1.Sec.SecNamedCurves.GetByName(curveName);
             BouncyCastleDomainParams = new ECDomainParameters(BouncyCastleCurve.Curve, BouncyCastleCurve.G, BouncyCastleCurve.N, BouncyCastleCurve.H);
-            _hashCode = HashCode.Combine(Q.GetHashCode(), A.GetHashCode(), B.GetHashCode(), N.GetHashCode(), curveName, G.Murmur32((uint)G.Length));
+            _hashCode = HashCode.Combine(Q.GetHashCode(), A.GetHashCode(), B.GetHashCode(), N.GetHashCode(), G.Murmur32((uint)G.Length), curveName);
         }
 
         /// <summary>

--- a/src/Neo/Cryptography/ECC/ECFieldElement.cs
+++ b/src/Neo/Cryptography/ECC/ECFieldElement.cs
@@ -100,7 +100,7 @@ namespace Neo.Cryptography.ECC
 
         public override int GetHashCode()
         {
-            return Value.GetHashCode();
+            return HashCode.Combine(_curve.GetHashCode(), Value.GetHashCode());
         }
 
         public ECFieldElement? Sqrt()

--- a/src/Neo/Cryptography/ECC/ECFieldElement.cs
+++ b/src/Neo/Cryptography/ECC/ECFieldElement.cs
@@ -40,13 +40,7 @@ namespace Neo.Cryptography.ECC
 
         public override bool Equals(object? obj)
         {
-            if (obj == this)
-                return true;
-
-            if (obj is not ECFieldElement other)
-                return false;
-
-            return Equals(other);
+            return Equals(obj as ECFieldElement);
         }
 
         public bool Equals(ECFieldElement? other)

--- a/src/Neo/Cryptography/ECC/ECPoint.cs
+++ b/src/Neo/Cryptography/ECC/ECPoint.cs
@@ -228,7 +228,7 @@ namespace Neo.Cryptography.ECC
 
         public override int GetHashCode()
         {
-            return HashCode.Combine(X?.GetHashCode() ?? 0, Y?.GetHashCode() ?? 0);
+            return HashCode.Combine(Curve.GetHashCode(), X?.GetHashCode() ?? 0, Y?.GetHashCode() ?? 0);
         }
 
         internal static ECPoint Multiply(ECPoint p, BigInteger k)

--- a/src/Neo/Cryptography/ECC/ECPoint.cs
+++ b/src/Neo/Cryptography/ECC/ECPoint.cs
@@ -228,7 +228,7 @@ namespace Neo.Cryptography.ECC
 
         public override int GetHashCode()
         {
-            return (X?.GetHashCode() ?? 0) + (Y?.GetHashCode() ?? 0);
+            return HashCode.Combine(X?.GetHashCode() ?? 0, Y?.GetHashCode() ?? 0);
         }
 
         internal static ECPoint Multiply(ECPoint p, BigInteger k)

--- a/tests/Neo.UnitTests/Cryptography/ECC/UT_ECFieldElement.cs
+++ b/tests/Neo.UnitTests/Cryptography/ECC/UT_ECFieldElement.cs
@@ -42,6 +42,20 @@ namespace Neo.UnitTests.Cryptography.ECC
         }
 
         [TestMethod]
+        public void TestGetHashCode()
+        {
+            var pointA = new ECFieldElement(new BigInteger(100), ECCurve.Secp256k1);
+            var pointB = new ECFieldElement(new BigInteger(100), ECCurve.Secp256k1);
+            var pointC = new ECFieldElement(new BigInteger(100), ECCurve.Secp256r1); // different curve
+            var pointD = new ECFieldElement(new BigInteger(101), ECCurve.Secp256k1);
+
+            Assert.AreEqual(pointA.GetHashCode(), pointB.GetHashCode());
+            Assert.AreNotEqual(pointA.GetHashCode(), pointC.GetHashCode());
+            Assert.AreNotEqual(pointB.GetHashCode(), pointC.GetHashCode());
+            Assert.AreNotEqual(pointB.GetHashCode(), pointD.GetHashCode());
+        }
+
+        [TestMethod]
         public void TestCompareTo()
         {
             ECFieldElement X1 = new(new BigInteger(100), ECCurve.Secp256k1);

--- a/tests/Neo.UnitTests/Cryptography/ECC/UT_ECPoint.cs
+++ b/tests/Neo.UnitTests/Cryptography/ECC/UT_ECPoint.cs
@@ -192,6 +192,17 @@ namespace Neo.UnitTests.Cryptography.ECC
         }
 
         [TestMethod]
+        public void TestGetHashCode()
+        {
+            var pointA = new ECPoint(ECCurve.Secp256k1.G.X, ECCurve.Secp256k1.G.Y, ECCurve.Secp256k1);
+            var pointB = new ECPoint(ECCurve.Secp256k1.G.Y, ECCurve.Secp256k1.G.X, ECCurve.Secp256k1);
+            var pointC = new ECPoint(ECCurve.Secp256k1.G.Y, ECCurve.Secp256k1.G.X, ECCurve.Secp256k1);
+
+            Assert.AreNotEqual(pointA.GetHashCode(), pointB.GetHashCode());
+            Assert.AreEqual(pointB.GetHashCode(), pointC.GetHashCode());
+        }
+
+        [TestMethod]
         public void TestEqualsObject()
         {
             object point = ECCurve.Secp256k1.G;

--- a/tests/Neo.UnitTests/Cryptography/ECC/UT_ECPoint.cs
+++ b/tests/Neo.UnitTests/Cryptography/ECC/UT_ECPoint.cs
@@ -196,10 +196,13 @@ namespace Neo.UnitTests.Cryptography.ECC
         {
             var pointA = new ECPoint(ECCurve.Secp256k1.G.X, ECCurve.Secp256k1.G.Y, ECCurve.Secp256k1);
             var pointB = new ECPoint(ECCurve.Secp256k1.G.Y, ECCurve.Secp256k1.G.X, ECCurve.Secp256k1);
-            var pointC = new ECPoint(ECCurve.Secp256k1.G.Y, ECCurve.Secp256k1.G.X, ECCurve.Secp256k1);
+            var pointC = new ECPoint(ECCurve.Secp256k1.G.Y, ECCurve.Secp256k1.G.X, ECCurve.Secp256r1); // different curve
+            var pointD = new ECPoint(ECCurve.Secp256k1.G.Y, ECCurve.Secp256k1.G.X, ECCurve.Secp256k1);
 
             Assert.AreNotEqual(pointA.GetHashCode(), pointB.GetHashCode());
-            Assert.AreEqual(pointB.GetHashCode(), pointC.GetHashCode());
+            Assert.AreNotEqual(pointA.GetHashCode(), pointC.GetHashCode());
+            Assert.AreNotEqual(pointB.GetHashCode(), pointC.GetHashCode());
+            Assert.AreEqual(pointB.GetHashCode(), pointD.GetHashCode());
         }
 
         [TestMethod]


### PR DESCRIPTION
# Description

- x and y should not be added together.
- take into account that curve can be different.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] `TestGetHashCode`

**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
