### PR TITLE
[`Style`]: avoid allocating emtpy array

### DIFF
--- a/tests/Neo.Network.RPC.Tests/UT_ContractClient.cs
+++ b/tests/Neo.Network.RPC.Tests/UT_ContractClient.cs
@@ -33,7 +33,7 @@ namespace Neo.Network.RPC.Tests
         {
             keyPair1 = new KeyPair(Wallet.GetPrivateKeyFromWIF("KyXwTh1hB76RRMquSvnxZrJzQx7h9nQP2PCRL38v6VDb5ip3nf1p"));
             sender = Contract.CreateSignatureRedeemScript(keyPair1.PublicKey).ToScriptHash();
-            rpcClientMock = UT_TransactionManager.MockRpcClient(sender, new byte[0]);
+            rpcClientMock = UT_TransactionManager.MockRpcClient(sender, []);
         }
 
         [TestMethod]
@@ -54,15 +54,11 @@ namespace Neo.Network.RPC.Tests
             byte[] script;
             var manifest = new ContractManifest()
             {
-                Permissions = new[] { ContractPermission.DefaultPermission },
-                Abi = new ContractAbi()
-                {
-                    Events = new ContractEventDescriptor[0],
-                    Methods = new ContractMethodDescriptor[0]
-                },
-                Groups = new ContractGroup[0],
+                Permissions = [ContractPermission.DefaultPermission],
+                Abi = new ContractAbi() { Events = [], Methods = [] },
+                Groups = [],
                 Trusts = WildcardContainer<ContractPermissionDescriptor>.Create(),
-                SupportedStandards = new string[] { "NEP-10" },
+                SupportedStandards = ["NEP-10"],
                 Extra = null,
             };
             using (ScriptBuilder sb = new ScriptBuilder())

--- a/tests/Neo.Network.RPC.Tests/UT_Nep17API.cs
+++ b/tests/Neo.Network.RPC.Tests/UT_Nep17API.cs
@@ -37,7 +37,7 @@ namespace Neo.Network.RPC.Tests
         {
             keyPair1 = new KeyPair(Wallet.GetPrivateKeyFromWIF("KyXwTh1hB76RRMquSvnxZrJzQx7h9nQP2PCRL38v6VDb5ip3nf1p"));
             sender = Contract.CreateSignatureRedeemScript(keyPair1.PublicKey).ToScriptHash();
-            rpcClientMock = UT_TransactionManager.MockRpcClient(sender, new byte[0]);
+            rpcClientMock = UT_TransactionManager.MockRpcClient(sender, []);
             nep17API = new Nep17API(rpcClientMock.Object);
         }
 
