### PR TITLE
[`Optimize`]: `Murmur128` is a noncryptographic hash aglorithm

### DIFF
--- a/benchmarks/Neo.Benchmarks/Benchmarks.Hash.cs
+++ b/benchmarks/Neo.Benchmarks/Benchmarks.Hash.cs
@@ -53,5 +53,13 @@ namespace Neo.Benchmark
             var result = data.Murmur32(0);
             Debug.Assert(result == 3731881930u);
         }
+
+        [Benchmark]
+        public void Murmur128_ComputeHash()
+        {
+            var result = data.Murmur128(0);
+            if (result.Length != 16)
+                throw new InvalidOperationException($"Invalid hash length {result.Length}");
+        }
     }
 }

--- a/src/Neo/Cryptography/Helper.cs
+++ b/src/Neo/Cryptography/Helper.cs
@@ -86,11 +86,7 @@ namespace Neo.Cryptography
         /// <param name="value">The input to compute the hash code for.</param>
         /// <param name="seed">The seed used by the murmur algorithm.</param>
         /// <returns>The computed hash code.</returns>
-        public static byte[] Murmur128(this byte[] value, uint seed)
-        {
-            using Murmur128 murmur = new(seed);
-            return murmur.ComputeHash(value);
-        }
+        public static byte[] Murmur128(this byte[] value, uint seed) => value.AsReadOnlySpan().Murmur128(seed);
 
         /// <summary>
         /// Computes the 128-bit hash value for the specified byte array using the murmur algorithm.
@@ -100,10 +96,7 @@ namespace Neo.Cryptography
         /// <returns>The computed hash code.</returns>
         public static byte[] Murmur128(this ReadOnlySpan<byte> value, uint seed)
         {
-            var buffer = new byte[16];
-            using Murmur128 murmur = new(seed);
-            murmur.TryComputeHash(value, buffer, out _);
-            return buffer;
+            return new Murmur128(seed).ComputeHash(value);
         }
 
         /// <summary>

--- a/src/Neo/Cryptography/Murmur128.cs
+++ b/src/Neo/Cryptography/Murmur128.cs
@@ -11,14 +11,16 @@
 
 using System;
 using System.Buffers.Binary;
