### PR TITLE
Avoid double `ToArray` on `OnInvMessageReceived`

### DIFF
--- a/src/Neo/Network/P2P/RemoteNode.ProtocolHandler.cs
+++ b/src/Neo/Network/P2P/RemoteNode.ProtocolHandler.cs
@@ -46,8 +46,8 @@ namespace Neo.Network.P2P
 
         private static readonly List<MessageReceivedHandler> handlers = new();
         private readonly PendingKnownHashesCollection pendingKnownHashes = new();
-        private readonly HashSetCache<UInt256> knownHashes;
-        private readonly HashSetCache<UInt256> sentHashes;
+        private readonly HashSetCache<UInt256> _knownHashes;
+        private readonly HashSetCache<UInt256> _sentHashes;
         private bool verack = false;
         private BloomFilter bloom_filter;
 
@@ -240,7 +240,7 @@ namespace Neo.Network.P2P
         private void OnGetDataMessageReceived(InvPayload payload)
         {
             var notFound = new List<UInt256>();
-            foreach (UInt256 hash in payload.Hashes.Where(p => sentHashes.Add(p)))
+            foreach (UInt256 hash in payload.Hashes.Where(p => _sentHashes.Add(p)))
             {
                 switch (payload.Type)
                 {
@@ -313,7 +313,7 @@ namespace Neo.Network.P2P
 
         private void OnInventoryReceived(IInventory inventory)
         {
-            if (!knownHashes.Add(inventory.Hash)) return;
+            if (!_knownHashes.Add(inventory.Hash)) return;
             pendingKnownHashes.Remove(inventory.Hash);
             system.TaskManager.Tell(inventory);
             switch (inventory)
@@ -335,25 +335,33 @@ namespace Neo.Network.P2P
 
         private void OnInvMessageReceived(InvPayload payload)
         {
-            UInt256[] hashes = payload.Hashes.Where(p => !pendingKnownHashes.Contains(p) && !knownHashes.Contains(p) && !sentHashes.Contains(p)).ToArray();
-            if (hashes.Length == 0) return;
+            UInt256[] hashes;
+            var source = payload.Hashes
+                .Where(p => !pendingKnownHashes.Contains(p) && !_knownHashes.Contains(p) && !_sentHashes.Contains(p));
             switch (payload.Type)
             {
                 case InventoryType.Block:
                     {
-                        var snapshot = system.StoreView;
-                        hashes = hashes.Where(p => !NativeContract.Ledger.ContainsBlock(snapshot, p)).ToArray();
+                        hashes = source
+                            .Where(p => !NativeContract.Ledger.ContainsBlock(system.StoreView, p))
+                            .ToArray();
+                        break;
                     }
-                    break;
                 case InventoryType.TX:
                     {
-                        var snapshot = system.StoreView;
-                        hashes = hashes.Where(p => !NativeContract.Ledger.ContainsTransaction(snapshot, p)).ToArray();
+                        hashes = source
+                            .Where(p => !NativeContract.Ledger.ContainsTransaction(system.StoreView, p))
+                            .ToArray();
+                        break;
                     }
-                    break;
+                default:
+                    {
+                        hashes = source.ToArray();
+                        break;
+                    }
             }
             if (hashes.Length == 0) return;
-            foreach (UInt256 hash in hashes)
+            foreach (var hash in hashes)
                 pendingKnownHashes.Add(Tuple.Create(hash, TimeProvider.Current.UtcNow));
             system.TaskManager.Tell(new TaskManager.NewTasks { Payload = InvPayload.Create(payload.Type, hashes) });
         }

--- a/src/Neo/Network/P2P/RemoteNode.cs
+++ b/src/Neo/Network/P2P/RemoteNode.cs
@@ -81,8 +81,8 @@ namespace Neo.Network.P2P
         {
             this.system = system;
             this.localNode = localNode;
-            knownHashes = new HashSetCache<UInt256>(system.MemPool.Capacity * 2 / 5);
-            sentHashes = new HashSetCache<UInt256>(system.MemPool.Capacity * 2 / 5);
+            _knownHashes = new HashSetCache<UInt256>(system.MemPool.Capacity * 2 / 5);
+            _sentHashes = new HashSetCache<UInt256>(system.MemPool.Capacity * 2 / 5);
             localNode.RemoteNodes.TryAdd(Self, this);
         }
 


### PR DESCRIPTION
# Description

To array was executed twice for transactions and blocks

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Manual tests

**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
