### PR TITLE
[`Optimzie`]: remove `AsParallel` in `Cache`

### DIFF
--- a/benchmarks/Neo.Benchmarks/IO/Benchmarks.Cache.cs
+++ b/benchmarks/Neo.Benchmarks/IO/Benchmarks.Cache.cs
@@ -1,0 +1,48 @@
+// Copyright (C) 2015-2025 The Neo Project.
+//
+// Benchmarks.Cache.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using BenchmarkDotNet.Attributes;
+using Neo.IO.Caching;
+using System.Diagnostics;
+
+namespace Neo.Benchmarks
+{
+    class BecnmarkFIFOCache : FIFOCache<long, long>
+    {
+        public BecnmarkFIFOCache(int maxCapacity) : base(maxCapacity) { }
+
+        protected override long GetKeyForItem(long item) => item;
+    }
+
+    public class Benchmarks_Cache
+    {
+        private readonly BecnmarkFIFOCache _cache = new(100);
+
+        [Benchmark]
+        public void FIFOCacheAdd()
+        {
+            for (int i = 0; i < 1000; i++)
+            {
+                _cache.Add(i);
+            }
+        }
+
+        [Benchmark]
+        public void FIFOCacheContains()
+        {
+            for (long i = 0; i < 1000; i++)
+            {
+                var ok = _cache.TryGet(i, out _);
+                Debug.Assert(ok);
+            }
+        }
+    }
+}

--- a/src/Neo.IO/Caching/Cache.cs
+++ b/src/Neo.IO/Caching/Cache.cs
@@ -93,10 +93,10 @@ namespace Neo.IO.Caching
             {
                 if (InnerDictionary.Count >= _max_capacity)
                 {
-                    //TODO: Perform a performance test on the PLINQ query to determine which algorithm is better here (parallel or not)
-                    foreach (var item_del in InnerDictionary.Values.AsParallel().OrderBy(p => p.Time).Take(InnerDictionary.Count - _max_capacity + 1))
+                    var removedCount = InnerDictionary.Count - _max_capacity + 1;
+                    foreach (var toDelete in InnerDictionary.Values.OrderBy(p => p.Time).Take(removedCount))
                     {
-                        RemoveInternal(item_del);
+                        RemoveInternal(toDelete);
                     }
                 }
                 InnerDictionary.Add(key, new CacheItem(key, item));


### PR DESCRIPTION
# Description

`AsParallel` isn't always a good idea(for example: Each task is very simple).

A simple benchmark case:

With `AsPrallel`
```
  [Host]     : .NET 9.0.1 (9.0.124.61010), Arm64 RyuJIT AdvSIMD
  DefaultJob : .NET 9.0.1 (9.0.124.61010), Arm64 RyuJIT AdvSIMD


| Method    | Mean     | Error   | StdDev  |
|---------- |---------:|--------:|--------:|
| FIFOCache | 117.9 ms | 1.94 ms | 1.81 ms |
```

Without `AsParallel`
```
  [Host]     : .NET 9.0.1 (9.0.124.61010), Arm64 RyuJIT AdvSIMD
  DefaultJob : .NET 9.0.1 (9.0.124.61010), Arm64 RyuJIT AdvSIMD


| Method    | Mean     | Error   | StdDev  |
|---------- |---------:|--------:|--------:|
| FIFOCache | 415.3 us | 2.80 us | 2.62 us |
```


## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