+using System.IO.Hashing;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace Neo.Cryptography
 {
     /// <summary>
     /// Computes the 128 bits murmur hash for the input data.
     /// </summary>
-    public sealed class Murmur128 : System.Security.Cryptography.HashAlgorithm
+    public sealed class Murmur128 : NonCryptographicHashAlgorithm
     {
         private const ulong c1 = 0x87c37b91114253d5;
         private const ulong c2 = 0x4cf5ad432745937f;
@@ -28,11 +30,27 @@ namespace Neo.Cryptography
         private const uint n1 = 0x52dce729;
         private const uint n2 = 0x38495ab5;
 
-        private readonly uint seed;
-        private int length;
+        private readonly uint _seed;
+        private int _length;
 
         public const int HashSizeInBits = 128;
-        public override int HashSize => HashSizeInBits;
+
+        [Obsolete("Use HashSizeInBits instead")]
+        public int HashSize => HashSizeInBits;
+
+#if NET8_0_OR_GREATER
+        [InlineArray(16)]
+        private struct Tail
+        {
+            private byte v0;
+            public Span<byte> AsSpan(int start = 0) => MemoryMarshal.CreateSpan(ref v0, 16).Slice(start);
+        }
+
+        private Tail _tail = new(); // cannot be readonly here
+#else
+        private readonly byte[] _tail = new byte[HashSizeInBits / 8];
+#endif
+        private int _tailLength;
 
         private ulong H1 { get; set; }
         private ulong H2 { get; set; }
@@ -41,83 +59,55 @@ namespace Neo.Cryptography
         /// Initializes a new instance of the <see cref="Murmur128"/> class with the specified seed.
         /// </summary>
         /// <param name="seed">The seed to be used.</param>
-        public Murmur128(uint seed)
+        public Murmur128(uint seed) : base(HashSizeInBits / 8)
         {
-            this.seed = seed;
-            HashSizeValue = HashSizeInBits;
-            Initialize();
+            _seed = seed;
+            Reset();
         }
 
-        protected override void HashCore(byte[] array, int ibStart, int cbSize)
+        public override void Append(ReadOnlySpan<byte> source)
         {
-            HashCore(array.AsSpan(ibStart, cbSize));
-        }
-
-        protected override void HashCore(ReadOnlySpan<byte> source)
-        {
-            int cbSize = source.Length;
-            length += cbSize;
-            int remainder = cbSize & 15;
-            int alignedLength = cbSize - remainder;
-            for (int i = 0; i < alignedLength; i += 16)
+            _length += source.Length;
+            if (_tailLength > 0)
             {
-                ulong k1 = BinaryPrimitives.ReadUInt64LittleEndian(source[i..]);
-                k1 *= c1;
-                k1 = Helper.RotateLeft(k1, r1);
-                k1 *= c2;
-                H1 ^= k1;
-                H1 = Helper.RotateLeft(H1, 27);
-                H1 += H2;
-                H1 = H1 * m + n1;
+                int copyLength = Math.Min(source.Length, HashSizeInBits / 8 - _tailLength);
+                source.Slice(0, copyLength).CopyTo(_tail.AsSpan(_tailLength));
 
-                ulong k2 = BinaryPrimitives.ReadUInt64LittleEndian(source[(i + 8)..]);
-                k2 *= c2;
-                k2 = Helper.RotateLeft(k2, r2);
-                k2 *= c1;
-                H2 ^= k2;
-                H2 = Helper.RotateLeft(H2, 31);
-                H2 += H1;
-                H2 = H2 * m + n2;
-            }
-
-            if (remainder > 0)
-            {
-                ulong remainingBytesL = 0, remainingBytesH = 0;
-                switch (remainder)
+                _tailLength += copyLength;
+                if (_tailLength == HashSizeInBits / 8)
                 {
-                    case 15: remainingBytesH ^= (ulong)source[alignedLength + 14] << 48; goto case 14;
-                    case 14: remainingBytesH ^= (ulong)source[alignedLength + 13] << 40; goto case 13;
-                    case 13: remainingBytesH ^= (ulong)source[alignedLength + 12] << 32; goto case 12;
-                    case 12: remainingBytesH ^= (ulong)source[alignedLength + 11] << 24; goto case 11;
-                    case 11: remainingBytesH ^= (ulong)source[alignedLength + 10] << 16; goto case 10;
-                    case 10: remainingBytesH ^= (ulong)source[alignedLength + 9] << 8; goto case 9;
-                    case 9: remainingBytesH ^= (ulong)source[alignedLength + 8] << 0; goto case 8;
-                    case 8: remainingBytesL ^= (ulong)source[alignedLength + 7] << 56; goto case 7;
-                    case 7: remainingBytesL ^= (ulong)source[alignedLength + 6] << 48; goto case 6;
-                    case 6: remainingBytesL ^= (ulong)source[alignedLength + 5] << 40; goto case 5;
-                    case 5: remainingBytesL ^= (ulong)source[alignedLength + 4] << 32; goto case 4;
-                    case 4: remainingBytesL ^= (ulong)source[alignedLength + 3] << 24; goto case 3;
-                    case 3: remainingBytesL ^= (ulong)source[alignedLength + 2] << 16; goto case 2;
-                    case 2: remainingBytesL ^= (ulong)source[alignedLength + 1] << 8; goto case 1;
-                    case 1: remainingBytesL ^= (ulong)source[alignedLength] << 0; break;
+                    Mix(_tail.AsSpan());
+                    _tailLength = 0;
+                    _tail.AsSpan().Clear();
                 }
+                source = source.Slice(copyLength);
+            }
 
-                H2 ^= Helper.RotateLeft(remainingBytesH * c2, r2) * c1;
-                H1 ^= Helper.RotateLeft(remainingBytesL * c1, r1) * c2;
+            for (; source.Length >= 16; source = source[16..])
+            {
+                Mix(source);
+            }
+
+            if (source.Length > 0)
+            {
+                source.CopyTo(_tail.AsSpan());
+                _tailLength = source.Length;
             }
         }
 
-        protected override byte[] HashFinal()
+        protected override void GetCurrentHashCore(Span<byte> destination)
         {
-            byte[] buffer = new byte[sizeof(ulong) * 2];
-            TryHashFinal(buffer, out _);
-            return buffer;
-        }
+            if (_tailLength > 0)
+            {
+                var tail = _tail.AsSpan();
+                ulong k1 = BinaryPrimitives.ReadUInt64LittleEndian(tail);
+                ulong k2 = BinaryPrimitives.ReadUInt64LittleEndian(tail[8..]);
+                H2 ^= Helper.RotateLeft(k2 * c2, r2) * c1;
+                H1 ^= Helper.RotateLeft(k1 * c1, r1) * c2;
+            }
 
-        protected override bool TryHashFinal(Span<byte> destination, out int bytesWritten)
-        {
-            ulong len = (ulong)length;
-            H1 ^= len; H2 ^= len;
+            H1 ^= (ulong)_length;
+            H2 ^= (ulong)_length;
 
             H1 += H2;
             H2 += H1;
@@ -128,17 +118,33 @@ namespace Neo.Cryptography
             H1 += H2;
             H2 += H1;
 
+            // NOTE: in some implementations, H1, H2 are output in big-endian, and little-endian is used here.
             if (BinaryPrimitives.TryWriteUInt64LittleEndian(destination, H1))
                 BinaryPrimitives.TryWriteUInt64LittleEndian(destination[sizeof(ulong)..], H2);
-
-            bytesWritten = Math.Min(destination.Length, sizeof(ulong) * 2);
-            return bytesWritten == sizeof(ulong) * 2;
         }
 
-        public override void Initialize()
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public override void Reset()
         {
-            H1 = H2 = seed;
-            length = 0;
+            H1 = H2 = _seed;
+            _length = 0;
+            _tailLength = 0;
+            _tail.AsSpan().Clear();
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void Mix(ReadOnlySpan<byte> source)
+        {
+            ulong k1 = BinaryPrimitives.ReadUInt64LittleEndian(source);
+            ulong k2 = BinaryPrimitives.ReadUInt64LittleEndian(source[8..]);
+
+            H1 ^= Helper.RotateLeft(k1 * c1, r1) * c2;
+            H1 = Helper.RotateLeft(H1, 27) + H2;
+            H1 = H1 * m + n1;
+
+            H2 ^= Helper.RotateLeft(k2 * c2, r2) * c1;
+            H2 = Helper.RotateLeft(H2, 31) + H1;
+            H2 = H2 * m + n2;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -146,8 +152,20 @@ namespace Neo.Cryptography
         {
             h = (h ^ (h >> 33)) * 0xff51afd7ed558ccd;
             h = (h ^ (h >> 33)) * 0xc4ceb9fe1a85ec53;
+            return h ^ (h >> 33);
+        }
 
-            return (h ^ (h >> 33));
+        /// <summary>
+        /// Resets the state and computes the 128 bits murmur hash for the input data.
+        /// </summary>
+        /// <param name="source">The input to compute the hash code for.</param>
+        /// <returns>The computed hash code.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public byte[] ComputeHash(ReadOnlySpan<byte> source)
+        {
+            Reset();
+            Append(source);
+            return GetCurrentHash();
         }
     }
 }

--- a/src/Neo/Cryptography/Murmur128.cs
+++ b/src/Neo/Cryptography/Murmur128.cs
@@ -39,6 +39,10 @@ namespace Neo.Cryptography
         public int HashSize => HashSizeInBits;
 
 #if NET8_0_OR_GREATER
+        // The Tail struct is used to store up to 16 bytes of unprocessed data
+        // when computing the hash. It leverages the InlineArray attribute for
+        // efficient memory usage in .NET 8.0 or greater, avoiding heap allocations
+        // and improving performance for small data sizes.
         [InlineArray(16)]
         private struct Tail
         {

--- a/tests/Neo.UnitTests/Cryptography/UT_Murmur128.cs
+++ b/tests/Neo.UnitTests/Cryptography/UT_Murmur128.cs
@@ -12,6 +12,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Neo.Cryptography;
 using Neo.Extensions;
+using System;
 using System.Text;
 
 namespace Neo.UnitTests.Cryptography
@@ -22,8 +23,7 @@ namespace Neo.UnitTests.Cryptography
         [TestMethod]
         public void TestGetHashSize()
         {
-            Murmur128 murmur128 = new Murmur128(1);
-            Assert.AreEqual(128, murmur128.HashSize);
+            Assert.AreEqual(128, Murmur128.HashSizeInBits);
         }
 
         [TestMethod]
@@ -43,13 +43,50 @@ namespace Neo.UnitTests.Cryptography
         }
 
         [TestMethod]
-        public void TestTryComputeHash()
+        public void TestComputeHash128()
         {
             var murmur128 = new Murmur128(123u);
-            var buffer = new byte[murmur128.HashSize / 8];
-            var ok = murmur128.TryComputeHash("hello world"u8.ToArray(), buffer, out _);
-            Assert.IsTrue(ok);
+            var buffer = murmur128.ComputeHash("hello world"u8.ToArray());
             Assert.AreEqual("e0a0632d4f51302c55e3b3e48d28795d", buffer.ToHexString());
+
+            murmur128.Reset();
+            murmur128.Append("hello "u8.ToArray());
+            murmur128.Append("world"u8.ToArray());
+            buffer = murmur128.GetCurrentHash();
+            Assert.AreEqual("e0a0632d4f51302c55e3b3e48d28795d", buffer.ToHexString());
+
+            murmur128.Reset();
+            murmur128.Append("hello worldhello world"u8.ToArray());
+            buffer = murmur128.GetCurrentHash();
+            Assert.AreEqual("76f870485d4e69f8302d4b3fad28fd39", buffer.ToHexString());
+
+            murmur128.Reset();
+            murmur128.Append("hello world"u8.ToArray());
+            murmur128.Append("hello world"u8.ToArray());
+            buffer = murmur128.GetCurrentHash();
+            Assert.AreEqual("76f870485d4e69f8302d4b3fad28fd39", buffer.ToHexString());
+
+            murmur128.Reset();
+            murmur128.Append("hello worldhello "u8.ToArray());
+            murmur128.Append("world"u8.ToArray());
+            buffer = murmur128.GetCurrentHash();
+            Assert.AreEqual("76f870485d4e69f8302d4b3fad28fd39", buffer.ToHexString());
+        }
+
+        [TestMethod]
+        public void TestAppend()
+        {
+            var random = new Random();
+            var buffer = new byte[random.Next(1, 2048)];
+            random.NextBytes(buffer);
+            for (int i = 0; i < 32; i++)
+            {
+                int split = random.Next(1, buffer.Length - 1);
+                var murmur128 = new Murmur128(123u);
+                murmur128.Append(buffer.AsSpan(0, split));
+                murmur128.Append(buffer.AsSpan(split));
+                Assert.AreEqual(murmur128.GetCurrentHash().ToHexString(), buffer.Murmur128(123u).ToHexString());
+            }
         }
     }
 }


