### PR TITLE
Improve `MemPool` event management

### DIFF
--- a/src/Neo/Ledger/MemoryPool.cs
+++ b/src/Neo/Ledger/MemoryPool.cs
@@ -634,11 +634,14 @@ namespace Neo.Ledger
                 _txRwLock.ExitWriteLock();
             }
 
-            TransactionRemoved?.Invoke(this, new()
+            if (invalidItems.Count > 0)
             {
-                Transactions = invalidItems.Select(p => p.Tx).ToArray(),
-                Reason = TransactionRemovalReason.NoLongerValid
-            });
+                TransactionRemoved?.Invoke(this, new()
+                {
+                    Transactions = invalidItems.Select(p => p.Tx).ToArray(),
+                    Reason = TransactionRemovalReason.NoLongerValid
+                });
+            }
 
             return reverifiedItems.Count;
         }

--- a/src/Neo/Ledger/MemoryPool.cs
+++ b/src/Neo/Ledger/MemoryPool.cs
@@ -336,7 +336,7 @@ namespace Neo.Ledger
             }
 
             TransactionAdded?.Invoke(this, poolItem.Tx);
-            if (removedTransactions.Count() > 0)
+            if (removedTransactions.Count > 0)
                 TransactionRemoved?.Invoke(this, new()
                 {
                     Transactions = removedTransactions,
@@ -527,11 +527,11 @@ namespace Neo.Ledger
             {
                 _txRwLock.ExitWriteLock();
             }
-            if (conflictingItems.Count() > 0)
+            if (conflictingItems.Count > 0)
             {
                 TransactionRemoved?.Invoke(this, new()
                 {
-                    Transactions = conflictingItems.ToArray(),
+                    Transactions = conflictingItems,
                     Reason = TransactionRemovalReason.Conflict,
                 });
             }
@@ -634,10 +634,9 @@ namespace Neo.Ledger
                 _txRwLock.ExitWriteLock();
             }
 
-            var invalidTransactions = invalidItems.Select(p => p.Tx).ToArray();
             TransactionRemoved?.Invoke(this, new()
             {
-                Transactions = invalidTransactions,
+                Transactions = invalidItems.Select(p => p.Tx).ToArray(),
                 Reason = TransactionRemovalReason.NoLongerValid
             });
 


### PR DESCRIPTION
# Description

- Avoid raise event when invalidItems is equal to 0.
- Avoid some ToArray because it's already a ReadOnlyCollection.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Current tests

**Test Configuration**:


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