@@ -150,7 +150,7 @@ namespace Neo.Network.RPC.Tests
         public async Task TestTransfer()
         {
             byte[] testScript = NativeContract.GAS.Hash.MakeScript("transfer", sender, UInt160.Zero, new BigInteger(1_00000000), null)
-                .Concat(new[] { (byte)OpCode.ASSERT })
+                .Concat([(byte)OpCode.ASSERT])
                 .ToArray();
             UT_TransactionManager.MockInvokeScript(rpcClientMock, testScript, new ContractParameter());
 
@@ -158,7 +158,7 @@ namespace Neo.Network.RPC.Tests
             var result = await nep17API.CreateTransferTxAsync(NativeContract.GAS.Hash, keyPair1, UInt160.Zero, new BigInteger(1_00000000), null, true);
 
             testScript = NativeContract.GAS.Hash.MakeScript("transfer", sender, UInt160.Zero, new BigInteger(1_00000000), string.Empty)
-                .Concat(new[] { (byte)OpCode.ASSERT })
+                .Concat([(byte)OpCode.ASSERT])
                 .ToArray();
             UT_TransactionManager.MockInvokeScript(rpcClientMock, testScript, new ContractParameter());
 

--- a/tests/Neo.Network.RPC.Tests/UT_PolicyAPI.cs
+++ b/tests/Neo.Network.RPC.Tests/UT_PolicyAPI.cs
@@ -33,7 +33,7 @@ namespace Neo.Network.RPC.Tests
         {
             keyPair1 = new KeyPair(Wallet.GetPrivateKeyFromWIF("KyXwTh1hB76RRMquSvnxZrJzQx7h9nQP2PCRL38v6VDb5ip3nf1p"));
             sender = Contract.CreateSignatureRedeemScript(keyPair1.PublicKey).ToScriptHash();
-            rpcClientMock = UT_TransactionManager.MockRpcClient(sender, new byte[0]);
+            rpcClientMock = UT_TransactionManager.MockRpcClient(sender, []);
             policyAPI = new PolicyAPI(rpcClientMock.Object);
         }
 

--- a/tests/Neo.Network.RPC.Tests/UT_WalletAPI.cs
+++ b/tests/Neo.Network.RPC.Tests/UT_WalletAPI.cs
@@ -44,8 +44,8 @@ namespace Neo.Network.RPC.Tests
         {
             keyPair1 = new KeyPair(Wallet.GetPrivateKeyFromWIF("KyXwTh1hB76RRMquSvnxZrJzQx7h9nQP2PCRL38v6VDb5ip3nf1p"));
             sender = Contract.CreateSignatureRedeemScript(keyPair1.PublicKey).ToScriptHash();
-            multiSender = Contract.CreateMultiSigContract(1, new ECPoint[] { keyPair1.PublicKey }).ScriptHash;
-            rpcClientMock = UT_TransactionManager.MockRpcClient(sender, new byte[0]);
+            multiSender = Contract.CreateMultiSigContract(1, [keyPair1.PublicKey]).ScriptHash;
+            rpcClientMock = UT_TransactionManager.MockRpcClient(sender, []);
             client = rpcClientMock.Object;
             address1 = Helper.ToAddress(sender, client.protocolSettings.AddressVersion);
             walletAPI = new WalletAPI(rpcClientMock.Object);
@@ -115,7 +115,7 @@ namespace Neo.Network.RPC.Tests
             UT_TransactionManager.MockInvokeScript(rpcClientMock, decimalsScript, new ContractParameter { Type = ContractParameterType.Integer, Value = new BigInteger(8) });
 
             byte[] testScript = NativeContract.GAS.Hash.MakeScript("transfer", sender, UInt160.Zero, NativeContract.GAS.Factor * 100, null)
-                .Concat(new[] { (byte)OpCode.ASSERT })
+                .Concat([(byte)OpCode.ASSERT])
                 .ToArray();
             UT_TransactionManager.MockInvokeScript(rpcClientMock, testScript, new ContractParameter { Type = ContractParameterType.Integer, Value = new BigInteger(1_10000000) });
 

--- a/tests/Neo.Plugins.OracleService.Tests/E2E_Https.cs
+++ b/tests/Neo.Plugins.OracleService.Tests/E2E_Https.cs
@@ -53,7 +53,7 @@ namespace Neo.Plugins.OracleService.Tests
                         }]);
                 // Expected result: 12685221
                 sb.EmitDynamicCall(customContract, "createRequest",
-                    ["https://api.github.com/orgs/neo-project", "$.id", "callback", new byte[] { }, 1_0000_0000]);
+                    ["https://api.github.com/orgs/neo-project", "$.id", "callback", Array.Empty<byte>(), 1_0000_0000]);
                 script = sb.ToArray();
             }
             Transaction[] txs = [

--- a/tests/Neo.UnitTests/IO/Caching/UT_ReflectionCache.cs
+++ b/tests/Neo.UnitTests/IO/Caching/UT_ReflectionCache.cs
@@ -12,6 +12,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Neo.IO;
 using Neo.IO.Caching;
+using System;
 using System.IO;
 
 namespace Neo.UnitTests.IO.Caching
@@ -63,13 +64,13 @@ namespace Neo.UnitTests.IO.Caching
         [TestMethod]
         public void TestCreateSerializable()
         {
-            object item1 = ReflectionCache<MyTestEnum>.CreateSerializable(MyTestEnum.Item1, new byte[0]);
+            object item1 = ReflectionCache<MyTestEnum>.CreateSerializable(MyTestEnum.Item1, ReadOnlyMemory<byte>.Empty);
             Assert.IsTrue(item1 is TestItem1);
 
-            object item2 = ReflectionCache<MyTestEnum>.CreateSerializable(MyTestEnum.Item2, new byte[0]);
+            object item2 = ReflectionCache<MyTestEnum>.CreateSerializable(MyTestEnum.Item2, ReadOnlyMemory<byte>.Empty);
             Assert.IsTrue(item2 is TestItem2);
 
-            object item3 = ReflectionCache<MyTestEnum>.CreateSerializable((MyTestEnum)0x02, new byte[0]);
+            object item3 = ReflectionCache<MyTestEnum>.CreateSerializable((MyTestEnum)0x02, ReadOnlyMemory<byte>.Empty);
             Assert.IsNull(item3);
         }
 

--- a/tests/Neo.UnitTests/Network/P2P/Payloads/UT_AddrPayload.cs
+++ b/tests/Neo.UnitTests/Network/P2P/Payloads/UT_AddrPayload.cs
@@ -25,27 +25,26 @@ namespace Neo.UnitTests.Network.P2P.Payloads
         [TestMethod]
         public void Size_Get()
         {
-            var test = new AddrPayload() { AddressList = new NetworkAddressWithTime[0] };
+            var test = new AddrPayload() { AddressList = [] };
             Assert.AreEqual(1, test.Size);
 
-            test = AddrPayload.Create(new NetworkAddressWithTime[] { new NetworkAddressWithTime() { Address = IPAddress.Any, Capabilities = new NodeCapability[0], Timestamp = 1 } });
+            test = AddrPayload.Create([new NetworkAddressWithTime() { Address = IPAddress.Any, Capabilities = [], Timestamp = 1 }]);
             Assert.AreEqual(22, test.Size);
         }
 
         [TestMethod]
         public void DeserializeAndSerialize()
         {
-            var test = AddrPayload.Create(new NetworkAddressWithTime[] { new NetworkAddressWithTime()
+            var test = AddrPayload.Create([new NetworkAddressWithTime()
             {
                 Address = IPAddress.Any,
-                Capabilities = new NodeCapability[0], Timestamp = 1
-            }
-            });
+                Capabilities = [],
+                Timestamp = 1
+            }]);
             var clone = test.ToArray().AsSerializable<AddrPayload>();
-
             CollectionAssert.AreEqual(test.AddressList.Select(u => u.EndPoint).ToArray(), clone.AddressList.Select(u => u.EndPoint).ToArray());
 
-            Assert.ThrowsExactly<FormatException>(() => _ = new AddrPayload() { AddressList = new NetworkAddressWithTime[0] }.ToArray().AsSerializable<AddrPayload>());
+            Assert.ThrowsExactly<FormatException>(() => _ = new AddrPayload() { AddressList = [] }.ToArray().AsSerializable<AddrPayload>());
         }
     }
 }

