### PR TITLE
Add build script

### DIFF
--- a/scripts/build-with-plugins.bat
+++ b/scripts/build-with-plugins.bat
@@ -1,0 +1,369 @@
+@echo off
+REM Neo build script with plugin integration v1.1.0
+REM This script builds Neo.CLI and all plugins, organizing them in framework-specific directories
+
+setlocal enabledelayedexpansion
+
+REM Start time measurement
+for /f "tokens=1-4 delims=:.," %%a in ("%time%") do (
+   set /A "start=(((%%a*60)+1%%b %% 100)*60+1%%c %% 100)*100+1%%d %% 100"
+)
+
+echo Neo Build Script with Plugin Integration
+echo.
+
+REM Set the directory variables
+set "SCRIPT_DIR=%~dp0"
+set "ROOT_DIR=%SCRIPT_DIR%.."
+set "BUILD_CONFIG=Release"
+set "OUTPUT_DIR=%ROOT_DIR%\bin"
+set "CLI_PROJECT=%ROOT_DIR%\src\Neo.CLI\Neo.CLI.csproj"
+set "NEO_SOLUTION=%ROOT_DIR%\neo.sln"
+set "PLUGINS_FOUND=0"
+set "PLUGINS_PROCESSED=0"
+
+REM Log file setup
+set "LOG_FILE=%ROOT_DIR%\build.log"
+echo Build started at %date% %time% > "%LOG_FILE%"
+
+REM Extract target framework from Neo.CLI.csproj
+echo Detecting .NET version from Neo.CLI project...
+echo Detecting .NET version from Neo.CLI project... >> "%LOG_FILE%"
+
+if not exist "%CLI_PROJECT%" (
+    echo Error: Could not find Neo.CLI project at %CLI_PROJECT%
+    echo Error: Could not find Neo.CLI project at %CLI_PROJECT% >> "%LOG_FILE%"
+    exit /b 1
+)
+
+REM Find the TargetFramework in the project file
+for /f "tokens=2 delims=<>" %%a in ('findstr /C:"<TargetFramework>" "%CLI_PROJECT%"') do (
+    set "TARGET_FRAMEWORK=%%a"
+)
+
+if not defined TARGET_FRAMEWORK (
+    echo Error: Could not detect target framework from Neo.CLI project
+    echo Falling back to default: net7.0
+    echo Warning: Could not detect target framework, falling back to net7.0 >> "%LOG_FILE%"
+    set "TARGET_FRAMEWORK=net7.0"
+) else (
+    echo Detected target framework: %TARGET_FRAMEWORK%
+    echo Detected target framework: %TARGET_FRAMEWORK% >> "%LOG_FILE%"
+)
+
+echo Root directory: %ROOT_DIR%
+echo Output directory: %OUTPUT_DIR%
+echo Target framework: %TARGET_FRAMEWORK%
+echo.
+
+REM Verify .NET SDK is installed
+echo Verifying .NET SDK installation...
+echo Verifying .NET SDK installation... >> "%LOG_FILE%"
+where dotnet >nul 2>nul
+if %ERRORLEVEL% neq 0 (
+    echo Error: .NET SDK is not installed or not in PATH
+    echo Error: .NET SDK is not installed or not in PATH >> "%LOG_FILE%"
+    exit /b 1
+)
+
+for /f "tokens=*" %%v in ('dotnet --version') do set "DOTNET_VERSION=%%v"
+echo Found .NET SDK version: %DOTNET_VERSION%
+echo Found .NET SDK version: %DOTNET_VERSION% >> "%LOG_FILE%"
+echo.
+
+REM Clean up old build artifacts
+echo Cleaning previous build artifacts...
+echo Cleaning previous build artifacts... >> "%LOG_FILE%"
+if exist "%OUTPUT_DIR%" rmdir /s /q "%OUTPUT_DIR%"
+mkdir "%OUTPUT_DIR%" 2>nul
+echo Clean complete
+echo Clean complete >> "%LOG_FILE%"
+echo.
+
+REM First build the entire solution to ensure dependencies are built
+if exist "%NEO_SOLUTION%" (
+    echo Building entire Neo solution first to resolve dependencies...
+    echo Building entire Neo solution first to resolve dependencies... >> "%LOG_FILE%"
+    dotnet build "%NEO_SOLUTION%" -c %BUILD_CONFIG%
+    if %ERRORLEVEL% neq 0 (
+        echo Failed to build Neo solution
+        echo Failed to build Neo solution >> "%LOG_FILE%"
+        exit /b 1
+    )
+    echo Successfully built Neo solution
+    echo Successfully built Neo solution >> "%LOG_FILE%"
+    echo.
+) else (
+    echo Neo solution file not found. Will attempt to build Neo.CLI directly.
+    echo Neo solution file not found. Will attempt to build Neo.CLI directly. >> "%LOG_FILE%"
+)
+
+REM Build Neo.CLI
+echo Building project: Neo.CLI
+echo Building project: Neo.CLI >> "%LOG_FILE%"
+dotnet build "%CLI_PROJECT%" -c %BUILD_CONFIG%
+if %ERRORLEVEL% neq 0 (
+    echo Failed to build Neo.CLI
+    echo Failed to build Neo.CLI >> "%LOG_FILE%"
+    exit /b 1
+)
+echo Successfully built Neo.CLI
+echo Successfully built Neo.CLI >> "%LOG_FILE%"
+echo.
+
+REM Copy Neo.CLI output to bin directory
+echo Copying Neo.CLI output to bin directory...
+echo Copying Neo.CLI output to bin directory... >> "%LOG_FILE%"
+
+REM Find the Neo.CLI DLL
+call :FindDll "neo-cli.dll"
+set "CLI_DLL=%FOUND_DLL%"
+
+if defined CLI_DLL if exist "!CLI_DLL!" (
+    for %%F in ("!CLI_DLL!") do set "CLI_DIR=%%~dpF"
+    echo Found neo-cli.dll at: !CLI_DIR!
+    echo Found neo-cli.dll at: !CLI_DIR! >> "%LOG_FILE%"
+    xcopy /E /Y "!CLI_DIR!*" "%OUTPUT_DIR%\"
+    echo Neo.CLI copied to output directory
+    echo Neo.CLI copied to output directory >> "%LOG_FILE%"
+) else (
+    echo Error: Could not find neo-cli.dll
+    echo Trying to find any DLLs in the output directories...
+    echo Warning: Could not find neo-cli.dll, searching for any DLLs >> "%LOG_FILE%"
+
+    REM Try to find any DLL in the build output directories
+    for /r "%ROOT_DIR%" %%F in (*.dll) do (
+        set "ANY_DLL=%%F"
+        if "!ANY_DLL!" neq "" (
+            for %%G in ("!ANY_DLL!") do set "ANY_DIR=%%~dpG"
+            echo Found DLLs at: !ANY_DIR!
+            echo Found DLLs at: !ANY_DIR! >> "%LOG_FILE%"
+            xcopy /E /Y "!ANY_DIR!*" "%OUTPUT_DIR%\"
+            echo Neo.CLI copied from found directory
+            echo Neo.CLI copied from found directory >> "%LOG_FILE%"
+            goto :CliCopyDone
+        )
+    )
+
+    echo Failed to locate any build output. Make sure the build succeeded.
+    echo Error: Failed to locate any build output >> "%LOG_FILE%"
+    exit /b 1
+)
+
+:CliCopyDone
+echo.
+
+REM Create plugins directory in the Neo.CLI output directory
+echo Setting up plugins directory...
+echo Setting up plugins directory... >> "%LOG_FILE%"
+
+REM Create the specific Neo.CLI output directory structure
+set "CLI_PLUGINS_DIR=%OUTPUT_DIR%\Neo.CLI\%TARGET_FRAMEWORK%\Plugins"
+mkdir "%CLI_PLUGINS_DIR%" 2>nul
+
+echo Plugins directory created at: %CLI_PLUGINS_DIR%
+echo Plugins directory created at: %CLI_PLUGINS_DIR% >> "%LOG_FILE%"
+echo.
+
+REM Build and copy all plugins
+echo Building and installing plugins...
+echo Building and installing plugins... >> "%LOG_FILE%"
+echo.
+
+REM Find all plugin directories
+for /d %%D in ("%ROOT_DIR%\src\Plugins\*") do (
+    set "PLUGIN_DIR=%%D"
+    set "PLUGIN_DIR_NAME=%%~nxD"
+
+    REM Skip obj directory
+    if "!PLUGIN_DIR_NAME!" == "obj" (
+        echo Skipping !PLUGIN_DIR_NAME! - not a plugin directory
+        echo Skipping !PLUGIN_DIR_NAME! - not a plugin directory >> "%LOG_FILE%"
+    ) else (
+        call :ProcessPluginDirectory "!PLUGIN_DIR!"
+    )
+)
+
+echo All plugins have been built and installed
+echo Found %PLUGINS_FOUND% plugin directories, processed %PLUGINS_PROCESSED% plugin projects
+echo All plugins have been built and installed >> "%LOG_FILE%"
+echo Found %PLUGINS_FOUND% plugin directories, processed %PLUGINS_PROCESSED% plugin projects >> "%LOG_FILE%"
+echo.
+
+REM Calculate build time
+for /f "tokens=1-4 delims=:.," %%a in ("%time%") do (
+   set /A "end=(((%%a*60)+1%%b %% 100)*60+1%%c %% 100)*100+1%%d %% 100"
+)
+set /A elapsed=end-start
+set /A hh=elapsed/(60*60*100), rest=elapsed%%(60*60*100), mm=rest/(60*100), rest%%=60*100, ss=rest/100, cc=rest%%100
+if %hh% lss 10 set hh=0%hh%
+if %mm% lss 10 set mm=0%mm%
+if %ss% lss 10 set ss=0%ss%
+if %cc% lss 10 set cc=0%cc%
+set DURATION=%hh%:%mm%:%ss%.%cc%
+
+echo Build completed successfully in %DURATION%!
+echo Build completed successfully in %DURATION%! >> "%LOG_FILE%"
+echo.
+
+echo Build completed successfully!
+echo The Neo node with plugins is available at: %OUTPUT_DIR%\Neo.CLI\%TARGET_FRAMEWORK%
+echo You can run it using: cd %OUTPUT_DIR%\Neo.CLI\%TARGET_FRAMEWORK% ^&^& dotnet neo-cli.dll
+
+REM Verify essential plugins were installed
+set "ESSENTIAL_PLUGINS=DBFTPlugin ApplicationLogs RpcServer"
+for %%P in (%ESSENTIAL_PLUGINS%) do (
+    if not exist "%CLI_PLUGINS_DIR%\%%P\%%P.dll" (
+        echo Warning: Essential plugin %%P is missing
+        echo Warning: Essential plugin %%P is missing >> "%LOG_FILE%"
+    )
+)
+
+exit /b 0
+
+:FindDll
+setlocal
+set "DLL_NAME=%~1"
+
+REM First check if the DLL is already in the main bin directory
+if exist "%OUTPUT_DIR%\%DLL_NAME%" (
+    endlocal & set "FOUND_DLL=%OUTPUT_DIR%\%DLL_NAME%"
+    exit /b 0
+)
+
+REM Check in direct project folders under bin
+for /d %%D in ("%OUTPUT_DIR%\*") do (
+    set "PROJECT_DIR=%%D"
+    set "PROJECT_DIR_NAME=%%~nxD"
+
+    if exist "!PROJECT_DIR!\%DLL_NAME%" (
+        endlocal & set "FOUND_DLL=!PROJECT_DIR!\%DLL_NAME%"
+        exit /b 0
+    )
+
+    REM Also check for nested target framework folders
+    for /d %%F in ("!PROJECT_DIR!\*") do (
+        if exist "%%F\%DLL_NAME%" (
+            endlocal & set "FOUND_DLL=%%F\%DLL_NAME%"
+            exit /b 0
+        )
+    )
+)
+
+REM Common locations to check in the src directory
+set "SRC_DIR=%ROOT_DIR%\src"
+set "PATTERNS=*\bin\%BUILD_CONFIG%\%TARGET_FRAMEWORK%\%DLL_NAME% *\bin\%BUILD_CONFIG%\%DLL_NAME% *\*\bin\%BUILD_CONFIG%\%TARGET_FRAMEWORK%\%DLL_NAME% *\*\bin\%BUILD_CONFIG%\%DLL_NAME%"
+
+REM Check each pattern
+for %%P in (%PATTERNS%) do (
+    for /r "%SRC_DIR%" %%F in (%%P) do (
+        if exist "%%F" (
+            endlocal & set "FOUND_DLL=%%F"
+            exit /b 0
+        )
+    )
+)
+
+REM As a last resort, search the entire src directory
+echo Searching for %DLL_NAME% in src directory...
+for /r "%SRC_DIR%" %%F in (%DLL_NAME%) do (
+    if exist "%%F" (
+        endlocal & set "FOUND_DLL=%%F"
+        exit /b 0
+    )
+)
+
+endlocal & set "FOUND_DLL="
+exit /b 0
+
+:ProcessPluginDirectory
+setlocal EnableDelayedExpansion
+set "PLUGIN_DIR=%~1"
+set /a PLUGINS_FOUND+=1
+
+REM Find all .csproj files in the directory
+set "FOUND_PROJECTS=0"
+for %%P in ("%PLUGIN_DIR%\*.csproj") do (
+    set "PROJECT_FILE=%%P"
+    set "PROJECT_NAME=%%~nP"
+
+    REM Build the plugin
+    echo Building project: !PROJECT_NAME!
+    echo Building project: !PROJECT_NAME! >> "%LOG_FILE%"
+    dotnet build "!PROJECT_FILE!" -c %BUILD_CONFIG%
+    if %ERRORLEVEL% neq 0 (
+        echo Failed to build !PROJECT_NAME!
+        echo Failed to build !PROJECT_NAME! >> "%LOG_FILE%"
+        exit /b 1
+    )
+    echo Successfully built !PROJECT_NAME!
+    echo Successfully built !PROJECT_NAME! >> "%LOG_FILE%"
+
+    REM Find the DLL file
+    call :FindDll "!PROJECT_NAME!.dll"
+    set "PLUGIN_DLL=%FOUND_DLL%"
+
+    REM Create a plugin-specific folder in the Neo.CLI's plugins directory
+    set "PLUGIN_SPECIFIC_DIR=%CLI_PLUGINS_DIR%\!PROJECT_NAME!"
+    mkdir "%PLUGIN_SPECIFIC_DIR%" 2>nul
+
+    REM Copy the plugin DLL to its specific directory
+    if defined PLUGIN_DLL if exist "!PLUGIN_DLL!" (
+        echo Copying !PROJECT_NAME!.dll to %PLUGIN_SPECIFIC_DIR%\ from !PLUGIN_DLL!
+        echo Copying !PROJECT_NAME!.dll to %PLUGIN_SPECIFIC_DIR%\ from !PLUGIN_DLL! >> "%LOG_FILE%"
+        copy /Y "!PLUGIN_DLL!" "%PLUGIN_SPECIFIC_DIR%\"
+
+        REM Verify the copy was successful
+        if not exist "%PLUGIN_SPECIFIC_DIR%\!PROJECT_NAME!.dll" (
+            echo Error: Failed to copy !PROJECT_NAME!.dll to %PLUGIN_SPECIFIC_DIR%
+            echo Error: Failed to copy !PROJECT_NAME!.dll to %PLUGIN_SPECIFIC_DIR% >> "%LOG_FILE%"
+            exit /b 1
+        )
+    ) else (
+        echo Warning: Could not find DLL for !PROJECT_NAME!
+        echo Warning: Could not find DLL for !PROJECT_NAME! >> "%LOG_FILE%"
+    )
+
+    REM Look for the config file in multiple locations
+    set "PLUGIN_CONFIG=%PLUGIN_DIR%\!PROJECT_NAME!.json"
+    if not exist "!PLUGIN_CONFIG!" (
+        REM Try to find the config elsewhere
+        for /r "%PLUGIN_DIR%" %%F in (!PROJECT_NAME!.json) do (
+            set "PLUGIN_CONFIG=%%F"
+            goto :FoundConfig
+        )
+    )
+
+    :FoundConfig
+    REM Copy the plugin config if it exists
+    if exist "!PLUGIN_CONFIG!" (
+        echo Copying !PROJECT_NAME!.json to %PLUGIN_SPECIFIC_DIR%\ from !PLUGIN_CONFIG!
+        echo Copying !PROJECT_NAME!.json to %PLUGIN_SPECIFIC_DIR%\ from !PLUGIN_CONFIG! >> "%LOG_FILE%"
+        copy /Y "!PLUGIN_CONFIG!" "%PLUGIN_SPECIFIC_DIR%\"
+
+        REM Verify the copy was successful
+        if not exist "%PLUGIN_SPECIFIC_DIR%\!PROJECT_NAME!.json" (
+            echo Error: Failed to copy !PROJECT_NAME!.json to %PLUGIN_SPECIFIC_DIR%
+            echo Error: Failed to copy !PROJECT_NAME!.json to %PLUGIN_SPECIFIC_DIR% >> "%LOG_FILE%"
+            exit /b 1
+        )
+    ) else (
+        echo No config file found for !PROJECT_NAME!, skipping config copy
+        echo No config file found for !PROJECT_NAME!, skipping config copy >> "%LOG_FILE%"
+    )
+
+    echo Plugin !PROJECT_NAME! installed
+    echo Plugin !PROJECT_NAME! installed >> "%LOG_FILE%"
+    echo.
+
+    set /a FOUND_PROJECTS+=1
+    set /a PLUGINS_PROCESSED+=1
+)
+
+if !FOUND_PROJECTS! equ 0 (
+    echo No project files found in !PLUGIN_DIR!, skipping
+    echo No project files found in !PLUGIN_DIR!, skipping >> "%LOG_FILE%"
+)
+
+endlocal & set /a PLUGINS_PROCESSED=%PLUGINS_PROCESSED% & set /a PLUGINS_FOUND=%PLUGINS_FOUND%
+exit /b 0

