### PR TITLE
[`Fix`]: add default value for `key` parameter in help command

### DIFF
--- a/src/Neo.ConsoleService/ConsoleServiceBase.cs
+++ b/src/Neo.ConsoleService/ConsoleServiceBase.cs
@@ -81,7 +81,7 @@ namespace Neo.ConsoleService
                                     }
                                     else
                                     {
-                                        throw new ArgumentException(arg.Name);
+                                        throw new ArgumentException($"Missing argument: {arg.Name}");
                                     }
                                 }
                             }
@@ -121,7 +121,7 @@ namespace Neo.ConsoleService
                     {
                         // Show Ambiguous call
 
-                        throw new ArgumentException("Ambiguous calls for: " + string.Join(',', availableCommands.Select(u => u.Command.Key).Distinct()));
+                        throw new ArgumentException($"Ambiguous calls for: {string.Join(',', availableCommands.Select(u => u.Command.Key).Distinct())}");
                     }
             }
         }
@@ -157,12 +157,11 @@ namespace Neo.ConsoleService
         /// Process "help" command
         /// </summary>
         [ConsoleCommand("help", Category = "Base Commands")]
-        protected void OnHelpCommand(string key)
+        protected void OnHelpCommand(string key = "")
         {
             var withHelp = new List<ConsoleCommandMethod>();
 
             // Try to find a plugin with this name
-
             if (_instances.TryGetValue(key.Trim().ToLowerInvariant(), out var instance))
             {
                 // Filter only the help of this plugin
@@ -170,10 +169,9 @@ namespace Neo.ConsoleService
                 key = "";
                 foreach (var commands in _verbs.Values.Select(u => u))
                 {
-                    withHelp.AddRange
-                        (
+                    withHelp.AddRange(
                         commands.Where(u => !string.IsNullOrEmpty(u.HelpCategory) && u.Instance == instance)
-                        );
+                    );
                 }
             }
             else
@@ -213,7 +211,7 @@ namespace Neo.ConsoleService
                     Console.WriteLine(" " + string.Join(' ',
                         command.Method.GetParameters()
                         .Select(u => u.HasDefaultValue ? $"[{u.Name}={(u.DefaultValue == null ? "null" : u.DefaultValue.ToString())}]" : $"<{u.Name}>"))
-                        );
+                    );
                 }
             }
             else
@@ -244,7 +242,7 @@ namespace Neo.ConsoleService
                     Console.WriteLine(" " + string.Join(' ',
                         command.Method.GetParameters()
                         .Select(u => u.HasDefaultValue ? $"[{u.Name}={u.DefaultValue?.ToString() ?? "null"}]" : $"<{u.Name}>"))
-                        );
+                    );
                 }
 
                 if (!found)
@@ -332,7 +330,7 @@ namespace Neo.ConsoleService
                 {
                     var ret = CommandToken.ToString(args);
                     args.Clear();
-                    return ret.Split(new[] { ',', ' ' }, StringSplitOptions.RemoveEmptyEntries);
+                    return ret.Split([',', ' '], StringSplitOptions.RemoveEmptyEntries);
                 }
 
                 return (CommandToken.ReadString(args, false)?.Split(',', ' ')) ?? Array.Empty<string>();
@@ -406,7 +404,7 @@ namespace Neo.ConsoleService
 
                     if (!method.GetParameters().All(u => u.ParameterType.IsEnum || _handlers.ContainsKey(u.ParameterType)))
                     {
-                        throw new ArgumentException("Handler not found for the command: " + method);
+                        throw new ArgumentException($"Handler not found for the command: {method}");
                     }
 
                     // Add command


### PR DESCRIPTION
# Description

The default value of the key parameter in help command is missing.
```csharp
        /// <summary>
        /// Process "help" command
        /// </summary>
        [ConsoleCommand("help", Category = "Base Commands")]
        protected void OnHelpCommand(string key)
```

So there is always an error message when running `help`
```
neo> help
Error: key
```

## Type of change

- [ ] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
