### PR TITLE
[`Add`]: set name when create wallet

### DIFF
--- a/src/Neo.CLI/CLI/MainService.Wallet.cs
+++ b/src/Neo.CLI/CLI/MainService.Wallet.cs
@@ -212,8 +212,16 @@ namespace Neo.CLI
         /// <summary>
         /// Process "create wallet" command
         /// </summary>
+        /// <param name="path">The path of the wallet file.</param>
+        /// <param name="wifOrFile">
+        /// The WIF or file of the wallet.
+        /// If <see langword="null"/> or empty, a new wallet will be created.
+        /// If it is a WIF, it will be added to the wallet.
+        /// If it is a file, it will be read each line as a WIF and added to the wallet.
+        /// </param>
+        /// <param name="walletName">The name of the wallet.</param>
         [ConsoleCommand("create wallet", Category = "Wallet Commands")]
-        private void OnCreateWalletCommand(string path, string? wifOrFile = null)
+        private void OnCreateWalletCommand(string path, string? wifOrFile = null, string? walletName = null)
         {
             string password = ConsoleHelper.ReadUserInput("password", true);
             if (password.Length == 0)
@@ -221,19 +229,22 @@ namespace Neo.CLI
                 ConsoleHelper.Info("Cancelled");
                 return;
             }
+
             string password2 = ConsoleHelper.ReadUserInput("repeat password", true);
             if (password != password2)
             {
                 ConsoleHelper.Error("Two passwords not match.");
                 return;
             }
+
             if (File.Exists(path))
             {
                 Console.WriteLine("This wallet already exists, please create another one.");
                 return;
             }
-            bool createDefaultAccount = wifOrFile is null;
-            CreateWallet(path, password, createDefaultAccount);
+
+            bool createDefaultAccount = string.IsNullOrEmpty(wifOrFile);
+            CreateWallet(path, password, createDefaultAccount, walletName);
             if (!createDefaultAccount) OnImportKeyCommand(wifOrFile!);
         }
 

--- a/src/Neo.CLI/CLI/MainService.cs
+++ b/src/Neo.CLI/CLI/MainService.cs
@@ -142,9 +142,9 @@ namespace Neo.CLI
             base.RunConsole();
         }
 
-        public void CreateWallet(string path, string password, bool createDefaultAccount = true)
+        public void CreateWallet(string path, string password, bool createDefaultAccount = true, string? walletName = null)
         {
-            Wallet wallet = Wallet.Create(null, path, password, NeoSystem.Settings);
+            Wallet wallet = Wallet.Create(walletName, path, password, NeoSystem.Settings);
             if (wallet == null)
             {
                 ConsoleHelper.Warning("Wallet files in that format are not supported, please use a .json or .db3 file extension.");

--- a/src/Neo.ConsoleService/ConsoleServiceBase.cs
+++ b/src/Neo.ConsoleService/ConsoleServiceBase.cs
@@ -515,11 +515,13 @@ namespace Neo.ConsoleService
         {
             _running = true;
             if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+            {
                 try
                 {
                     Console.Title = ServiceName;
                 }
                 catch { }
+            }
 
             Console.ForegroundColor = ConsoleColor.DarkGreen;
             Console.SetIn(new StreamReader(Console.OpenStandardInput(), Console.InputEncoding, false, ushort.MaxValue));

--- a/src/Neo/Wallets/IWalletFactory.cs
+++ b/src/Neo/Wallets/IWalletFactory.cs
@@ -13,10 +13,30 @@ namespace Neo.Wallets
 {
     public interface IWalletFactory
     {
+        /// <summary>
+        /// Determines whether the factory can handle the specified path.
+        /// </summary>
+        /// <param name="path">The path of the wallet file.</param>
+        /// <returns>
+        /// <see langword="true"/> if the factory can handle the specified path; otherwise, <see langword="false"/>.
+        /// </returns>
         public bool Handle(string path);
 
+        /// <summary>
+        /// Creates a new wallet.
+        /// </summary>
+        /// <param name="name">The name of the wallet.</param>
+        /// <param name="path">The path of the wallet file.</param>
+        /// <param name="password">The password of the wallet.</param>
+        /// <param name="settings">The settings of the wallet.</param>
         public Wallet CreateWallet(string name, string path, string password, ProtocolSettings settings);
 
+        /// <summary>
+        /// Opens a wallet.
+        /// </summary>
+        /// <param name="path">The path of the wallet file.</param>
+        /// <param name="password">The password of the wallet.</param>
+        /// <param name="settings">The settings of the wallet.</param>
         public Wallet OpenWallet(string path, string password, ProtocolSettings settings);
     }
 }


### PR DESCRIPTION
# Description

I found that no name option when creating a wallet,
So add this parameter to set wallet name.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