--- a/scripts/build-with-plugins.md
+++ b/scripts/build-with-plugins.md
@@ -1,0 +1,176 @@
+# Neo Build Scripts with Plugin Integration
+
+This directory contains scripts to build Neo.CLI and all its plugins, organizing them in framework-specific directories.
+
+## Available Scripts
+
+- `build-with-plugins.sh` - For Linux/macOS (Version 1.1.0)
+- `build-with-plugins.bat` - For Windows (Version 1.1.0)
+
+## Features
+
+- Automatically builds Neo.CLI project
+- Builds the entire Neo solution first to ensure all dependencies are resolved
+- Detects the .NET version from the project file
+- Builds all plugins in the src/Plugins directory
+- Places each plugin in its own subdirectory under the Neo.CLI's framework-specific Plugins directory
+- Copies plugin configuration files automatically
+- Smart DLL detection that searches multiple locations:
+  - Main output directory (bin/)
+  - Project-specific folders under bin/ (e.g., bin/Neo.Plugins.ApplicationLogs/)
+  - Framework-specific folders (e.g., bin/Neo.CLI/net9.0/)
+  - Source directory build outputs
+- Comprehensive logging to build.log
+- Build time measurement
+- Essential plugin verification
+- .NET SDK version checking
+- File copy verification
+- Always performs a clean build to ensure up-to-date files
+
+## Usage
+
+### On Linux/macOS:
+
+```bash
+cd scripts
+./build-with-plugins.sh
+
+# View build log
+tail -f ../build.log
+```
+
+### On Windows:
+
+```cmd
+cd scripts
+build-with-plugins.bat
+
+REM View build log
+type ..\build.log
+```
+
+## Output Structure
+
+After running the script, the bin/ directory will have the following structure:
+
+```
+bin/
+└── Neo.CLI/
+    └── net9.0/    (or other detected framework version)
+        ├── neo-cli.dll (and other core files)
+        └── Plugins/
+            ├── DBFTPlugin/
+            │   ├── DBFTPlugin.dll
+            │   └── DBFTPlugin.json (if available)
+            ├── RpcServer/
+            │   ├── RpcServer.dll
+            │   └── RpcServer.json (if available)
+            └── ... (other plugin directories)
+```
+
+## Running Neo with Plugins
+
+After the build is complete, you can run Neo with all its plugins using:
+
+```bash
+cd bin/Neo.CLI/net9.0  # Replace net9.0 with your framework version
+dotnet neo-cli.dll
+```
+
+## Process Overview
+
+1. Verify .NET SDK installation
+2. Clean previous build artifacts
+3. Detect .NET version from Neo.CLI.csproj
+4. Build the entire Neo solution first to ensure all dependencies are resolved
+5. Build Neo.CLI project
+6. Copy Neo.CLI output to the bin directory
+7. Create the framework-specific Plugins directory (bin/Neo.CLI/[framework]/Plugins)
+8. Find all plugin projects within the src/Plugins directory (detecting all .csproj files)
+9. Build each plugin project
+10. Create a plugin-specific subdirectory for each plugin
+11. Copy each plugin's DLL to its specific directory under Plugins
+12. Copy each plugin's configuration file (if it exists) to the same directory
+13. Verify essential plugins were installed
+14. Measure and report build time
+15. Generate detailed build log
+
+## Plugin Detection
+
+The scripts handle plugin detection by:
+
+- Processing each subdirectory under src/Plugins
+- Finding all .csproj files in each directory
+- Building each project file found
+- Creating a directory for each plugin under the Plugins directory
+- Copying DLLs and config files to their respective plugin directories
+
+This approach ensures all plugins are properly built and copied, even when:
+- A plugin project name differs from its directory name
+- Multiple plugin projects exist in a single directory
+- Non-standard naming conventions are used
+
+## Directory Structure After Build
+
+```
+/bin
+  └── Neo.CLI/
+      └── net9.0/    (or other detected framework version)
+          ├── neo-cli.dll (and other core files)
+          └── Plugins/
+              ├── DBFTPlugin/
+              │   ├── DBFTPlugin.dll
+              │   └── DBFTPlugin.json
+              ├── RpcServer/
+              │   ├── RpcServer.dll
+              │   └── RpcServer.json
+              └── ... (other plugin directories)
+```
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Missing .NET SDK**:
+   - Error: `.NET SDK is not installed or not in PATH`
+   - Solution: Install the correct .NET SDK version (see project requirements)
+
+2. **Plugin not found**:
+   - Error: `Could not find DLL for [PluginName]`
+   - Solution: Verify the plugin project builds successfully
+
+3. **File copy failures**:
+   - Error: `Failed to copy [file] to [destination]`
+   - Solution: Check file permissions and disk space
+
+4. **Missing essential plugin**:
+   - Warning: `Essential plugin [PluginName] is missing`
+   - Solution: Ensure the essential plugin project exists and builds correctly
+
+5. **Dependency resolution errors**:
+   - Error: `Metadata file 'xxx.dll' could not be found`
+   - Solution: This should be automatically resolved by building the entire solution first
+
+### Checking Build Logs
+
+Both scripts create a `build.log` file in the project root with detailed output:
+
+```bash
+# View last 20 lines of log
+tail -20 build.log
+
+# Search for errors
+grep -i error build.log
+```
+
+## Notes
+
+- The scripts will automatically detect the target .NET framework version from the Neo.CLI project file
+- If the target framework cannot be detected, the scripts will fall back to a default of "net7.0"
+- The scripts will overwrite existing files if they already exist in the destination directories
+- If a plugin doesn't have a corresponding JSON configuration file, the script will skip copying the config but will still copy the DLL
+- The output will be placed in the `/bin/Neo.CLI/[framework]` directory at the root of your Neo repository
+- Each plugin will be placed in its own subdirectory under `/bin/Neo.CLI/[framework]/Plugins` with its DLL and config files
+- Essential plugins (DBFTPlugin, ApplicationLogs, RpcServer) are verified after build
+- Build time is measured and reported
+- A complete build log is generated at the root of the repository