--- a/tests/Neo.UnitTests/Network/P2P/Payloads/UT_FilterAddPayload.cs
+++ b/tests/Neo.UnitTests/Network/P2P/Payloads/UT_FilterAddPayload.cs
@@ -22,7 +22,7 @@ namespace Neo.UnitTests.Network.P2P.Payloads
         [TestMethod]
         public void Size_Get()
         {
-            var test = new FilterAddPayload() { Data = new byte[0] };
+            var test = new FilterAddPayload() { Data = ReadOnlyMemory<byte>.Empty };
             Assert.AreEqual(1, test.Size);
 
             test = new FilterAddPayload() { Data = new byte[] { 1, 2, 3 } };

--- a/tests/Neo.UnitTests/Network/P2P/Payloads/UT_NetworkAddressWithTime.cs
+++ b/tests/Neo.UnitTests/Network/P2P/Payloads/UT_NetworkAddressWithTime.cs
@@ -24,21 +24,24 @@ namespace Neo.UnitTests.Network.P2P.Payloads
         [TestMethod]
         public void SizeAndEndPoint_Get()
         {
-            var test = new NetworkAddressWithTime() { Capabilities = new NodeCapability[0], Address = IPAddress.Any, Timestamp = 1 };
+            var test = new NetworkAddressWithTime() { Capabilities = [], Address = IPAddress.Any, Timestamp = 1 };
             Assert.AreEqual(21, test.Size);
-
             Assert.AreEqual(test.EndPoint.Port, 0);
 
-            test = NetworkAddressWithTime.Create(IPAddress.Any, 1, new NodeCapability[] { new ServerCapability(NodeCapabilityType.TcpServer, 22) });
+            test = NetworkAddressWithTime.Create(IPAddress.Any, 1, [new ServerCapability(NodeCapabilityType.TcpServer, 22)]);
             Assert.AreEqual(24, test.Size);
-
             Assert.AreEqual(test.EndPoint.Port, 22);
         }
 
         [TestMethod]
         public void DeserializeAndSerialize()
         {
-            var test = NetworkAddressWithTime.Create(IPAddress.Any, 1, new NodeCapability[] { new ServerCapability(NodeCapabilityType.TcpServer, 22), new UnknownCapability(NodeCapabilityType.Extension0), new UnknownCapability(NodeCapabilityType.Extension0) });
+            var test = NetworkAddressWithTime.Create(IPAddress.Any, 1,
+                [
+                    new ServerCapability(NodeCapabilityType.TcpServer, 22),
+                    new UnknownCapability(NodeCapabilityType.Extension0),
+                    new UnknownCapability(NodeCapabilityType.Extension0)
+                ]);
             var clone = test.ToArray().AsSerializable<NetworkAddressWithTime>();
 
             Assert.AreEqual(test.Address, clone.Address);
@@ -46,11 +49,12 @@ namespace Neo.UnitTests.Network.P2P.Payloads
             Assert.AreEqual(test.Timestamp, clone.Timestamp);
             CollectionAssert.AreEqual(test.Capabilities.ToByteArray(), clone.Capabilities.ToByteArray());
 
-            Assert.ThrowsExactly<FormatException>(() => _ = NetworkAddressWithTime.Create(IPAddress.Any, 1,
-                new NodeCapability[] {
-                    new ServerCapability(NodeCapabilityType.TcpServer, 22) ,
+            test = NetworkAddressWithTime.Create(IPAddress.Any, 1,
+                [
+                    new ServerCapability(NodeCapabilityType.TcpServer, 22),
                     new ServerCapability(NodeCapabilityType.TcpServer, 22)
-                }).ToArray().AsSerializable<NetworkAddressWithTime>());
+                ]);
+            Assert.ThrowsExactly<FormatException>(() => _ = test.ToArray().AsSerializable<NetworkAddressWithTime>());
         }
     }
 }

