### PR TITLE
[`Optimize`]: show native contract is active or not

### DIFF
--- a/src/Neo.CLI/CLI/MainService.Native.cs
+++ b/src/Neo.CLI/CLI/MainService.Native.cs
@@ -23,7 +23,12 @@ namespace Neo.CLI
         [ConsoleCommand("list nativecontract", Category = "Native Contract")]
         private void OnListNativeContract()
         {
-            NativeContract.Contracts.ToList().ForEach(p => ConsoleHelper.Info($"\t{p.Name,-20}", $"{p.Hash}"));
+            var currentIndex = NativeContract.Ledger.CurrentIndex(NeoSystem.StoreView);
+            NativeContract.Contracts.ToList().ForEach(contract =>
+            {
+                var active = contract.IsActive(NeoSystem.Settings, currentIndex) ? "" : "not active yet";
+                ConsoleHelper.Info($"\t{contract.Name,-20}", $"{contract.Hash} {active}");
+            });
         }
     }
 }

--- a/src/Neo/SmartContract/Native/NativeContract.cs
+++ b/src/Neo/SmartContract/Native/NativeContract.cs
@@ -330,7 +330,7 @@ namespace Neo.SmartContract.Native
         /// <param name="settings">The <see cref="ProtocolSettings"/> where the HardForks are configured.</param>
         /// <param name="blockHeight">Block height</param>
         /// <returns>True if the native contract is active</returns>
-        internal bool IsActive(ProtocolSettings settings, uint blockHeight)
+        public bool IsActive(ProtocolSettings settings, uint blockHeight)
         {
             if (ActiveIn is null) return true;
 


### PR DESCRIPTION
# Description

Optimzie `show contract` and `list nativecontract`

1. `list nativecontract` shows the not actived contract, but `show contract` show that it not exists
Before:
```
neo> list nativecontract
	ContractManagement  0xfffdc93764dbaddd97c48f252a53ea4643faa3fd
	StdLib              0xacce6fd80d44e1796aa0c2c625e9e4e0ce39efc0
	CryptoLib           0x726cb6e0cd8628a1350a611384688911ab75f51b
	LedgerContract      0xda65b600f7124ce6c79950c1772a36403104f2be
	NeoToken            0xef4073a0f2b305a38ec4050e4d3d28bc40ea63f5
	GasToken            0xd2a4cff31913016155e38e474a2c06d08be276cf
	PolicyContract      0xcc5e4edd9f5f8dba8bb65734541df7a1c081c67b
	RoleManagement      0x49cf4e5378ffcd4dec034fd98a174c5491e395e2
	OracleContract      0xfe924b7cfe89ddd271abaf7210a80a7e11178758
	Notary              0xc1e14f19c3e60d0b9244d06dd7ba9b113135ec3b

neo> show contract Notary
Error: Contract Notary doesn't exist.
```

After:
```
neo> list nativecontract
	ContractManagement  0xfffdc93764dbaddd97c48f252a53ea4643faa3fd
	StdLib              0xacce6fd80d44e1796aa0c2c625e9e4e0ce39efc0
	CryptoLib           0x726cb6e0cd8628a1350a611384688911ab75f51b
	LedgerContract      0xda65b600f7124ce6c79950c1772a36403104f2be
	NeoToken            0xef4073a0f2b305a38ec4050e4d3d28bc40ea63f5
	GasToken            0xd2a4cff31913016155e38e474a2c06d08be276cf
	PolicyContract      0xcc5e4edd9f5f8dba8bb65734541df7a1c081c67b
	RoleManagement      0x49cf4e5378ffcd4dec034fd98a174c5491e395e2
	OracleContract      0xfe924b7cfe89ddd271abaf7210a80a7e11178758
	Notary              0xc1e14f19c3e60d0b9244d06dd7ba9b113135ec3b (not active yet)

neo> show contract Notary
Error: Contract Notary not active yet.
```

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