### PR DESCRIPTION
# Description

Same as the  murmur32, murmur128 is a noncryptographic hash aglorithm.
So it shouldn't be implemented as a cryptographic hash (This would be misleading.):

This PR:
1. Implements murmur128 as a noncryptographic hash aglorithm;
2. Optimizes murmur128 performance in some cases;

A simple benchmark:

Before:
```
.NET SDK 9.0.203
  [Host]     : .NET 9.0.4 (9.0.425.16305), Arm64 RyuJIT AdvSIMD
  DefaultJob : .NET 9.0.4 (9.0.425.16305), Arm64 RyuJIT AdvSIMD


| Method    | Mean     | Error    | StdDev   |
|---------- |---------:|---------:|---------:|
| Murmur128 | 81.65 us | 1.461 us | 1.295 us |
```

After:
```
.NET SDK 9.0.203
  [Host]     : .NET 9.0.4 (9.0.425.16305), Arm64 RyuJIT AdvSIMD
  DefaultJob : .NET 9.0.4 (9.0.425.16305), Arm64 RyuJIT AdvSIMD


| Method                | Mean     | Error    | StdDev   |
|---------------------- |---------:|---------:|---------:|
| Murmur128_ComputeHash | 40.74 us | 0.097 us | 0.090 us |
```

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
