### PR TITLE
[`Fix`]: `BigIntegerExtension.ModInverse` returns a wrong result if value < 0

### DIFF
--- a/src/Neo.Extensions/BigIntegerExtensions.cs
+++ b/src/Neo.Extensions/BigIntegerExtensions.cs
@@ -18,20 +18,33 @@ namespace Neo.Extensions
 {
     public static class BigIntegerExtensions
     {
-        public static int GetLowestSetBit(this BigInteger i)
+        /// <summary>
+        /// Finds the lowest set bit in the specified value.
+        /// </summary>
+        /// <param name="value">The value to find the lowest set bit in.</param>
+        /// <returns>The lowest set bit in the specified value.</returns>
+        /// <exception cref="Exception">Thrown when the value is zero.</exception>
+        public static int GetLowestSetBit(this BigInteger value)
         {
-            if (i.Sign == 0)
+            if (value.Sign == 0)
                 return -1;
-            var b = i.ToByteArray();
+            var b = value.ToByteArray();
             var w = 0;
             while (b[w] == 0)
                 w++;
             for (var x = 0; x < 8; x++)
                 if ((b[w] & 1 << x) > 0)
                     return x + w * 8;
-            throw new Exception();
+            throw new Exception("The value is zero.");
         }
 
+        /// <summary>
+        /// Computes the remainder of the division of the specified value by the modulus.
+        /// </summary>
+        /// <param name="x">The value to compute the remainder of.</param>
+        /// <param name="y">The modulus.</param>
+        /// <returns>The remainder of the division of the specified value by the modulus.</returns>
+        /// <exception cref="DivideByZeroException">Thrown when the modulus is zero.</exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static BigInteger Mod(this BigInteger x, BigInteger y)
         {
@@ -41,32 +54,47 @@ namespace Neo.Extensions
             return x;
         }
 
-        public static BigInteger ModInverse(this BigInteger a, BigInteger n)
+        /// <summary>
+        /// Computes the modular inverse of the specified value.
+        /// </summary>
+        /// <param name="value">The value to find the modular inverse of.</param>
+        /// <param name="modulus">The modulus.</param>
+        /// <returns>The modular inverse of the specified value.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the value or modulus is out of range.</exception>
+        /// <exception cref="ArithmeticException">
+        /// Thrown when no modular inverse exists for the given inputs. i.e. when the value and modulus are not coprime.
+        /// </exception>
+        public static BigInteger ModInverse(this BigInteger value, BigInteger modulus)
         {
-            if (BigInteger.GreatestCommonDivisor(a, n) != 1)
-            {
-                throw new ArithmeticException("No modular inverse exists for the given inputs.");
-            }
+            if (value <= 0) throw new ArgumentOutOfRangeException(nameof(value));
+            if (modulus < 2) throw new ArgumentOutOfRangeException(nameof(modulus));
 
-            BigInteger i = n, v = 0, d = 1;
-            while (a > 0)
+            BigInteger r = value, oldR = modulus, s = 1, oldS = 0;
+            while (r > 0)
             {
-                BigInteger t = i / a, x = a;
-                a = i % x;
-                i = x;
-                x = d;
-                d = v - t * x;
-                v = x;
+                var q = oldR / r;
+                (oldR, r) = (r, oldR % r);
+                (oldS, s) = (s, oldS - q * s);
             }
-            v %= n;
-            if (v < 0) v = (v + n) % n;
-            return v;
+            var result = oldS % modulus;
+            if (result < 0) result += modulus;
+
+            if (!(value * result % modulus).IsOne)
+                throw new ArithmeticException("No modular inverse exists for the given inputs.");
+            return result;
         }
 
+        /// <summary>
+        /// Tests whether the specified bit is set in the specified value.
+        /// </summary>
+        /// <param name="value">The value to test.</param>
+        /// <param name="index">The index of the bit to test.</param>
+        /// <returns>True if the specified bit is set in the specified value, otherwise false.</returns>
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TestBit(this BigInteger i, int index)
+        public static bool TestBit(this BigInteger value, int index)
         {
-            return (i & (BigInteger.One << index)) > BigInteger.Zero;
+            return (value & (BigInteger.One << index)) > BigInteger.Zero;
         }
 
         /// <summary>
@@ -84,13 +112,13 @@ namespace Neo.Extensions
         /// <summary>
         /// Converts a <see cref="BigInteger"/> to byte array and eliminates all the leading zeros.
         /// </summary>
-        /// <param name="i">The <see cref="BigInteger"/> to convert.</param>
+        /// <param name="value">The <see cref="BigInteger"/> to convert.</param>
         /// <returns>The converted byte array.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static byte[] ToByteArrayStandard(this BigInteger i)
+        public static byte[] ToByteArrayStandard(this BigInteger value)
         {
-            if (i.IsZero) return Array.Empty<byte>();
-            return i.ToByteArray();
+            if (value.IsZero) return Array.Empty<byte>();
+            return value.ToByteArray();
         }
     }
 }