--- a/scripts/build-with-plugins.sh
+++ b/scripts/build-with-plugins.sh
@@ -1,0 +1,359 @@
+#!/bin/bash
+# Neo build script with plugin integration v1.1.0
+# This script builds Neo.CLI and all plugins, organizing them in framework-specific directories
+
+# Start time measurement
+START_TIME=$(date +%s)
+
+# Set bash to exit on error
+set -e
+
+# Change to the root directory of the Neo project
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+cd "$ROOT_DIR"
+
+# Colors for terminal output
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+# Log file setup
+LOG_FILE="$ROOT_DIR/build.log"
+echo "Build started at $(date)" > "$LOG_FILE"
+
+# Configuration
+BUILD_CONFIG="Release"
+OUTPUT_DIR="$ROOT_DIR/bin"
+CLI_PROJECT="$ROOT_DIR/src/Neo.CLI/Neo.CLI.csproj"
+NEO_SOLUTION="$ROOT_DIR/neo.sln"
+
+# Extract target framework from Neo.CLI.csproj
+echo -e "${YELLOW}Detecting .NET version from Neo.CLI project...${NC}"
+echo "Detecting .NET version from Neo.CLI project..." >> "$LOG_FILE"
+
+if [ ! -f "$CLI_PROJECT" ]; then
+    echo -e "${RED}Error: Could not find Neo.CLI project at $CLI_PROJECT${NC}"
+    echo "Error: Could not find Neo.CLI project at $CLI_PROJECT" >> "$LOG_FILE"
+    exit 1
+fi
+
+TARGET_FRAMEWORK=$(grep -o '<TargetFramework>.*</TargetFramework>' "$CLI_PROJECT" | sed 's/<TargetFramework>\(.*\)<\/TargetFramework>/\1/')
+
+if [ -z "$TARGET_FRAMEWORK" ]; then
+    echo -e "${RED}Error: Could not detect target framework from Neo.CLI project${NC}"
+    echo -e "${YELLOW}Falling back to default: net7.0${NC}"
+    echo -e "${YELLOW}Falling back to default: net7.0${NC}" >> "$LOG_FILE"
+    TARGET_FRAMEWORK="net7.0"
+else
+    echo -e "${GREEN}Detected target framework: $TARGET_FRAMEWORK${NC}"
+    echo "Detected target framework: $TARGET_FRAMEWORK" >> "$LOG_FILE"
+fi
+
+echo -e "${GREEN}Neo Build Script with Plugin Integration${NC}"
+echo "Root directory: $ROOT_DIR"
+echo "Output directory: $OUTPUT_DIR"
+echo "Target framework: $TARGET_FRAMEWORK"
+echo
+
+# Verify .NET SDK is installed
+echo -e "${YELLOW}Verifying .NET SDK installation...${NC}"
+if ! command -v dotnet &> /dev/null; then
+    echo -e "${RED}Error: .NET SDK is not installed or not in PATH${NC}"
+    echo "Error: .NET SDK is not installed or not in PATH" >> "$LOG_FILE"
+    exit 1
+fi
+
+DOTNET_VERSION=$(dotnet --version)
+echo -e "${GREEN}Found .NET SDK version: $DOTNET_VERSION${NC}"
+echo "Found .NET SDK version: $DOTNET_VERSION" >> "$LOG_FILE"
+
+# Clean up old build artifacts
+echo -e "${YELLOW}Cleaning previous build artifacts...${NC}"
+echo "Cleaning previous build artifacts..." >> "$LOG_FILE"
+rm -rf "$OUTPUT_DIR"
+mkdir -p "$OUTPUT_DIR"
+echo -e "${GREEN}Clean complete${NC}"
+echo "Clean complete" >> "$LOG_FILE"
+echo
+
+# First build the entire solution to ensure dependencies are built
+if [ -f "$NEO_SOLUTION" ]; then
+    echo -e "${YELLOW}Building entire Neo solution first to resolve dependencies...${NC}"
+    echo "Building entire Neo solution first to resolve dependencies..." >> "$LOG_FILE"
+    dotnet build "$NEO_SOLUTION" -c "$BUILD_CONFIG"
+    if [ $? -ne 0 ]; then
+        echo -e "${RED}Failed to build Neo solution${NC}"
+        echo "Failed to build Neo solution" >> "$LOG_FILE"
+        exit 1
+    fi
+    echo -e "${GREEN}Successfully built Neo solution${NC}"
+    echo "Successfully built Neo solution" >> "$LOG_FILE"
+    echo
+else
+    echo -e "${YELLOW}Neo solution file not found. Will attempt to build Neo.CLI directly.${NC}"
+    echo "Neo solution file not found. Will attempt to build Neo.CLI directly." >> "$LOG_FILE"
+fi
+
+# Function to build a project
+build_project() {
+    local project_path="$1"
+    local project_name="$(basename "${project_path%.*}")"
+
+    echo -e "${YELLOW}Building project: ${project_name}${NC}"
+    echo "Building project: ${project_name}" >> "$LOG_FILE"
+
+    dotnet build "$project_path" -c "$BUILD_CONFIG"
+
+    if [ $? -ne 0 ]; then
+        echo -e "${RED}Failed to build ${project_name}${NC}"
+        echo "Failed to build ${project_name}" >> "$LOG_FILE"
+        exit 1
+    fi
+
+    echo -e "${GREEN}Successfully built ${project_name}${NC}"
+    echo "Successfully built ${project_name}" >> "$LOG_FILE"
+    echo
+}
+
+# Function to find a DLL file in the bin directory
+find_dll() {
+    local dll_name="$1"
+
+    # First, check if the DLL is already in the main bin directory
+    if [ -d "$OUTPUT_DIR" ]; then
+        local root_bin_dll="$OUTPUT_DIR/$dll_name"
+        if [ -f "$root_bin_dll" ]; then
+            echo "$root_bin_dll"
+            return
+        fi
+
+        # Check in direct project folders under bin
+        for project_dir in "$OUTPUT_DIR"/* ; do
+            if [ -d "$project_dir" ]; then
+                local project_dll="$project_dir/$dll_name"
+                if [ -f "$project_dll" ]; then
+                    echo "$project_dll"
+                    return
+                fi
+
+                # Also check for nested target framework folders
+                for framework_dir in "$project_dir"/* ; do
+                    if [ -d "$framework_dir" ]; then
+                        local framework_dll="$framework_dir/$dll_name"
+                        if [ -f "$framework_dll" ]; then
+                            echo "$framework_dll"
+                            return
+                        fi
+                    fi
+                done
+            fi
+        done
+    fi
+
+    # If not found in bin, look in the src directory
+    local base_dir="$ROOT_DIR/src"
+
+    # List of common build output directories to search in order
+    local search_dirs=(
+        "${base_dir}/*/bin/${BUILD_CONFIG}/${TARGET_FRAMEWORK}"
+        "${base_dir}/*/bin/${BUILD_CONFIG}"
+        "${base_dir}/*/*/bin/${BUILD_CONFIG}/${TARGET_FRAMEWORK}"
+        "${base_dir}/*/*/bin/${BUILD_CONFIG}"
+    )
+
+    # Try the common directories
+    for dir_pattern in "${search_dirs[@]}"; do
+        for dir in $dir_pattern; do
+            if [ -d "$dir" ] && [ -f "${dir}/${dll_name}" ]; then
+                echo "${dir}/${dll_name}"
+                return
+            fi
+        done
+    done
+
+    # If not found, do a recursive search through src
+    echo -e "${YELLOW}Searching for ${dll_name} in src directory...${NC}"
+    local found_dll=$(find "${base_dir}" -name "${dll_name}" -type f 2>/dev/null | head -1)
+
+    if [ -n "$found_dll" ]; then
+        echo "$found_dll"
+    else
+        echo ""
+    fi
+}
+
+# Build Neo.CLI
+build_project "$CLI_PROJECT"
+
+# Copy Neo.CLI output to bin directory
+echo -e "${YELLOW}Copying Neo.CLI output to bin directory...${NC}"
+echo "Copying Neo.CLI output to bin directory..." >> "$LOG_FILE"
+
+# Find the Neo.CLI DLL
+CLI_DLL=$(find_dll "neo-cli.dll")
+
+if [ -n "$CLI_DLL" ] && [ -f "$CLI_DLL" ]; then
+    CLI_DIR=$(dirname "$CLI_DLL")
+    echo -e "${GREEN}Found neo-cli.dll at: $CLI_DIR${NC}"
+    echo "Found neo-cli.dll at: $CLI_DIR" >> "$LOG_FILE"
+    cp -r "$CLI_DIR/"* "$OUTPUT_DIR/"
+    echo -e "${GREEN}Neo.CLI copied to output directory${NC}"
+    echo "Neo.CLI copied to output directory" >> "$LOG_FILE"
+else
+    echo -e "${RED}Error: Could not find neo-cli.dll${NC}"
+    echo -e "${YELLOW}Trying to find any DLLs in the output directories...${NC}"
+    echo "Warning: Could not find neo-cli.dll, searching for any DLLs" >> "$LOG_FILE"
+
+    # Try to find any DLL to determine the output location
+    ANY_DLL=$(find "$ROOT_DIR" -path "*/bin/$BUILD_CONFIG/*" -name "*.dll" -type f | head -1)
+    if [ -n "$ANY_DLL" ]; then
+        ANY_DIR=$(dirname "$ANY_DLL")
+        echo -e "${GREEN}Found DLLs at: $ANY_DIR${NC}"
+        echo "Found DLLs at: $ANY_DIR" >> "$LOG_FILE"
+        cp -r "$ANY_DIR/"* "$OUTPUT_DIR/"
+        echo -e "${GREEN}Neo.CLI copied from found directory${NC}"
+        echo "Neo.CLI copied from found directory" >> "$LOG_FILE"
+    else
+        echo -e "${RED}Failed to locate any build output. Make sure the build succeeded.${NC}"
+        echo "Error: Failed to locate any build output" >> "$LOG_FILE"
+        exit 1
+    fi
+fi
+echo
+
+# Create plugins directory in the Neo.CLI output directory
+echo -e "${YELLOW}Setting up plugins directory...${NC}"
+echo "Setting up plugins directory..." >> "$LOG_FILE"
+
+# Create the specific Neo.CLI output directory structure
+CLI_PLUGINS_DIR="$OUTPUT_DIR/Neo.CLI/$TARGET_FRAMEWORK/Plugins"
+mkdir -p "$CLI_PLUGINS_DIR"
+
+echo -e "${GREEN}Plugins directory created at: $CLI_PLUGINS_DIR${NC}"
+echo "Plugins directory created at: $CLI_PLUGINS_DIR" >> "$LOG_FILE"
+echo
+
+# Build and copy all plugins
+echo -e "${YELLOW}Building and installing plugins...${NC}"
+echo "Building and installing plugins..." >> "$LOG_FILE"
+
+# Get all plugin directories
+PLUGIN_DIRS=$(find "$ROOT_DIR/src/Plugins" -maxdepth 1 -mindepth 1 -type d | sort)
+
+# Count of plugins found and processed
+PLUGINS_FOUND=0
+PLUGINS_PROCESSED=0
+
+# Process each plugin directory
+for plugin_dir in $PLUGIN_DIRS; do
+    plugin_dir_name="$(basename "$plugin_dir")"
+
+    # Skip obj directory
+    if [[ "$plugin_dir_name" == "obj" ]]; then
+        continue
+    fi
+
+    # Find all .csproj files in the directory
+    project_files=$(find "$plugin_dir" -maxdepth 1 -name "*.csproj")
+
+    if [ -z "$project_files" ]; then
+        echo "No project files found in $plugin_dir_name, skipping"
+        echo "No project files found in $plugin_dir_name, skipping" >> "$LOG_FILE"
+        continue
+    fi
+
+    PLUGINS_FOUND=$((PLUGINS_FOUND + 1))
+
+    # Build and copy each project in the directory
+    for project_file in $project_files; do
+        # Build the plugin
+        build_project "$project_file"
+
+        plugin_name="$(basename "${project_file%.*}")"
+        plugin_dll_name="${plugin_name}.dll"
+
+        # Find the DLL file
+        plugin_dll=$(find_dll "$plugin_dll_name")
+
+        # Create a plugin-specific folder in the Neo.CLI's plugins directory
+        plugin_specific_dir="$CLI_PLUGINS_DIR/$plugin_name"
+        mkdir -p "$plugin_specific_dir"
+
+        # Copy the plugin DLL to its specific directory
+        if [ -n "$plugin_dll" ] && [ -f "$plugin_dll" ]; then
+            echo "Copying $plugin_dll_name to $plugin_specific_dir from $plugin_dll"
+            echo "Copying $plugin_dll_name to $plugin_specific_dir from $plugin_dll" >> "$LOG_FILE"
+            cp "$plugin_dll" "$plugin_specific_dir/"
+
+            # Verify the copy was successful
+            if [ ! -f "$plugin_specific_dir/$plugin_dll_name" ]; then
+                echo -e "${RED}Error: Failed to copy $plugin_dll_name to $plugin_specific_dir${NC}"
+                echo "Error: Failed to copy $plugin_dll_name to $plugin_specific_dir" >> "$LOG_FILE"
+                exit 1
+            fi
+        else
+            echo -e "${RED}Warning: Could not find DLL for $plugin_name${NC}"
+            echo "Warning: Could not find DLL for $plugin_name" >> "$LOG_FILE"
+        fi
+
+        # Look for the config file in multiple locations
+        plugin_config="$plugin_dir/$plugin_name.json"
+        if [ ! -f "$plugin_config" ]; then
+            # Try alternative locations
+            alt_config=$(find "$plugin_dir" -name "${plugin_name}.json" -type f | head -1)
+            if [ -n "$alt_config" ]; then
+                plugin_config="$alt_config"
+            fi
+        fi
+
+        # Copy the plugin config if it exists
+        if [ -f "$plugin_config" ]; then
+            echo "Copying ${plugin_name}.json to $plugin_specific_dir from $plugin_config"
+            echo "Copying ${plugin_name}.json to $plugin_specific_dir from $plugin_config" >> "$LOG_FILE"
+            cp "$plugin_config" "$plugin_specific_dir/"
+
+            # Verify the copy was successful
+            if [ ! -f "$plugin_specific_dir/$plugin_name.json" ]; then
+                echo -e "${RED}Error: Failed to copy $plugin_name.json to $plugin_specific_dir${NC}"
+                echo "Error: Failed to copy $plugin_name.json to $plugin_specific_dir" >> "$LOG_FILE"
+                exit 1
+            fi
+        else
+            echo "No config file found for $plugin_name, skipping config copy"
+            echo "No config file found for $plugin_name, skipping config copy" >> "$LOG_FILE"
+        fi
+
+        echo -e "${GREEN}Plugin $plugin_name installed${NC}"
+        echo "Plugin $plugin_name installed" >> "$LOG_FILE"
+        echo
+
+        PLUGINS_PROCESSED=$((PLUGINS_PROCESSED + 1))
+    done
+done
+
+echo -e "${GREEN}All plugins have been built and installed${NC}"
+echo -e "Found $PLUGINS_FOUND plugin directories, processed $PLUGINS_PROCESSED plugin projects"
+echo "All plugins have been built and installed" >> "$LOG_FILE"
+echo "Found $PLUGINS_FOUND plugin directories, processed $PLUGINS_PROCESSED plugin projects" >> "$LOG_FILE"
+echo
+
+# Calculate build time
+END_TIME=$(date +%s)
+BUILD_TIME=$((END_TIME - START_TIME))
+echo -e "${GREEN}Build completed successfully in ${BUILD_TIME} seconds!${NC}"
+echo "Build completed successfully in ${BUILD_TIME} seconds!" >> "$LOG_FILE"
+
+echo -e "${GREEN}Build completed successfully!${NC}"
+echo "The Neo node with plugins is available at: $OUTPUT_DIR/Neo.CLI/$TARGET_FRAMEWORK"
+echo "You can run it using: cd $OUTPUT_DIR/Neo.CLI/$TARGET_FRAMEWORK && dotnet neo-cli.dll"
+
+# Verify essential plugins were installed
+ESSENTIAL_PLUGINS=("DBFTPlugin" "ApplicationLogs" "RpcServer")
+for plugin in "${ESSENTIAL_PLUGINS[@]}"; do
+    if [ ! -f "$CLI_PLUGINS_DIR/$plugin/$plugin.dll" ]; then
+        echo -e "${YELLOW}Warning: Essential plugin $plugin is missing${NC}"
+        echo "Warning: Essential plugin $plugin is missing" >> "$LOG_FILE"
+    fi
+done


