### PR TITLE
[`Fix`]: concurrent conflict in `Cache.CopyTo`

### DIFF
--- a/src/Neo.IO/Caching/Cache.cs
+++ b/src/Neo.IO/Caching/Cache.cs
@@ -155,11 +155,20 @@ namespace Neo.IO.Caching
         {
             if (array == null) throw new ArgumentNullException(nameof(array));
             if (startIndex < 0) throw new ArgumentOutOfRangeException(nameof(startIndex));
-            if (startIndex + InnerDictionary.Count > array.Length)
-                throw new ArgumentOutOfRangeException(nameof(startIndex));
-            foreach (var item in this)
+
+            RwSyncRootLock.EnterReadLock();
+            try
             {
-                array[startIndex++] = item;
+                if (startIndex + InnerDictionary.Count > array.Length)
+                    throw new ArgumentOutOfRangeException(nameof(startIndex));
+                foreach (var item in InnerDictionary.Values)
+                {
+                    array[startIndex++] = item.Value;
+                }
+            }
+            finally
+            {
+                RwSyncRootLock.ExitReadLock();
             }
         }
 


### PR DESCRIPTION
# Description

Get `InnerDictionary.Count` in `Cache` should be protected by lock

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