--- a/src/Neo.VM/JumpTable/JumpTable.Numeric.cs
+++ b/src/Neo.VM/JumpTable/JumpTable.Numeric.cs
@@ -9,6 +9,7 @@
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
+using Neo.Extensions;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 

--- a/src/Neo.VM/Utility.cs
+++ b/src/Neo.VM/Utility.cs
@@ -18,23 +18,6 @@ namespace Neo.VM
 {
     public static class Utility
     {
-        public static BigInteger ModInverse(this BigInteger value, BigInteger modulus)
-        {
-            if (value <= 0) throw new ArgumentOutOfRangeException(nameof(value));
-            if (modulus < 2) throw new ArgumentOutOfRangeException(nameof(modulus));
-            BigInteger r = value, old_r = modulus, s = 1, old_s = 0;
-            while (r > 0)
-            {
-                var q = old_r / r;
-                (old_r, r) = (r, old_r % r);
-                (old_s, s) = (s, old_s - q * s);
-            }
-            var result = old_s % modulus;
-            if (result < 0) result += modulus;
-            if (!(value * result % modulus).IsOne) throw new InvalidOperationException();
-            return result;
-        }
-
         public static BigInteger Sqrt(this BigInteger value)
         {
             if (value < 0) throw new InvalidOperationException($"value {value} can not be negative for {nameof(Integer)}.{nameof(Sqrt)}.");

--- a/tests/Neo.Extensions.Tests/UT_BigIntegerExtensions.cs
+++ b/tests/Neo.Extensions.Tests/UT_BigIntegerExtensions.cs
@@ -135,7 +135,7 @@ namespace Neo.Extensions.Tests
         [TestMethod]
         public void TestModInverse_EdgeCases()
         {
-            Assert.ThrowsExactly<ArithmeticException>(() => _ = BigInteger.Zero.ModInverse(11));
+            Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => _ = BigInteger.Zero.ModInverse(11));
 
             Assert.AreEqual(1, BigInteger.One.ModInverse(2));
 
@@ -179,6 +179,17 @@ namespace Neo.Extensions.Tests
             Assert.AreEqual(0, new List<BigInteger>().Sum());
             Assert.AreEqual(0, new List<BigInteger> { JNumber.MIN_SAFE_INTEGER, JNumber.MAX_SAFE_INTEGER }.Sum());
             Assert.AreEqual(JNumber.MAX_SAFE_INTEGER * 2, new List<BigInteger> { JNumber.MAX_SAFE_INTEGER, JNumber.MAX_SAFE_INTEGER }.Sum());
+        }
+
+        [TestMethod]
+        public void TestModInverseTest()
+        {
+            Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => _ = BigInteger.One.ModInverse(BigInteger.Zero));
+            Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => _ = BigInteger.One.ModInverse(BigInteger.One));
+            Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => _ = BigInteger.Zero.ModInverse(BigInteger.Zero));
+            Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => _ = BigInteger.Zero.ModInverse(BigInteger.One));
+            Assert.ThrowsExactly<ArithmeticException>(() => _ = new BigInteger(ushort.MaxValue).ModInverse(byte.MaxValue));
+            Assert.AreEqual(new BigInteger(52), new BigInteger(19).ModInverse(141));
         }
     }
 }

--- a/tests/Neo.VM.Tests/UT_Utility.cs
+++ b/tests/Neo.VM.Tests/UT_Utility.cs
@@ -89,17 +89,5 @@ namespace Neo.Test
                 Assert.AreEqual(bi.GetBitLength(), VM.Utility.GetBitLength(bi), message: $"Error comparing: {bi}");
             }
         }
-
-        [TestMethod]
-        public void TestModInverseTest()
-        {
-            Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => _ = BigInteger.One.ModInverse(BigInteger.Zero));
-            Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => _ = BigInteger.One.ModInverse(BigInteger.One));
-            Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => _ = BigInteger.Zero.ModInverse(BigInteger.Zero));
-            Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => _ = BigInteger.Zero.ModInverse(BigInteger.One));
-            Assert.ThrowsExactly<InvalidOperationException>(() => _ = new BigInteger(ushort.MaxValue).ModInverse(byte.MaxValue));
-
-            Assert.AreEqual(new BigInteger(52), new BigInteger(19).ModInverse(141));
-        }
     }
 }


### PR DESCRIPTION
# Description

There are two `BigIntegerExtension.ModInverse` implementations.
One  in `Neo.Extensions.BigIntegerExtension`, and another in `Neo.Vm.Utility`.

`BigIntegerExtension.ModInverse` returns a wrong result if value < 0(always return 0), but it's only used when get public key from private key, so no negative case.

Negative value is not allowed  in `Neo.Vm.Utility.ModInverse`.

This PR removes duplicated implementation and keeps the `Neo.Vm.Utility.ModInverse` one(and move it to BigIntegerExtension)

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