### PR DESCRIPTION
By running this script, plugins are directly built into the Neo.CLI, such that we can directly test with the latest udpate in the plugin. 


## Overview
This PR implements a comprehensive build system for Neo N3 with improved plugin integration. The scripts automate building Neo.CLI and all its plugins, ensuring they are organized correctly for proper loading and execution.

## Key Features
- **Dependency Resolution**: Builds the entire Neo solution first to resolve dependency issues
- **Framework Detection**: Automatically detects the .NET target framework from project files
- **Plugin Organization**: Places each plugin in its dedicated subdirectory under the Neo.CLI's Plugins folder
- **Observability**: Comprehensive logging to build.log with detailed feedback and timing information
- **Verification**: Essential plugin verification ensures critical components are properly built
- **Reliability**: File copy verification and smart DLL detection across multiple locations
- **Cross-Platform**: Full support for both Windows (batch) and Linux/macOS (bash) environments

## Technical Details
- The build system first cleans previous artifacts and builds the entire Neo solution
- Neo.CLI output is copied to a structured directory layout at bin/Neo.CLI/[framework]
- Plugins are built and placed in bin/Neo.CLI/[framework]/Plugins/[PluginName]
- Configuration files are automatically located and copied alongside their DLLs
- DLL detection logic searches multiple common locations to ensure files are found

## Documentation
The PR includes comprehensive documentation in `scripts/build-with-plugins.md` covering:
- Usage instructions for both platforms
- Expected directory structure
- Process overview and troubleshooting guidance
- Example commands for examining build logs

## Testing Performed
- Successfully built Neo.CLI with all plugins on Windows and macOS
- Verified correct framework detection and plugin organization
- Tested error handling with various edge cases
- Ensured essential plugins (DBFTPlugin, ApplicationLogs, RpcServer) are properly verified

## How to Use
```bash
# Linux/macOS
cd scripts
./build-with-plugins.sh

# Windows
cd scripts
build-with-plugins.bat
```
