### PR TITLE
Use `DateTime.UtcNow` for time differences

### DIFF
--- a/src/Neo.CLI/CLI/MainService.Logger.cs
+++ b/src/Neo.CLI/CLI/MainService.Logger.cs
@@ -93,7 +93,7 @@ namespace Neo.CLI
 
             lock (syncRoot)
             {
-                DateTime now = DateTime.Now;
+                var now = DateTime.Now;
                 var log = $"[{now.TimeOfDay:hh\\:mm\\:ss\\.fff}]";
                 if (_showLog)
                 {

--- a/src/Neo.CLI/CLI/MainService.Node.cs
+++ b/src/Neo.CLI/CLI/MainService.Node.cs
@@ -89,7 +89,7 @@ namespace Neo.CLI
             var task = Task.Run(async () =>
             {
                 var maxLines = 0;
-                var startTime = DateTime.Now;
+                var startTime = DateTime.UtcNow;
                 var refreshInterval = 1000; // Slower refresh to reduce flickering
                 var lastRefresh = DateTime.MinValue;
                 var lastHeight = 0u;
@@ -104,7 +104,7 @@ namespace Neo.CLI
                     try
                     {
                         // Only refresh data if time elapsed or significant changes
-                        var now = DateTime.Now;
+                        var now = DateTime.UtcNow;
                         var timeSinceRefresh = (now - lastRefresh).TotalMilliseconds;
 
                         // Capture data (do this frequently)

--- a/src/Neo/Network/P2P/Payloads/VersionPayload.cs
+++ b/src/Neo/Network/P2P/Payloads/VersionPayload.cs
@@ -39,7 +39,7 @@ namespace Neo.Network.P2P.Payloads
         public uint Version;
 
         /// <summary>
-        /// The time when connected to the node.
+        /// The time when connected to the node (UTC).
         /// </summary>
         public uint Timestamp;
 
@@ -85,7 +85,7 @@ namespace Neo.Network.P2P.Payloads
             {
                 Network = network,
                 Version = LocalNode.ProtocolVersion,
-                Timestamp = DateTime.Now.ToTimestamp(),
+                Timestamp = DateTime.UtcNow.ToTimestamp(),
                 Nonce = nonce,
                 UserAgent = userAgent,
                 Capabilities = capabilities,

--- a/src/Neo/Network/UPnP.cs
+++ b/src/Neo/Network/UPnP.cs
@@ -47,7 +47,7 @@ namespace Neo.Network
             "MX:3\r\n\r\n";
             var data = Encoding.ASCII.GetBytes(req);
             var ipe = new IPEndPoint(IPAddress.Broadcast, 1900);
-            var start = DateTime.Now;
+            var start = DateTime.UtcNow;
 
             try
             {
@@ -85,7 +85,7 @@ namespace Neo.Network
                     continue;
                 }
             }
-            while (DateTime.Now - start < TimeOut);
+            while (DateTime.UtcNow - start < TimeOut);
 
             return false;
         }

--- a/tests/Neo.Extensions.Tests/UT_DateTimeExtensions.cs
+++ b/tests/Neo.Extensions.Tests/UT_DateTimeExtensions.cs
@@ -21,7 +21,7 @@ namespace Neo.Extensions.Tests
         [TestMethod]
         public void TestToTimestamp()
         {
-            var time = DateTime.Now;
+            var time = DateTime.UtcNow;
             var expected = (uint)(time.ToUniversalTime() - unixEpoch).TotalSeconds;
             var actual = time.ToTimestamp();
 
@@ -31,7 +31,7 @@ namespace Neo.Extensions.Tests
         [TestMethod]
         public void TestToTimestampMS()
         {
-            var time = DateTime.Now;
+            var time = DateTime.UtcNow;
             var expected = (ulong)(time.ToUniversalTime() - unixEpoch).TotalMilliseconds;
             var actual = time.ToTimestampMS();
 


### PR DESCRIPTION
# Description

Use DateTime.UtcNow for time differences.

Part of the review of https://github.com/neo-project/neo/pull/3899

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Manual tests

**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