--- a/tests/Neo.UnitTests/SmartContract/Manifest/UT_ContractEventDescriptor.cs
+++ b/tests/Neo.UnitTests/SmartContract/Manifest/UT_ContractEventDescriptor.cs
@@ -20,12 +20,12 @@ namespace Neo.UnitTests.SmartContract.Manifest
         [TestMethod]
         public void TestFromJson()
         {
-            ContractEventDescriptor expected = new ContractEventDescriptor
+            var expected = new ContractEventDescriptor
             {
                 Name = "AAA",
-                Parameters = new ContractParameterDefinition[0]
+                Parameters = [],
             };
-            ContractEventDescriptor actual = ContractEventDescriptor.FromJson(expected.ToJson());
+            var actual = ContractEventDescriptor.FromJson(expected.ToJson());
             Assert.AreEqual(expected.Name, actual.Name);
             Assert.AreEqual(0, actual.Parameters.Length);
         }

--- a/tests/Neo.UnitTests/SmartContract/Manifest/UT_WildCardContainer.cs
+++ b/tests/Neo.UnitTests/SmartContract/Manifest/UT_WildCardContainer.cs
@@ -46,7 +46,7 @@ namespace Neo.UnitTests.SmartContract.Manifest
         [TestMethod]
         public void TestGetCount()
         {
-            string[] s = new string[] { "hello", "world" };
+            string[] s = ["hello", "world"];
             WildcardContainer<string> container = WildcardContainer<string>.Create(s);
             Assert.AreEqual(2, container.Count);
 
@@ -58,7 +58,7 @@ namespace Neo.UnitTests.SmartContract.Manifest
         [TestMethod]
         public void TestGetItem()
         {
-            string[] s = new string[] { "hello", "world" };
+            string[] s = ["hello", "world"];
             WildcardContainer<string> container = WildcardContainer<string>.Create(s);
             Assert.AreEqual("hello", container[0]);
             Assert.AreEqual("world", container[1]);
@@ -68,12 +68,12 @@ namespace Neo.UnitTests.SmartContract.Manifest
         public void TestGetEnumerator()
         {
             string[] s = null;
-            IReadOnlyList<string> rs = new string[0];
+            IReadOnlyList<string> rs = Array.Empty<string>();
             WildcardContainer<string> container = WildcardContainer<string>.Create(s);
             IEnumerator<string> enumerator = container.GetEnumerator();
             Assert.AreEqual(rs.GetEnumerator(), enumerator);
 
-            s = new string[] { "hello", "world" };
+            s = ["hello", "world"];
             container = WildcardContainer<string>.Create(s);
             enumerator = container.GetEnumerator();
             foreach (string _ in s)
@@ -86,7 +86,7 @@ namespace Neo.UnitTests.SmartContract.Manifest
         [TestMethod]
         public void TestIEnumerableGetEnumerator()
         {
-            string[] s = new string[] { "hello", "world" };
+            string[] s = ["hello", "world"];
             WildcardContainer<string> container = WildcardContainer<string>.Create(s);
             IEnumerable enumerable = container;
             var enumerator = enumerable.GetEnumerator();

--- a/tests/Neo.UnitTests/SmartContract/UT_ApplicationEngine.cs
+++ b/tests/Neo.UnitTests/SmartContract/UT_ApplicationEngine.cs
@@ -68,7 +68,7 @@ namespace Neo.UnitTests.SmartContract
         public void TestCreateDummyBlock()
         {
             var snapshotCache = TestBlockchain.GetTestSnapshotCache();
-            byte[] SyscallSystemRuntimeCheckWitnessHash = new byte[] { 0x68, 0xf8, 0x27, 0xec, 0x8c };
+            byte[] SyscallSystemRuntimeCheckWitnessHash = [0x68, 0xf8, 0x27, 0xec, 0x8c];
             ApplicationEngine engine = ApplicationEngine.Run(SyscallSystemRuntimeCheckWitnessHash, snapshotCache, settings: TestProtocolSettings.Default);
             Assert.AreEqual(0u, engine.PersistingBlock.Version);
             Assert.AreEqual(TestBlockchain.TheNeoSystem.GenesisBlock.Hash, engine.PersistingBlock.PrevHash);
@@ -126,19 +126,10 @@ namespace Neo.UnitTests.SmartContract
 
                 snapshotCache.DeleteContract(scriptHash);
                 var contract = TestUtils.GetContract(script.ToArray(), TestUtils.CreateManifest("test", ContractParameterType.Any));
-                contract.Manifest.Abi.Methods = new[]
-                {
-                    new ContractMethodDescriptor
-                    {
-                        Name = "disallowed",
-                        Parameters = new ContractParameterDefinition[]{}
-                    },
-                    new ContractMethodDescriptor
-                    {
-                        Name = "test",
-                        Parameters = new ContractParameterDefinition[]{}
-                    }
-                };
+                contract.Manifest.Abi.Methods = [
+                    new ContractMethodDescriptor { Name = "disallowed", Parameters = [] },
+                    new ContractMethodDescriptor { Name = "test", Parameters = [] }
+                ];
                 snapshotCache.AddContract(scriptHash, contract);
             }
 
@@ -155,15 +146,14 @@ namespace Neo.UnitTests.SmartContract
                 {
                     Manifest = new()
                     {
-                        Abi = new() { },
-                        Permissions = new ContractPermission[]
-                        {
+                        Abi = new(),
+                        Permissions = [
                             new ContractPermission
                             {
                                 Contract = ContractPermissionDescriptor.Create(scriptHash),
-                                Methods = WildcardContainer<string>.Create(new string[]{"test"}) // allowed to call only "test" method of the target contract.
+                                Methods = WildcardContainer<string>.Create(["test"]) // allowed to call only "test" method of the target contract.
                             }
-                        }
+                        ]
                     }
                 };
                 var currentScriptHash = engine.EntryScriptHash;
@@ -192,15 +182,14 @@ namespace Neo.UnitTests.SmartContract
                 {
                     Manifest = new()
                     {
-                        Abi = new() { },
-                        Permissions = new ContractPermission[]
-                        {
+                        Abi = new(),
+                        Permissions = [
                             new ContractPermission
                             {
                                 Contract = ContractPermissionDescriptor.Create(scriptHash),
-                                Methods = WildcardContainer<string>.Create(new string[]{"test"}) // allowed to call only "test" method of the target contract.
+                                Methods = WildcardContainer<string>.Create(["test"]) // allowed to call only "test" method of the target contract.
                             }
-                        }
+                        ]
                     }
                 };
                 var currentScriptHash = engine.EntryScriptHash;

--- a/tests/Neo.UnitTests/SmartContract/UT_InteropService.NEO.cs
+++ b/tests/Neo.UnitTests/SmartContract/UT_InteropService.NEO.cs
@@ -73,39 +73,19 @@ namespace Neo.UnitTests.SmartContract
             };
             Assert.IsTrue(engine.CheckMultisig(pubkeys, signatures));
 
-            pubkeys = new byte[0][];
+            pubkeys = Array.Empty<byte[]>();
             Assert.ThrowsExactly<ArgumentException>(() => _ = engine.CheckMultisig(pubkeys, signatures));
 
-            pubkeys = new[]
-            {
-                pubkey1.EncodePoint(false),
-                pubkey2.EncodePoint(false)
-            };
-            signatures = new byte[0][];
+            pubkeys = [pubkey1.EncodePoint(false), pubkey2.EncodePoint(false)];
+            signatures = Array.Empty<byte[]>();
             Assert.ThrowsExactly<ArgumentException>(() => _ = engine.CheckMultisig(pubkeys, signatures));
 
-            pubkeys = new[]
-            {
-                pubkey1.EncodePoint(false),
-                pubkey2.EncodePoint(false)
-            };
-            signatures = new[]
-            {
-                signature1,
-                new byte[64]
-            };
+            pubkeys = [pubkey1.EncodePoint(false), pubkey2.EncodePoint(false)];
+            signatures = [signature1, new byte[64]];
             Assert.IsFalse(engine.CheckMultisig(pubkeys, signatures));
 
-            pubkeys = new[]
-            {
-                pubkey1.EncodePoint(false),
-                new byte[70]
-            };
-            signatures = new[]
-            {
-                signature1,
-                signature2
-            };
+            pubkeys = [pubkey1.EncodePoint(false), new byte[70]];
+            signatures = [signature1, signature2];
             Assert.ThrowsExactly<FormatException>(() => _ = engine.CheckMultisig(pubkeys, signatures));
         }
 
@@ -168,7 +148,7 @@ namespace Neo.UnitTests.SmartContract
                 Tokens = Array.Empty<MethodToken>()
             };
             nef.CheckSum = NefFile.ComputeChecksum(nef);
-            Assert.ThrowsExactly<InvalidOperationException>(() => snapshotCache.UpdateContract(null, nef.ToArray(), new byte[0]));
+            Assert.ThrowsExactly<InvalidOperationException>(() => snapshotCache.UpdateContract(null, nef.ToArray(), []));
 
             var manifest = TestUtils.CreateDefaultManifest();
             byte[] privkey = { 0x01,0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
@@ -222,21 +202,21 @@ namespace Neo.UnitTests.SmartContract
 
             var snapshotCache = TestBlockchain.GetTestSnapshotCache();
 
-            Assert.ThrowsExactly<InvalidOperationException>(() => snapshotCache.UpdateContract(null, null, new byte[] { 0x01 }));
+            Assert.ThrowsExactly<InvalidOperationException>(() => snapshotCache.UpdateContract(null, null, [0x01]));
             Assert.ThrowsExactly<InvalidOperationException>(() => snapshotCache.UpdateContract(null, nefFile.ToArray(), null));
             Assert.ThrowsExactly<ArgumentException>(() => snapshotCache.UpdateContract(null, null, null));
 
             nefFile = new NefFile()
             {
-                Script = new byte[0],
+                Script = ReadOnlyMemory<byte>.Empty,
                 Source = string.Empty,
                 Compiler = "",
                 Tokens = []
             };
             nefFile.CheckSum = NefFile.ComputeChecksum(nefFile);
 
-            Assert.ThrowsExactly<InvalidOperationException>(() => snapshotCache.UpdateContract(null, nefFile.ToArray(), new byte[] { 0x01 }));
-            Assert.ThrowsExactly<InvalidOperationException>(() => snapshotCache.UpdateContract(null, nefFile.ToArray(), new byte[0]));
+            Assert.ThrowsExactly<InvalidOperationException>(() => snapshotCache.UpdateContract(null, nefFile.ToArray(), [0x01]));
+            Assert.ThrowsExactly<InvalidOperationException>(() => snapshotCache.UpdateContract(null, nefFile.ToArray(), []));
         }
 
         [TestMethod]

--- a/tests/Neo.UnitTests/SmartContract/UT_InteropService.cs
+++ b/tests/Neo.UnitTests/SmartContract/UT_InteropService.cs
@@ -618,17 +618,17 @@ namespace Neo.UnitTests.SmartContract
 
             //key.Length > MaxStorageKeySize
             key = new byte[ApplicationEngine.MaxStorageKeySize + 1];
-            value = new byte[] { 0x02 };
+            value = [0x02];
             Assert.ThrowsExactly<ArgumentException>(() => engine.Put(storageContext, key, value));
 
             //value.Length > MaxStorageValueSize
-            key = new byte[] { 0x01 };
+            key = [0x01];
             value = new byte[ushort.MaxValue + 1];
             Assert.ThrowsExactly<ArgumentException>(() => engine.Put(storageContext, key, value));
 
             //context.IsReadOnly
-            key = new byte[] { 0x01 };
-            value = new byte[] { 0x02 };
+            key = [0x01];
+            value = [0x02];
             storageContext.IsReadOnly = true;
             Assert.ThrowsExactly<ArgumentException>(() => engine.Put(storageContext, key, value));
 
@@ -648,14 +648,14 @@ namespace Neo.UnitTests.SmartContract
             snapshotCache.Add(storageKey, storageItem);
             engine = ApplicationEngine.Create(TriggerType.Application, null, snapshotCache);
             engine.LoadScript(new byte[] { 0x01 });
-            key = new byte[] { 0x01 };
-            value = new byte[] { 0x02 };
+            key = [0x01];
+            value = [0x02];
             storageContext.IsReadOnly = false;
             engine.Put(storageContext, key, value);
 
             //value length == 0
-            key = new byte[] { 0x01 };
-            value = Array.Empty<byte>();
+            key = [0x01];
+            value = [];
             engine.Put(storageContext, key, value);
         }
 
