### PR TITLE
Revert "Change <TargetFrameworks> to <TargetFramework> for Plugin projects"

### DIFF
--- a/src/Plugins/ApplicationLogs/ApplicationLogs.csproj
+++ b/src/Plugins/ApplicationLogs/ApplicationLogs.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   

--- a/src/Plugins/DBFTPlugin/DBFTPlugin.csproj
+++ b/src/Plugins/DBFTPlugin/DBFTPlugin.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0</TargetFrameworks>
     <PackageId>Neo.Consensus.DBFT</PackageId>
     <RootNamespace>Neo.Consensus</RootNamespace>
   </PropertyGroup>

--- a/src/Plugins/LevelDBStore/LevelDBStore.csproj
+++ b/src/Plugins/LevelDBStore/LevelDBStore.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk" InitialTargets="DownloadNativeLibs">
+﻿<Project Sdk="Microsoft.NET.Sdk" InitialTargets="DownloadNativeLibs">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0</TargetFrameworks>
     <BuildInParallel>false</BuildInParallel>
     <PackageId>Neo.Plugins.Storage.LevelDBStore</PackageId>
     <RootNamespace>Neo.Plugins.Storage</RootNamespace>

--- a/src/Plugins/MPTTrie/MPTTrie.csproj
+++ b/src/Plugins/MPTTrie/MPTTrie.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0</TargetFrameworks>
     <PackageId>Neo.Cryptography.MPT</PackageId>
     <RootNamespace>Neo.Cryptography</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/Plugins/OracleService/OracleService.csproj
+++ b/src/Plugins/OracleService/OracleService.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Plugins/RocksDBStore/RocksDBStore.csproj
+++ b/src/Plugins/RocksDBStore/RocksDBStore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0</TargetFrameworks>
     <PackageId>Neo.Plugins.Storage.RocksDBStore</PackageId>
     <RootNamespace>Neo.Plugins.Storage</RootNamespace>
     <Nullable>enable</Nullable>

--- a/src/Plugins/RpcClient/RpcClient.csproj
+++ b/src/Plugins/RpcClient/RpcClient.csproj
@@ -1,9 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0</TargetFrameworks>
     <PackageId>Neo.Network.RPC.RpcClient</PackageId>
     <RootNamespace>Neo.Network.RPC</RootNamespace>
   </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Neo\Neo.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/src/Plugins/SQLiteWallet/SQLiteWallet.csproj
+++ b/src/Plugins/SQLiteWallet/SQLiteWallet.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0</TargetFrameworks>
     <RootNamespace>Neo.Wallets.SQLite</RootNamespace>
     <PackageId>Neo.Wallets.SQLite</PackageId>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/Plugins/StateService/StateService.csproj
+++ b/src/Plugins/StateService/StateService.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 

--- a/src/Plugins/StorageDumper/StorageDumper.csproj
+++ b/src/Plugins/StorageDumper/StorageDumper.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
@@ -9,7 +9,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\Neo.ConsoleService\Neo.ConsoleService.csproj" />
   </ItemGroup>
-
+  
   <ItemGroup>
     <None Update="StorageDumper.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/Plugins/TokensTracker/TokensTracker.csproj
+++ b/src/Plugins/TokensTracker/TokensTracker.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Reverts neo-project/neo#3809

Build broken. I don't know if its Visual Studio or net9.0 that's the problem. It used to work with mixed frameworks before.
![image](https://github.com/user-attachments/assets/71ea7ce0-6c49-492d-8a03-7503a17e3a5a)
