### PR TITLE
Avoid parallel UT

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,20 +71,20 @@ jobs:
         brew install leveldb
         brew install gperftools
         dotnet build --disable-parallel -p:GITHUB_ACTIONS=true -bl:build-macos.binlog
-        dotnet test --no-build -p:GITHUB_ACTIONS=true -bl:test-macos.binlog
+        dotnet test --no-build -p:GITHUB_ACTIONS=true -bl:test-macos.binlog -p:TestTfmsInParallel=false
 
     - name: Test (windows)
       if: matrix.os == 'windows-latest'
       run: |
         dotnet build --disable-parallel -p:GITHUB_ACTIONS=true -bl:build-windows.binlog
-        dotnet test --no-build -p:GITHUB_ACTIONS=true -bl:test-windows.binlog
+        dotnet test --no-build -p:GITHUB_ACTIONS=true -bl:test-windows.binlog -p:TestTfmsInParallel=false
 
     - name: Test for coverall
       if: matrix.os == 'ubuntu-latest'
       run: |
         sudo apt-get --assume-yes install libleveldb-dev librocksdb-dev
         dotnet build --disable-parallel -p:GITHUB_ACTIONS=true -bl:build-ubuntu.binlog
-        dotnet test --no-build -p:GITHUB_ACTIONS=true -p:Exclude="[Neo.UnitTests]*" -bl:test-ubuntu.binlog
+        dotnet test --no-build -p:GITHUB_ACTIONS=true -p:Exclude="[Neo.UnitTests]*" -bl:test-ubuntu.binlog -p:TestTfmsInParallel=false
 
     - uses: actions/upload-artifact@v4.6.2
       if: always()


### PR DESCRIPTION
# Description

Sorry guys, but our tests was never done isolated at the begining, so if we want parallel unit tests, we should fix this before. #3874 was fault because of that, other test makes changes in HeadersCache, and other test consume it, and boom.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Manual test

**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