@@ -800,7 +800,7 @@ namespace Neo.UnitTests.SmartContract
             Assert.IsTrue(result);
             result = CryptoLib.VerifyWithECDsaV0(hexMessage, publicKeyK1, signatureK1, NamedCurveHash.secp256k1SHA256);
             Assert.IsTrue(result);
-            result = CryptoLib.VerifyWithECDsaV0(hexMessage, publicKeyK1, new byte[0], NamedCurveHash.secp256k1SHA256);
+            result = CryptoLib.VerifyWithECDsaV0(hexMessage, publicKeyK1, [], NamedCurveHash.secp256k1SHA256);
             Assert.IsFalse(result);
             Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => _ = CryptoLib.VerifyWithECDsaV0(hexMessage, publicKeyK1, new byte[64], NamedCurveHash.secp256r1Keccak256));
         }

--- a/tests/Neo.UnitTests/UT_DataCache.cs
+++ b/tests/Neo.UnitTests/UT_DataCache.cs
@@ -12,6 +12,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Neo.Persistence;
 using Neo.SmartContract;
+using System;
 using System.Linq;
 
 namespace Neo.UnitTests
@@ -26,36 +27,31 @@ namespace Neo.UnitTests
             var storages = snapshotCache.CloneCache();
             var cache = new ClonedCache(storages);
 
