### PR TITLE
Allow to import watch only addresses into the wallet

### DIFF
--- a/src/Plugins/RpcServer/RpcServer.Wallet.cs
+++ b/src/Plugins/RpcServer/RpcServer.Wallet.cs
@@ -176,11 +176,11 @@ namespace Neo.Plugins.RpcServer
             UInt160 scriptHash = AddressToScriptHash(address, system.Settings.AddressVersion);
             WalletAccount account = wallet.GetAccount(scriptHash);
             if (account is null)
-                {
-                    account = wallet.CreateAccount(scriptHash);
-                    if (wallet is NEP6Wallet nep6wallet)
-                        nep6wallet.Save();
-                }
+            {
+                account = wallet.CreateAccount(scriptHash);
+                if (wallet is NEP6Wallet nep6wallet)
+                    nep6wallet.Save();
+            }
             return new JObject
             {
                 ["address"] = account.Address,

--- a/src/Plugins/RpcServer/RpcServer.Wallet.cs
+++ b/src/Plugins/RpcServer/RpcServer.Wallet.cs
@@ -163,6 +163,34 @@ namespace Neo.Plugins.RpcServer
         }
 
         /// <summary>
+        /// Imports watch only address into the wallet.
+        /// </summary>
+        /// <param name="_params">An array containing the address as a string.</param>
+        /// <returns>A JSON object containing information about the imported account.</returns>
+        /// <exception cref="RpcException">Thrown when no wallet is open or the address is invalid.</exception>
+        [RpcMethod]
+        protected internal virtual JToken ImportWatchOnly(JArray _params)
+        {
+            CheckWallet();
+            string address = _params[0].AsString();
+            UInt160 scriptHash = AddressToScriptHash(address, system.Settings.AddressVersion);
+            WalletAccount account = wallet.GetAccount(scriptHash);
+            if (account is null)
+                {
+                    account = wallet.CreateAccount(scriptHash);
+                    if (wallet is NEP6Wallet nep6wallet)
+                        nep6wallet.Save();
+                }
+            return new JObject
+            {
+                ["address"] = account.Address,
+                ["haskey"] = account.HasKey,
+                ["label"] = account.Label,
+                ["watchonly"] = account.WatchOnly
+            };
+        }
+
+        /// <summary>
         /// Calculates the network fee for a given transaction.
         /// </summary>
         /// <param name="_params">An array containing the Base64-encoded serialized transaction.</param>


### PR DESCRIPTION
# Description

Allow to import watch only addresses into the wallet.  
Convenient for minimizing the risks of using hot wallets.

Fixes # (issue)

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# How Has This Been Tested?

**Test Configuration**:


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
