### PR TITLE
config: upgrade NeoFS chains protocol configuration

### DIFF
--- a/src/Neo.CLI/CLI/MainService.CommandLine.cs
+++ b/src/Neo.CLI/CLI/MainService.CommandLine.cs
@@ -62,6 +62,7 @@ namespace Neo.CLI
                 MaxTransactionsPerBlock = tempSetting.MaxTransactionsPerBlock,
                 MemoryPoolMaxTransactions = tempSetting.MemoryPoolMaxTransactions,
                 MaxTraceableBlocks = tempSetting.MaxTraceableBlocks,
+                MaxValidUntilBlockIncrement = tempSetting.MaxValidUntilBlockIncrement,
                 InitialGasDistribution = tempSetting.InitialGasDistribution,
                 Hardforks = tempSetting.Hardforks
             };

--- a/src/Neo.CLI/config.fs.mainnet.json
+++ b/src/Neo.CLI/config.fs.mainnet.json
@@ -31,7 +31,7 @@
   "ProtocolConfiguration": {
     "Network": 91414437,
     "AddressVersion": 53,
-    "MillisecondsPerBlock": 15000,
+    "MillisecondsPerBlock": 1000,
     "MaxTransactionsPerBlock": 512,
     "MemoryPoolMaxTransactions": 50000,
     "MaxTraceableBlocks": 17280,

--- a/src/Neo.CLI/config.fs.mainnet.json
+++ b/src/Neo.CLI/config.fs.mainnet.json
@@ -35,6 +35,7 @@
     "MaxTransactionsPerBlock": 512,
     "MemoryPoolMaxTransactions": 50000,
     "MaxTraceableBlocks": 17280,
+    "MaxValidUntilBlockIncrement": 8640,
     "InitialGasDistribution": 5200000000000000,
     "ValidatorsCount": 7,
     "Hardforks": {

--- a/src/Neo.CLI/config.fs.testnet.json
+++ b/src/Neo.CLI/config.fs.testnet.json
@@ -35,6 +35,7 @@
     "MaxTransactionsPerBlock": 512,
     "MemoryPoolMaxTransactions": 50000,
     "MaxTraceableBlocks": 17280,
+    "MaxValidUntilBlockIncrement": 8640,
     "InitialGasDistribution": 5200000000000000,
     "ValidatorsCount": 7,
     "StandbyCommittee": [

--- a/src/Neo.CLI/config.fs.testnet.json
+++ b/src/Neo.CLI/config.fs.testnet.json
@@ -31,7 +31,7 @@
   "ProtocolConfiguration": {
     "Network": 91466898,
     "AddressVersion": 53,
-    "MillisecondsPerBlock": 15000,
+    "MillisecondsPerBlock": 1000,
     "MaxTransactionsPerBlock": 512,
     "MemoryPoolMaxTransactions": 50000,
     "MaxTraceableBlocks": 17280,

--- a/src/Neo/ProtocolSettings.cs
+++ b/src/Neo/ProtocolSettings.cs
@@ -70,7 +70,7 @@ namespace Neo
         /// <summary>
         /// The maximum increment of the <see cref="Transaction.ValidUntilBlock"/> field.
         /// </summary>
-        public uint MaxValidUntilBlockIncrement => 86400000 / MillisecondsPerBlock;
+        public uint MaxValidUntilBlockIncrement { get; init; }
 
         /// <summary>
         /// Indicates the maximum number of transactions that can be contained in a block.
@@ -116,6 +116,7 @@ namespace Neo
             SeedList = Array.Empty<string>(),
             MillisecondsPerBlock = 15000,
             MaxTransactionsPerBlock = 512,
+            MaxValidUntilBlockIncrement = 86400000 / 15000,
             MemoryPoolMaxTransactions = 50_000,
             MaxTraceableBlocks = 2_102_400,
             InitialGasDistribution = 52_000_000_00000000,
@@ -211,6 +212,7 @@ namespace Neo
                 MaxTransactionsPerBlock = section.GetValue("MaxTransactionsPerBlock", Default.MaxTransactionsPerBlock),
                 MemoryPoolMaxTransactions = section.GetValue("MemoryPoolMaxTransactions", Default.MemoryPoolMaxTransactions),
                 MaxTraceableBlocks = section.GetValue("MaxTraceableBlocks", Default.MaxTraceableBlocks),
+                MaxValidUntilBlockIncrement = section.GetValue("MaxValidUntilBlockIncrement", Default.MaxValidUntilBlockIncrement),
                 InitialGasDistribution = section.GetValue("InitialGasDistribution", Default.InitialGasDistribution),
                 Hardforks = section.GetSection("Hardforks").Exists()
                     ? EnsureOmmitedHardforks(section.GetSection("Hardforks").GetChildren().ToDictionary(p => Enum.Parse<Hardfork>(p.Key, true), p => uint.Parse(p.Value))).ToImmutableDictionary()

--- a/tests/Neo.UnitTests/UT_ProtocolSettings.cs
+++ b/tests/Neo.UnitTests/UT_ProtocolSettings.cs
@@ -217,6 +217,12 @@ namespace Neo.UnitTests
         }
 
         [TestMethod]
+        public void TestMaxValidUntilBlockIncrement()
+        {
+            Assert.IsTrue(TestProtocolSettings.Default.MaxValidUntilBlockIncrement > 0);
+        }
+
+        [TestMethod]
         public void TestInitialGasDistribution()
         {
             Assert.IsTrue(TestProtocolSettings.Default.InitialGasDistribution > 0);
@@ -311,6 +317,12 @@ namespace Neo.UnitTests
         }
 
         [TestMethod]
+        public void TestDefaultMaxValidUntilBlockIncrementValue()
+        {
+            Assert.AreEqual(ProtocolSettings.Default.MaxValidUntilBlockIncrement, TestProtocolSettings.Default.MaxValidUntilBlockIncrement);
+        }
+
+        [TestMethod]
         public void TestDefaultInitialGasDistributionValue()
         {
             Assert.AreEqual(ProtocolSettings.Default.InitialGasDistribution, TestProtocolSettings.Default.InitialGasDistribution);
@@ -344,6 +356,7 @@ namespace Neo.UnitTests
             Assert.AreEqual(TestProtocolSettings.Default.MaxTransactionsPerBlock, loadedSetting.MaxTransactionsPerBlock);
             Assert.AreEqual(TestProtocolSettings.Default.MemoryPoolMaxTransactions, loadedSetting.MemoryPoolMaxTransactions);
             Assert.AreEqual(TestProtocolSettings.Default.MaxTraceableBlocks, loadedSetting.MaxTraceableBlocks);
+            Assert.AreEqual(TestProtocolSettings.Default.MaxValidUntilBlockIncrement, loadedSetting.MaxValidUntilBlockIncrement);
             Assert.AreEqual(TestProtocolSettings.Default.InitialGasDistribution, loadedSetting.InitialGasDistribution);
             CollectionAssert.AreEqual(TestProtocolSettings.Default.Hardforks, loadedSetting.Hardforks);
 


### PR DESCRIPTION
# Description

We're close to v3.8.0 which means that C# node will be able to process NeoFS chains. We need NeoFS protocol configuration to be up-to-date with the one that is used in real NeoFS mainnet/testnet. Port the https://github.com/nspcc-dev/neo-go/pull/3833.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [X] `TestMaxValidUntilBlockIncrement`, `TestDefaultMaxValidUntilBlockIncrementValue`

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