-            storages.Add
-                (
+            storages.Add(
                 new StorageKey() { Key = new byte[] { 0x01, 0x01 }, Id = 0 },
-                new StorageItem() { Value = new byte[] { } }
-                );
-            storages.Add
-                (
+                new StorageItem() { Value = ReadOnlyMemory<byte>.Empty }
+            );
+            storages.Add(
                 new StorageKey() { Key = new byte[] { 0x00, 0x01 }, Id = 0 },
-                new StorageItem() { Value = new byte[] { } }
-                );
-            storages.Add
-                (
+                new StorageItem() { Value = ReadOnlyMemory<byte>.Empty }
+            );
+            storages.Add(
                 new StorageKey() { Key = new byte[] { 0x00, 0x03 }, Id = 0 },
-                new StorageItem() { Value = new byte[] { } }
-                );
-            cache.Add
-                (
+                new StorageItem() { Value = ReadOnlyMemory<byte>.Empty }
+            );
+            cache.Add(
                 new StorageKey() { Key = new byte[] { 0x01, 0x02 }, Id = 0 },
-                new StorageItem() { Value = new byte[] { } }
-                );
-            cache.Add
-                (
+                new StorageItem() { Value = ReadOnlyMemory<byte>.Empty }
+            );
+            cache.Add(
                 new StorageKey() { Key = new byte[] { 0x00, 0x02 }, Id = 0 },
-                new StorageItem() { Value = new byte[] { } }
-                );
+                new StorageItem() { Value = ReadOnlyMemory<byte>.Empty }
+            );
 
             CollectionAssert.AreEqual(
                 cache.Find(new byte[5]).Select(u => u.Key.Key.Span[1]).ToArray(),
                 new byte[] { 0x01, 0x02, 0x03 }
-                );
+            );
         }
 
         [TestMethod]
