### PR TITLE
[MemPool] Remove constant arguments

### DIFF
--- a/src/Neo/Ledger/MemoryPool.cs
+++ b/src/Neo/Ledger/MemoryPool.cs
@@ -249,19 +249,18 @@ namespace Neo.Ledger
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static PoolItem? GetLowestFeeTransaction(SortedSet<PoolItem> verifiedTxSorted,
-            SortedSet<PoolItem> unverifiedTxSorted, out SortedSet<PoolItem>? sortedPool)
+        private PoolItem? GetLowestFeeTransaction(out SortedSet<PoolItem>? sortedPool)
         {
-            var minItem = unverifiedTxSorted.Min;
-            sortedPool = minItem != null ? unverifiedTxSorted : null;
+            var minItem = _unverifiedSortedTransactions.Min;
+            sortedPool = minItem != null ? _unverifiedSortedTransactions : null;
 
-            var verifiedMin = verifiedTxSorted.Min;
+            var verifiedMin = _sortedTransactions.Min;
             if (verifiedMin == null) return minItem;
 
             if (minItem != null && verifiedMin.CompareTo(minItem) >= 0)
                 return minItem;
 
-            sortedPool = verifiedTxSorted;
+            sortedPool = _sortedTransactions;
             minItem = verifiedMin;
 
             return minItem;
@@ -273,7 +272,7 @@ namespace Neo.Ledger
 
             try
             {
-                return GetLowestFeeTransaction(_sortedTransactions, _unverifiedSortedTransactions, out sortedPool);
+                return GetLowestFeeTransaction(out sortedPool);
             }
             finally
             {
@@ -541,7 +540,7 @@ namespace Neo.Ledger
             if (block.Index > 0 && _system.HeaderCache.Count > 0)
                 return;
 
-            ReverifyTransactions(_sortedTransactions, _unverifiedSortedTransactions, (int)_system.Settings.MaxTransactionsPerBlock, MaxMillisecondsToReverifyTx, snapshot);
+            ReverifyTransactions((int)_system.Settings.MaxTransactionsPerBlock, MaxMillisecondsToReverifyTx, snapshot);
         }
 
         internal void InvalidateAllTransactions()
@@ -557,8 +556,7 @@ namespace Neo.Ledger
             }
         }
 
-        private int ReverifyTransactions(SortedSet<PoolItem> verifiedSortedTxPool,
-            SortedSet<PoolItem> unverifiedSortedTxPool, int count, double millisecondsTimeout, DataCache snapshot)
+        private int ReverifyTransactions(int count, double millisecondsTimeout, DataCache snapshot)
         {
             DateTime reverifyCutOffTimeStamp = TimeProvider.Current.UtcNow.AddMilliseconds(millisecondsTimeout);
             List<PoolItem> reverifiedItems = new(count);
@@ -568,7 +566,7 @@ namespace Neo.Ledger
             try
             {
                 // Since unverifiedSortedTxPool is ordered in an ascending manner, we take from the end.
-                foreach (PoolItem item in unverifiedSortedTxPool.Reverse().Take(count))
+                foreach (PoolItem item in _unverifiedSortedTransactions.Reverse().Take(count))
                 {
                     if (CheckConflicts(item.Tx, out List<PoolItem> conflictsToBeRemoved) &&
                         item.Tx.VerifyStateDependent(_system.Settings, snapshot, VerificationContext, conflictsToBeRemoved.Select(c => c.Tx)) == VerifyResult.Succeed)
@@ -576,7 +574,7 @@ namespace Neo.Ledger
                         reverifiedItems.Add(item);
                         if (_unsortedTransactions.TryAdd(item.Tx.Hash, item))
                         {
-                            verifiedSortedTxPool.Add(item);
+                            _sortedTransactions.Add(item);
                             foreach (var attr in item.Tx.GetAttributes<Conflicts>())
                             {
                                 if (!_conflicts.TryGetValue(attr.Hash, out var pooled))
@@ -620,13 +618,13 @@ namespace Neo.Ledger
                     }
 
                     _unverifiedTransactions.Remove(item.Tx.Hash);
-                    unverifiedSortedTxPool.Remove(item);
+                    _unverifiedSortedTransactions.Remove(item);
                 }
 
                 foreach (PoolItem item in invalidItems)
                 {
                     _unverifiedTransactions.Remove(item.Tx.Hash);
-                    unverifiedSortedTxPool.Remove(item);
+                    _unverifiedSortedTransactions.Remove(item);
                 }
             }
             finally
@@ -663,8 +661,7 @@ namespace Neo.Ledger
             if (_unverifiedSortedTransactions.Count > 0)
             {
                 int verifyCount = _sortedTransactions.Count > _system.Settings.MaxTransactionsPerBlock ? 1 : maxToVerify;
-                ReverifyTransactions(_sortedTransactions, _unverifiedSortedTransactions,
-                    verifyCount, MaxMillisecondsToReverifyTxPerIdle, snapshot);
+                ReverifyTransactions(verifyCount, MaxMillisecondsToReverifyTxPerIdle, snapshot);
             }
 
             return _unverifiedTransactions.Count > 0;


### PR DESCRIPTION
# Description

Make easier the review of #3822
- `GetLowestFeeTransaction` and `ReverifyTransactions` used always the same args for all calls.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Optimization (the change is only an optimization)
- [x] Style (the change is only a code style for better maintenance or standard purpose)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Test A
- [ ] Test B

**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
