### PR TITLE
Emit `ArchivalNode` capability

### DIFF
--- a/src/Neo.CLI/CLI/MainService.Network.cs
+++ b/src/Neo.CLI/CLI/MainService.Network.cs
@@ -15,7 +15,6 @@ using Neo.Extensions;
 using Neo.IO;
 using Neo.Json;
 using Neo.Network.P2P;
-using Neo.Network.P2P.Capabilities;
 using Neo.Network.P2P.Payloads;
 using Neo.SmartContract;
 using Neo.SmartContract.Native;
@@ -44,10 +43,8 @@ namespace Neo.CLI
                 AddrPayload.Create(
                     NetworkAddressWithTime.Create(
                         payload, DateTime.UtcNow.ToTimestamp(),
-                        new ArchivalNodeCapability(),
-                        new FullNodeCapability(),
-                        new ServerCapability(NodeCapabilityType.TcpServer, port))
-                    ));
+                        LocalNode.GetNodeCapabilities()
+                    )));
         }
 
         /// <summary>

--- a/src/Neo/Network/P2P/LocalNode.cs
+++ b/src/Neo/Network/P2P/LocalNode.cs
@@ -11,7 +11,9 @@
 
 using Akka.Actor;
 using Neo.IO;
+using Neo.Network.P2P.Capabilities;
 using Neo.Network.P2P.Payloads;
+using Neo.SmartContract.Native;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -261,6 +263,24 @@ namespace Neo.Network.P2P
             }
             else
                 SendToRemoteNodes(message);
+        }
+
+        public NodeCapability[] GetNodeCapabilities()
+        {
+            var capabilities = new List<NodeCapability>
+            {
+                new FullNodeCapability(NativeContract.Ledger.CurrentIndex(system.StoreView)),
+                new ArchivalNodeCapability()
+            };
+
+            if (!EnableCompression)
+            {
+                capabilities.Add(new DisableCompressionCapability());
+            }
+
+            if (ListenerTcpPort > 0) capabilities.Add(new ServerCapability(NodeCapabilityType.TcpServer, (ushort)ListenerTcpPort));
+
+            return [.. capabilities];
         }
 
         private void OnSendDirectly(IInventory inventory) => SendToRemoteNodes(inventory);

--- a/src/Neo/Network/P2P/RemoteNode.cs
+++ b/src/Neo/Network/P2P/RemoteNode.cs
@@ -16,9 +16,7 @@ using Neo.Cryptography;
 using Neo.IO;
 using Neo.IO.Actors;
 using Neo.IO.Caching;
-using Neo.Network.P2P.Capabilities;
 using Neo.Network.P2P.Payloads;
-using Neo.SmartContract.Native;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -203,19 +201,7 @@ namespace Neo.Network.P2P
 
         private void OnStartProtocol()
         {
-            var capabilities = new List<NodeCapability>
-            {
-                new FullNodeCapability(NativeContract.Ledger.CurrentIndex(system.StoreView))
-            };
-
-            if (!localNode.EnableCompression)
-            {
-                capabilities.Add(new DisableCompressionCapability());
-            }
-
-            if (localNode.ListenerTcpPort > 0) capabilities.Add(new ServerCapability(NodeCapabilityType.TcpServer, (ushort)localNode.ListenerTcpPort));
-
-            SendMessage(Message.Create(MessageCommand.Version, VersionPayload.Create(system.Settings.Network, LocalNode.Nonce, LocalNode.UserAgent, [.. capabilities])));
+            SendMessage(Message.Create(MessageCommand.Version, VersionPayload.Create(system.Settings.Network, LocalNode.Nonce, LocalNode.UserAgent, localNode.GetNodeCapabilities())));
         }
 
         protected override void PostStop()


### PR DESCRIPTION
# Description

We already have the `ArchivalNode` but we don't emit them, and currently we are always an archival node.
Fix https://github.com/neo-project/neo/issues/2346

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Test A
- [ ] Test B

**Test Configuration**:


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