@@ -65,29 +61,26 @@ namespace Neo.UnitTests
             var storages = snapshotCache.CloneCache();
             var cache = new ClonedCache(storages);
 
-            storages.Add
-                (
+            storages.Add(
                 new StorageKey() { Key = new byte[] { 0x00, 0x01 }, Id = 0 },
-                new StorageItem() { Value = new byte[] { } }
-                );
-            storages.Add
-                (
+                new StorageItem() { Value = ReadOnlyMemory<byte>.Empty }
+            );
+            storages.Add(
                 new StorageKey() { Key = new byte[] { 0x01, 0x01 }, Id = 0 },
-                new StorageItem() { Value = new byte[] { } }
-                );
-            cache.Add
-                (
+                new StorageItem() { Value = ReadOnlyMemory<byte>.Empty }
+            );
+            cache.Add(
                 new StorageKey() { Key = new byte[] { 0x00, 0x02 }, Id = 0 },
-                new StorageItem() { Value = new byte[] { } }
-                );
-            cache.Add
-                (
+                new StorageItem() { Value = ReadOnlyMemory<byte>.Empty }
+            );
+            cache.Add(
                 new StorageKey() { Key = new byte[] { 0x01, 0x02 }, Id = 0 },
-                new StorageItem() { Value = new byte[] { } }
-                );
-            CollectionAssert.AreEqual(cache.Find(new byte[5]).Select(u => u.Key.Key.Span[1]).ToArray(),
+                new StorageItem() { Value = ReadOnlyMemory<byte>.Empty }
+            );
+            CollectionAssert.AreEqual(
+                cache.Find(new byte[5]).Select(u => u.Key.Key.Span[1]).ToArray(),
                 new byte[] { 0x01, 0x02 }
-                );
+             );
         }
 
         [TestMethod]
