### PR TITLE
Native: revert Update/Deploy callflag change for pre-Aspidochelone

### DIFF
--- a/src/Neo/SmartContract/Native/NativeContract.cs
+++ b/src/Neo/SmartContract/Native/NativeContract.cs
@@ -420,12 +420,7 @@ namespace Neo.SmartContract.Native
                 if (method.DeprecatedIn is not null && engine.IsHardforkEnabled(method.DeprecatedIn.Value))
                     throw new InvalidOperationException($"Cannot call this method after hardfork {method.DeprecatedIn}.");
                 var state = context.GetState<ExecutionContextState>();
-                var requiredFlags = method.RequiredCallFlags;
-                // A special case for `deploy` and `update` methods of native ContractManagement contract
-                // for pre-Aspidochelone blocks to avoid breaking existing chains, ref. #2653, #2673.
-                if (!engine.IsHardforkEnabled(Hardfork.HF_Aspidochelone) && Id == -1 && (method.Name == "deploy" || method.Name == "update"))
-                    requiredFlags &= CallFlags.States | CallFlags.AllowNotify;
-                if (!state.CallFlags.HasFlag(requiredFlags))
+                if (!state.CallFlags.HasFlag(method.RequiredCallFlags))
                     throw new InvalidOperationException($"Cannot call this method with the flag {state.CallFlags}.");
                 // In the unit of datoshi, 1 datoshi = 1e-8 GAS
                 engine.AddFee(method.CpuFee * engine.ExecFeeFactor + method.StorageFee * engine.StoragePrice);

--- a/src/Neo/SmartContract/Native/NativeContract.cs
+++ b/src/Neo/SmartContract/Native/NativeContract.cs
@@ -420,7 +420,12 @@ namespace Neo.SmartContract.Native
                 if (method.DeprecatedIn is not null && engine.IsHardforkEnabled(method.DeprecatedIn.Value))
                     throw new InvalidOperationException($"Cannot call this method after hardfork {method.DeprecatedIn}.");
                 var state = context.GetState<ExecutionContextState>();
-                if (!state.CallFlags.HasFlag(method.RequiredCallFlags))
+                var requiredFlags = method.RequiredCallFlags;
+                // A special case for `deploy` and `update` methods of native ContractManagement contract
+                // for pre-Aspidochelone blocks to avoid breaking existing chains, ref. #2653, #2673.
+                if (!engine.IsHardforkEnabled(Hardfork.HF_Aspidochelone) && Id == -1 && (method.Name == "deploy" || method.Name == "update"))
+                    requiredFlags &= CallFlags.States | CallFlags.AllowNotify;
+                if (!state.CallFlags.HasFlag(requiredFlags))
                     throw new InvalidOperationException($"Cannot call this method with the flag {state.CallFlags}.");
                 // In the unit of datoshi, 1 datoshi = 1e-8 GAS
                 engine.AddFee(method.CpuFee * engine.ExecFeeFactor + method.StorageFee * engine.StoragePrice);


### PR DESCRIPTION
# Description

https://github.com/neo-project/neo/pull/2653 changed required callflags of native ContractManagement's Update and Deploy methods from `States|AllowNotify` to `All`. This change didn't affect N3 mainnet/T5 (ref. https://github.com/neo-project/neo/issues/2673), but the problem is that this change affected NeoFS mainnet network (see https://github.com/nspcc-dev/neo-go/pull/2848 and https://github.com/nspcc-dev/neo-go/pull/2848/commits/5d478b55141f6673e3c3796df86354786e08351e in particular).

This commit fixes state difference between Go and C# nodes at height 451626 of NeoFS mainnet. Note that this commit does not affect existing N3 mainnet/testnet states, so no resynchronisation is required on the node update.

The difference itself:
```
go run scripts/compare-dumps/compare-dumps.go ./godump-echidna-neofs-mainnet/ ../../neo-project/neo/neo-cli-notary-mainnet/Storage_0572dfa5/
Processing directory BlockStorage_0
Processing directory BlockStorage_100000
Processing directory BlockStorage_200000
Processing directory BlockStorage_300000
Processing directory BlockStorage_400000
Processing directory BlockStorage_500000
file BlockStorage_500000/dump-block-452000.json: block 451626, changes length mismatch: 25 vs 11
compare-dumps dumpDirA dumpDirB
exit status 1
```
<details>
  <summary>Go node application log for the problem transaction in block 451626</summary>

```
anna@kiwi:~/Documents/GitProjects/nspcc-dev/neo-go$ curl -d '{ "jsonrpc": "2.0", "id": 1, "method": "getapplicationlog", "params": ["0x5028585a5c27b7f357771fa8b512c2d1b0ba40dcb3ea30e67d3db2d75d2da60d"] }' localhost:40332 | json_pp
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   592  100   450  100   142   461k   145k --:--:-- --:--:-- --:--:--  578k
{
   "id" : 1,
   "jsonrpc" : "2.0",
   "result" : {
      "executions" : [
         {
            "exception" : null,
            "gasconsumed" : "900316660",
            "invocations" : null,
            "notifications" : [
               {
                  "contract" : "0xfffdc93764dbaddd97c48f252a53ea4643faa3fd",
                  "eventname" : "Update",
                  "state" : {
                     "type" : "Array",
                     "value" : [
                        {
                           "type" : "ByteString",
                           "value" : "r6jbcP2s5N7DIvRYS2ZiFdP7YXA="
                        }
                     ]
                  }
               }
            ],
            "stack" : [
               {
                  "type" : "Any"
               }
            ],
            "trigger" : "Application",
            "vmstate" : "HALT"
         }
      ],
      "txid" : "0x5028585a5c27b7f357771fa8b512c2d1b0ba40dcb3ea30e67d3db2d75d2da60d"
   }
}
```

</details>


<details>
  <summary>C# application log for the same transaction</summary>
  
```
anna@kiwi:~/Documents/GitProjects/nspcc-dev/neo-go$ curl -d '{ "jsonrpc": "2.0", "id": 1, "method": "getapplicationlog", "params": ["0x5028585a5c27b7f357771fa8b512c2d1b0ba40dcb3ea30e67d3db2d75d2da60d"] }' localhost:50332 | json_pp
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   439    0   297  100   142   3502   1674 --:--:-- --:--:-- --:--:--  5226
{
   "id" : 1,
   "jsonrpc" : "2.0",
   "result" : {
      "executions" : [
         {
            "exception" : "Cannot call this method with the flag States, AllowNotify.",
            "gasconsumed" : "5684010",
            "notifications" : [],
            "stack" : [],
            "trigger" : "Application",
            "vmstate" : "FAULT"
         }
      ],
      "txid" : "0x5028585a5c27b7f357771fa8b512c2d1b0ba40dcb3ea30e67d3db2d75d2da60d"
   }
}
```

</details>

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

We used this fix in NeoGo and it is confirmed that this fix does not affect existing N3 chains state. However, I'm now syncing chains to ensure that the same fix works for C# node, just in case. @superboyiii, you may also take a look.

- [x] Node synchronisation for NeoFS testnet/mainnet
- [x] Node synchronisation for N3 testnet/mainnet

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