@@ -97,21 +90,19 @@ namespace Neo.UnitTests
             var storages = snapshotCache.CloneCache();
             var cache = new ClonedCache(storages);
 
-            cache.Add
-                (
+            cache.Add(
                 new StorageKey() { Key = new byte[] { 0x00, 0x02 }, Id = 0 },
-                new StorageItem() { Value = new byte[] { } }
-                );
-            cache.Add
-                (
+                new StorageItem() { Value = ReadOnlyMemory<byte>.Empty }
+            );
+            cache.Add(
                 new StorageKey() { Key = new byte[] { 0x01, 0x02 }, Id = 0 },
-                new StorageItem() { Value = new byte[] { } }
-                );
+                new StorageItem() { Value = ReadOnlyMemory<byte>.Empty }
+            );
 
             CollectionAssert.AreEqual(
                 cache.Find(new byte[5]).Select(u => u.Key.Key.Span[1]).ToArray(),
                 new byte[] { 0x02 }
-                );
+            );
         }
     }
 }

--- a/tests/Neo.UnitTests/VM/UT_Helper.cs
+++ b/tests/Neo.UnitTests/VM/UT_Helper.cs
@@ -64,7 +64,7 @@ namespace Neo.UnitTests.VMT
             Assert.AreEqual("{\"type\":\"Array\",\"value\":[{\"type\":\"Integer\",\"value\":\"5\"},{\"type\":\"ByteString\",\"value\":\"aGVsbG8gd29ybGQ=\"},{\"type\":\"ByteString\",\"value\":\"AQID\"},{\"type\":\"Boolean\",\"value\":true}]}", item.ToJson().ToString());
 
             var item2 = new Map();
-            item2[1] = new Pointer(new Script(new byte[0]), 0);
+            item2[1] = new Pointer(new Script(ReadOnlyMemory<byte>.Empty), 0);
 
             Assert.AreEqual("{\"type\":\"Map\",\"value\":[{\"key\":{\"type\":\"Integer\",\"value\":\"1\"},\"value\":{\"type\":\"Pointer\",\"value\":0}}]}", item2.ToJson().ToString());
         }


### PR DESCRIPTION
# Description

Avoid allocating emtpy array.

Use `Array.Empty<Type>()` or `[]` instead.


## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Optimization (the change is only an optimization)
- [x] Style (the change is only a code style for better maintenance or standard purpose)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
