### PR TITLE
[`Style`]: unify json initialization for rpc client and rpc server

### DIFF
--- a/src/Neo.Network.RpcClient/Models/RpcAccount.cs
+++ b/src/Neo.Network.RpcClient/Models/RpcAccount.cs
@@ -25,7 +25,7 @@ namespace Neo.Network.RPC.Models
 
         public JObject ToJson()
         {
-            return new JObject
+            return new()
             {
                 ["address"] = Address,
                 ["haskey"] = HasKey,

--- a/src/Neo.Network.RpcClient/Models/RpcApplicationLog.cs
+++ b/src/Neo.Network.RpcClient/Models/RpcApplicationLog.cs
@@ -29,7 +29,7 @@ namespace Neo.Network.RPC.Models
 
         public JObject ToJson()
         {
-            JObject json = new JObject();
+            var json = new JObject();
             if (TxId != null)
                 json["txid"] = TxId.ToString();
             if (BlockHash != null)
@@ -65,14 +65,15 @@ namespace Neo.Network.RPC.Models
 
         public JObject ToJson()
         {
-            JObject json = new();
-            json["trigger"] = Trigger;
-            json["vmstate"] = VMState;
-            json["gasconsumed"] = GasConsumed.ToString();
-            json["exception"] = ExceptionMessage;
-            json["stack"] = Stack.Select(q => q.ToJson()).ToArray();
-            json["notifications"] = Notifications.Select(q => q.ToJson()).ToArray();
-            return json;
+            return new()
+            {
+                ["trigger"] = Trigger,
+                ["vmstate"] = VMState,
+                ["gasconsumed"] = GasConsumed.ToString(),
+                ["exception"] = ExceptionMessage,
+                ["stack"] = Stack.Select(q => q.ToJson()).ToArray(),
+                ["notifications"] = Notifications.Select(q => q.ToJson()).ToArray(),
+            };
         }
 
         public static Execution FromJson(JObject json, ProtocolSettings protocolSettings)
@@ -99,11 +100,12 @@ namespace Neo.Network.RPC.Models
 
         public JObject ToJson()
         {
-            JObject json = new();
-            json["contract"] = Contract.ToString();
-            json["eventname"] = EventName;
-            json["state"] = State.ToJson();
-            return json;
+            return new()
+            {
+                ["contract"] = Contract.ToString(),
+                ["eventname"] = EventName,
+                ["state"] = State.ToJson(),
+            };
         }
 
         public static RpcNotifyEventArgs FromJson(JObject json, ProtocolSettings protocolSettings)

--- a/src/Neo.Network.RpcClient/Models/RpcBlock.cs
+++ b/src/Neo.Network.RpcClient/Models/RpcBlock.cs
@@ -24,7 +24,7 @@ namespace Neo.Network.RPC.Models
 
         public JObject ToJson(ProtocolSettings protocolSettings)
         {
-            JObject json = Utility.BlockToJson(Block, protocolSettings);
+            var json = Utility.BlockToJson(Block, protocolSettings);
             json["confirmations"] = Confirmations;
             json["nextblockhash"] = NextBlockHash?.ToString();
             return json;

--- a/src/Neo.Network.RpcClient/Models/RpcBlockHeader.cs
+++ b/src/Neo.Network.RpcClient/Models/RpcBlockHeader.cs
@@ -24,7 +24,7 @@ namespace Neo.Network.RPC.Models
 
         public JObject ToJson(ProtocolSettings protocolSettings)
         {
-            JObject json = Header.ToJson(protocolSettings);
+            var json = Header.ToJson(protocolSettings);
             json["confirmations"] = Confirmations;
             json["nextblockhash"] = NextBlockHash?.ToString();
             return json;

--- a/src/Neo.Network.RpcClient/Models/RpcInvokeResult.cs
+++ b/src/Neo.Network.RpcClient/Models/RpcInvokeResult.cs
@@ -36,12 +36,16 @@ namespace Neo.Network.RPC.Models
 
         public JObject ToJson()
         {
-            JObject json = new();
-            json["script"] = Script;
-            json["state"] = State;
-            json["gasconsumed"] = GasConsumed.ToString();
+            var json = new JObject()
+            {
+                ["script"] = Script,
+                ["state"] = State,
+                ["gasconsumed"] = GasConsumed.ToString()
+            };
+
             if (!string.IsNullOrEmpty(Exception))
                 json["exception"] = Exception;
+
             try
             {
                 json["stack"] = new JArray(Stack.Select(p => p.ToJson()));
@@ -51,13 +55,14 @@ namespace Neo.Network.RPC.Models
                 // ContractParameter.ToJson() may cause InvalidOperationException
                 json["stack"] = "error: recursive reference";
             }
+
             if (!string.IsNullOrEmpty(Tx)) json["tx"] = Tx;
             return json;
         }
 
         public static RpcInvokeResult FromJson(JObject json)
         {
-            RpcInvokeResult invokeScriptResult = new()
+            var invokeScriptResult = new RpcInvokeResult()
             {
                 Script = json["script"].AsString(),
                 State = json["state"].GetEnum<VMState>(),
@@ -81,13 +86,7 @@ namespace Neo.Network.RPC.Models
 
         public JToken Value { get; set; }
 
-        public JObject ToJson()
-        {
-            JObject json = new();
-            json["type"] = Type;
-            json["value"] = Value;
-            return json;
-        }
+        public JObject ToJson() => new() { ["type"] = Type, ["value"] = Value };
 
         public static RpcStack FromJson(JObject json)
         {

--- a/src/Neo.Network.RpcClient/Models/RpcNep17Balances.cs
+++ b/src/Neo.Network.RpcClient/Models/RpcNep17Balances.cs
@@ -25,20 +25,20 @@ namespace Neo.Network.RPC.Models
 
         public JObject ToJson(ProtocolSettings protocolSettings)
         {
-            JObject json = new();
-            json["balance"] = Balances.Select(p => p.ToJson()).ToArray();
-            json["address"] = UserScriptHash.ToAddress(protocolSettings.AddressVersion);
-            return json;
+            return new()
+            {
+                ["balance"] = Balances.Select(p => p.ToJson()).ToArray(),
+                ["address"] = UserScriptHash.ToAddress(protocolSettings.AddressVersion)
+            };
         }
 
         public static RpcNep17Balances FromJson(JObject json, ProtocolSettings protocolSettings)
         {
-            RpcNep17Balances nep17Balance = new()
+            return new()
             {
                 Balances = ((JArray)json["balance"]).Select(p => RpcNep17Balance.FromJson((JObject)p, protocolSettings)).ToList(),
                 UserScriptHash = json["address"].ToScriptHash(protocolSettings)
             };
-            return nep17Balance;
         }
     }
 
@@ -52,22 +52,22 @@ namespace Neo.Network.RPC.Models
 
         public JObject ToJson()
         {
-            JObject json = new();
-            json["assethash"] = AssetHash.ToString();
-            json["amount"] = Amount.ToString();
-            json["lastupdatedblock"] = LastUpdatedBlock;
-            return json;
+            return new()
+            {
+                ["assethash"] = AssetHash.ToString(),
+                ["amount"] = Amount.ToString(),
+                ["lastupdatedblock"] = LastUpdatedBlock
+            };
         }
 
         public static RpcNep17Balance FromJson(JObject json, ProtocolSettings protocolSettings)
         {
-            RpcNep17Balance balance = new()
+            return new()
             {
                 AssetHash = json["assethash"].ToScriptHash(protocolSettings),
                 Amount = BigInteger.Parse(json["amount"].AsString()),
                 LastUpdatedBlock = (uint)json["lastupdatedblock"].AsNumber()
             };
-            return balance;
         }
     }
 }

--- a/src/Neo.Network.RpcClient/Models/RpcNep17Transfers.cs
+++ b/src/Neo.Network.RpcClient/Models/RpcNep17Transfers.cs
@@ -27,22 +27,22 @@ namespace Neo.Network.RPC.Models
 
         public JObject ToJson(ProtocolSettings protocolSettings)
         {
-            JObject json = new();
-            json["sent"] = Sent.Select(p => p.ToJson(protocolSettings)).ToArray();
-            json["received"] = Received.Select(p => p.ToJson(protocolSettings)).ToArray();
-            json["address"] = UserScriptHash.ToAddress(protocolSettings.AddressVersion);
-            return json;
+            return new()
+            {
+                ["sent"] = Sent.Select(p => p.ToJson(protocolSettings)).ToArray(),
+                ["received"] = Received.Select(p => p.ToJson(protocolSettings)).ToArray(),
+                ["address"] = UserScriptHash.ToAddress(protocolSettings.AddressVersion)
+            };
         }
 
         public static RpcNep17Transfers FromJson(JObject json, ProtocolSettings protocolSettings)
         {
-            RpcNep17Transfers transfers = new()
+            return new()
             {
                 Sent = ((JArray)json["sent"]).Select(p => RpcNep17Transfer.FromJson((JObject)p, protocolSettings)).ToList(),
                 Received = ((JArray)json["received"]).Select(p => RpcNep17Transfer.FromJson((JObject)p, protocolSettings)).ToList(),
                 UserScriptHash = json["address"].ToScriptHash(protocolSettings)
             };
-            return transfers;
         }
     }
 
@@ -64,15 +64,16 @@ namespace Neo.Network.RPC.Models
 
         public JObject ToJson(ProtocolSettings protocolSettings)
         {
-            JObject json = new();
-            json["timestamp"] = TimestampMS;
-            json["assethash"] = AssetHash.ToString();
-            json["transferaddress"] = UserScriptHash?.ToAddress(protocolSettings.AddressVersion);
-            json["amount"] = Amount.ToString();
-            json["blockindex"] = BlockIndex;
-            json["transfernotifyindex"] = TransferNotifyIndex;
-            json["txhash"] = TxHash.ToString();
-            return json;
+            return new()
+            {
+                ["timestamp"] = TimestampMS,
+                ["assethash"] = AssetHash.ToString(),
+                ["transferaddress"] = UserScriptHash?.ToAddress(protocolSettings.AddressVersion),
+                ["amount"] = Amount.ToString(),
+                ["blockindex"] = BlockIndex,
+                ["transfernotifyindex"] = TransferNotifyIndex,
+                ["txhash"] = TxHash.ToString()
+            };
         }
 
         public static RpcNep17Transfer FromJson(JObject json, ProtocolSettings protocolSettings)

--- a/src/Neo.Network.RpcClient/Models/RpcPeers.cs
+++ b/src/Neo.Network.RpcClient/Models/RpcPeers.cs
@@ -24,11 +24,12 @@ namespace Neo.Network.RPC.Models
 
         public JObject ToJson()
         {
-            JObject json = new();
-            json["unconnected"] = new JArray(Unconnected.Select(p => p.ToJson()));
-            json["bad"] = new JArray(Bad.Select(p => p.ToJson()));
-            json["connected"] = new JArray(Connected.Select(p => p.ToJson()));
-            return json;
+            return new()
+            {
+                ["unconnected"] = new JArray(Unconnected.Select(p => p.ToJson())),
+                ["bad"] = new JArray(Bad.Select(p => p.ToJson())),
+                ["connected"] = new JArray(Connected.Select(p => p.ToJson()))
+            };
         }
 
         public static RpcPeers FromJson(JObject json)
@@ -48,13 +49,7 @@ namespace Neo.Network.RPC.Models
 
         public int Port { get; set; }
 
-        public JObject ToJson()
-        {
-            JObject json = new();
-            json["address"] = Address;
-            json["port"] = Port;
-            return json;
-        }
+        public JObject ToJson() => new() { ["address"] = Address, ["port"] = Port };
 
         public static RpcPeer FromJson(JObject json)
         {

--- a/src/Neo.Network.RpcClient/Models/RpcPlugin.cs
+++ b/src/Neo.Network.RpcClient/Models/RpcPlugin.cs
@@ -24,11 +24,12 @@ namespace Neo.Network.RPC.Models
 
         public JObject ToJson()
         {
-            JObject json = new();
-            json["name"] = Name;
-            json["version"] = Version;
-            json["interfaces"] = new JArray(Interfaces.Select(p => (JToken)p));
-            return json;
+            return new()
+            {
+                ["name"] = Name,
+                ["version"] = Version,
+                ["interfaces"] = new JArray(Interfaces.Select(p => (JToken)p))
+            };
         }
 
         public static RpcPlugin FromJson(JObject json)

--- a/src/Neo.Network.RpcClient/Models/RpcRawMemPool.cs
+++ b/src/Neo.Network.RpcClient/Models/RpcRawMemPool.cs
@@ -25,11 +25,12 @@ namespace Neo.Network.RPC.Models
 
         public JObject ToJson()
         {
-            JObject json = new();
-            json["height"] = Height;
-            json["verified"] = new JArray(Verified.Select(p => (JToken)p.ToString()));
-            json["unverified"] = new JArray(UnVerified.Select(p => (JToken)p.ToString()));
-            return json;
+            return new()
+            {
+                ["height"] = Height,
+                ["verified"] = new JArray(Verified.Select(p => (JToken)p.ToString())),
+                ["unverified"] = new JArray(UnVerified.Select(p => (JToken)p.ToString()))
+            };
         }
 
         public static RpcRawMemPool FromJson(JObject json)

--- a/src/Neo.Network.RpcClient/Models/RpcRequest.cs
+++ b/src/Neo.Network.RpcClient/Models/RpcRequest.cs
@@ -37,12 +37,13 @@ namespace Neo.Network.RPC.Models
 
         public JObject ToJson()
         {
-            var json = new JObject();
-            json["id"] = Id;
-            json["jsonrpc"] = JsonRpc;
-            json["method"] = Method;
-            json["params"] = new JArray(Params);
-            return json;
+            return new()
+            {
+                ["id"] = Id,
+                ["jsonrpc"] = JsonRpc,
+                ["method"] = Method,
+                ["params"] = new JArray(Params)
+            };
         }
     }
 }

--- a/src/Neo.Network.RpcClient/Models/RpcResponse.cs
+++ b/src/Neo.Network.RpcClient/Models/RpcResponse.cs
@@ -27,7 +27,7 @@ namespace Neo.Network.RPC.Models
 
         public static RpcResponse FromJson(JObject json)
         {
-            RpcResponse response = new()
+            var response = new RpcResponse
             {
                 Id = json["id"],
                 JsonRpc = json["jsonrpc"].AsString(),
@@ -44,12 +44,13 @@ namespace Neo.Network.RPC.Models
 
         public JObject ToJson()
         {
-            JObject json = new();
-            json["id"] = Id;
-            json["jsonrpc"] = JsonRpc;
-            json["error"] = Error?.ToJson();
-            json["result"] = Result;
-            return json;
+            return new()
+            {
+                ["id"] = Id,
+                ["jsonrpc"] = JsonRpc,
+                ["error"] = Error?.ToJson(),
+                ["result"] = Result
+            };
         }
     }
 
@@ -73,11 +74,12 @@ namespace Neo.Network.RPC.Models
 
         public JObject ToJson()
         {
-            JObject json = new();
-            json["code"] = Code;
-            json["message"] = Message;
-            json["data"] = Data;
-            return json;
+            return new()
+            {
+                ["code"] = Code,
+                ["message"] = Message,
+                ["data"] = Data
+            };
         }
     }
 }

--- a/src/Neo.Network.RpcClient/Models/RpcTransaction.cs
+++ b/src/Neo.Network.RpcClient/Models/RpcTransaction.cs
@@ -29,7 +29,7 @@ namespace Neo.Network.RPC.Models
 
         public JObject ToJson(ProtocolSettings protocolSettings)
         {
-            JObject json = Utility.TransactionToJson(Transaction, protocolSettings);
+            var json = Utility.TransactionToJson(Transaction, protocolSettings);
             if (Confirmations != null)
             {
                 json["blockhash"] = BlockHash.ToString();
@@ -45,10 +45,11 @@ namespace Neo.Network.RPC.Models
 
         public static RpcTransaction FromJson(JObject json, ProtocolSettings protocolSettings)
         {
-            RpcTransaction transaction = new RpcTransaction
+            var transaction = new RpcTransaction
             {
                 Transaction = Utility.TransactionFromJson(json, protocolSettings)
             };
+
             if (json["confirmations"] != null)
             {
                 transaction.BlockHash = UInt256.Parse(json["blockhash"].AsString());

--- a/src/Neo.Network.RpcClient/Models/RpcTransferOut.cs
+++ b/src/Neo.Network.RpcClient/Models/RpcTransferOut.cs
@@ -24,7 +24,7 @@ namespace Neo.Network.RPC.Models
 
         public JObject ToJson(ProtocolSettings protocolSettings)
         {
-            return new JObject
+            return new()
             {
                 ["asset"] = Asset.ToString(),
                 ["value"] = Value,

--- a/src/Neo.Network.RpcClient/Models/RpcUnclaimedGas.cs
+++ b/src/Neo.Network.RpcClient/Models/RpcUnclaimedGas.cs
@@ -19,13 +19,7 @@ namespace Neo.Network.RPC.Models
 
         public string Address { get; set; }
 
-        public JObject ToJson()
-        {
-            JObject json = new();
-            json["unclaimed"] = Unclaimed.ToString();
-            json["address"] = Address;
-            return json;
-        }
+        public JObject ToJson() => new() { ["unclaimed"] = Unclaimed.ToString(), ["address"] = Address };
 
         public static RpcUnclaimedGas FromJson(JObject json)
         {

--- a/src/Neo.Network.RpcClient/Models/RpcValidateAddressResult.cs
+++ b/src/Neo.Network.RpcClient/Models/RpcValidateAddressResult.cs
@@ -19,13 +19,7 @@ namespace Neo.Network.RPC.Models
 
         public bool IsValid { get; set; }
 
-        public JObject ToJson()
-        {
-            JObject json = new();
-            json["address"] = Address;
-            json["isvalid"] = IsValid;
-            return json;
-        }
+        public JObject ToJson() => new() { ["address"] = Address, ["isvalid"] = IsValid };
 
         public static RpcValidateAddressResult FromJson(JObject json)
         {

--- a/src/Neo.Network.RpcClient/Models/RpcValidator.cs
+++ b/src/Neo.Network.RpcClient/Models/RpcValidator.cs
@@ -20,13 +20,7 @@ namespace Neo.Network.RPC.Models
 
         public BigInteger Votes { get; set; }
 
-        public JObject ToJson()
-        {
-            JObject json = new();
-            json["publickey"] = PublicKey;
-            json["votes"] = Votes.ToString();
-            return json;
-        }
+        public JObject ToJson() => new() { ["publickey"] = PublicKey, ["votes"] = Votes.ToString() };
 
         public static RpcValidator FromJson(JObject json)
         {

--- a/src/Neo.Network.RpcClient/Models/RpcVersion.cs
+++ b/src/Neo.Network.RpcClient/Models/RpcVersion.cs
@@ -36,25 +36,25 @@ namespace Neo.Network.RPC.Models
 
             public JObject ToJson()
             {
-                JObject json = new();
-                json["network"] = Network;
-                json["validatorscount"] = ValidatorsCount;
-                json["msperblock"] = MillisecondsPerBlock;
-                json["maxvaliduntilblockincrement"] = MaxValidUntilBlockIncrement;
-                json["maxtraceableblocks"] = MaxTraceableBlocks;
-                json["addressversion"] = AddressVersion;
-                json["maxtransactionsperblock"] = MaxTransactionsPerBlock;
-                json["memorypoolmaxtransactions"] = MemoryPoolMaxTransactions;
-                json["initialgasdistribution"] = InitialGasDistribution;
-                json["hardforks"] = new JArray(Hardforks.Select(s => new JObject()
+                return new()
                 {
-                    // Strip HF_ prefix.
-                    ["name"] = StripPrefix(s.Key.ToString(), "HF_"),
-                    ["blockheight"] = s.Value,
-                }));
-                json["standbycommittee"] = new JArray(StandbyCommittee.Select(u => new JString(u.ToString())));
-                json["seedlist"] = new JArray(SeedList.Select(u => new JString(u)));
-                return json;
+                    ["network"] = Network,
+                    ["validatorscount"] = ValidatorsCount,
+                    ["msperblock"] = MillisecondsPerBlock,
+                    ["maxvaliduntilblockincrement"] = MaxValidUntilBlockIncrement,
+                    ["maxtraceableblocks"] = MaxTraceableBlocks,
+                    ["addressversion"] = AddressVersion,
+                    ["maxtransactionsperblock"] = MaxTransactionsPerBlock,
+                    ["memorypoolmaxtransactions"] = MemoryPoolMaxTransactions,
+                    ["initialgasdistribution"] = InitialGasDistribution,
+                    ["hardforks"] = new JArray(Hardforks.Select(s => new JObject()
+                    {
+                        ["name"] = StripPrefix(s.Key.ToString(), "HF_"), // Strip HF_ prefix.
+                        ["blockheight"] = s.Value,
+                    })),
+                    ["standbycommittee"] = new JArray(StandbyCommittee.Select(u => new JString(u.ToString()))),
+                    ["seedlist"] = new JArray(SeedList.Select(u => new JString(u)))
+                };
             }
 
             public static RpcProtocol FromJson(JObject json)
@@ -74,16 +74,11 @@ namespace Neo.Network.RPC.Models
                     {
                         var name = s["name"].AsString();
                         // Add HF_ prefix to the hardfork response for proper Hardfork enum parsing.
-                        return new KeyValuePair<Hardfork, uint>(Enum.Parse<Hardfork>(name.StartsWith("HF_") ? name : $"HF_{name}"), (uint)s["blockheight"].AsNumber());
+                        var hardfork = Enum.Parse<Hardfork>(name.StartsWith("HF_") ? name : $"HF_{name}");
+                        return new KeyValuePair<Hardfork, uint>(hardfork, (uint)s["blockheight"].AsNumber());
                     })),
-                    SeedList = new List<string>(((JArray)json["seedlist"]).Select(s =>
-                    {
-                        return s.AsString();
-                    })),
-                    StandbyCommittee = new List<ECPoint>(((JArray)json["standbycommittee"]).Select(s =>
-                    {
-                        return ECPoint.Parse(s.AsString(), ECCurve.Secp256r1);
-                    }))
+                    SeedList = [.. ((JArray)json["seedlist"]).Select(s => s.AsString())],
+                    StandbyCommittee = [.. ((JArray)json["standbycommittee"]).Select(s => ECPoint.Parse(s.AsString(), ECCurve.Secp256r1))]
                 };
             }
 
@@ -103,13 +98,14 @@ namespace Neo.Network.RPC.Models
 
         public JObject ToJson()
         {
-            JObject json = new();
-            json["network"] = Protocol.Network; // Obsolete
-            json["tcpport"] = TcpPort;
-            json["nonce"] = Nonce;
-            json["useragent"] = UserAgent;
-            json["protocol"] = Protocol.ToJson();
-            return json;
+            return new()
+            {
+                ["network"] = Protocol.Network, // Obsolete
+                ["tcpport"] = TcpPort,
+                ["nonce"] = Nonce,
+                ["useragent"] = UserAgent,
+                ["protocol"] = Protocol.ToJson()
+            };
         }
 
         public static RpcVersion FromJson(JObject json)

--- a/src/Plugins/RpcServer/RpcError.cs
+++ b/src/Plugins/RpcServer/RpcError.cs
@@ -90,9 +90,11 @@ namespace Neo.Plugins.RpcServer
 
         public JToken ToJson()
         {
-            JObject json = new();
-            json["code"] = Code;
-            json["message"] = ErrorMessage;
+            var json = new JObject()
+            {
+                ["code"] = Code,
+                ["message"] = ErrorMessage,
+            };
             if (!string.IsNullOrEmpty(Data))
                 json["data"] = Data;
             return json;

--- a/src/Plugins/RpcServer/RpcServer.Node.cs
+++ b/src/Plugins/RpcServer/RpcServer.Node.cs
@@ -41,23 +41,18 @@ namespace Neo.Plugins.RpcServer
         [RpcMethodWithParams]
         protected internal virtual JToken GetPeers()
         {
-            JObject json = new();
-            json["unconnected"] = new JArray(localNode.GetUnconnectedPeers().Select(p =>
+            return new JObject()
             {
-                JObject peerJson = new();
-                peerJson["address"] = p.Address.ToString();
-                peerJson["port"] = p.Port;
-                return peerJson;
-            }));
-            json["bad"] = new JArray(); //badpeers has been removed
-            json["connected"] = new JArray(localNode.GetRemoteNodes().Select(p =>
-            {
-                JObject peerJson = new();
-                peerJson["address"] = p.Remote.Address.ToString();
-                peerJson["port"] = p.ListenerTcpPort;
-                return peerJson;
-            }));
-            return json;
+                ["unconnected"] = new JArray(localNode.GetUnconnectedPeers().Select(p =>
+                {
+                    return new JObject() { ["address"] = p.Address.ToString(), ["port"] = p.Port, };
+                })),
+                ["bad"] = new JArray(),
+                ["connected"] = new JArray(localNode.GetRemoteNodes().Select(p =>
+                {
+                    return new JObject() { ["address"] = p.Remote.Address.ToString(), ["port"] = p.ListenerTcpPort, };
+                }))
+            };
         }
 
         /// <summary>
@@ -71,55 +66,30 @@ namespace Neo.Plugins.RpcServer
             switch (reason)
             {
                 case VerifyResult.Succeed:
-                    {
-                        var ret = new JObject();
-                        ret["hash"] = hash.ToString();
-                        return ret;
-                    }
+                    return new JObject() { ["hash"] = hash.ToString() };
                 case VerifyResult.AlreadyExists:
-                    {
-                        throw new RpcException(RpcError.AlreadyExists.WithData(reason.ToString()));
-                    }
+                    throw new RpcException(RpcError.AlreadyExists.WithData(reason.ToString()));
                 case VerifyResult.AlreadyInPool:
-                    {
-                        throw new RpcException(RpcError.AlreadyInPool.WithData(reason.ToString()));
-                    }
+                    throw new RpcException(RpcError.AlreadyInPool.WithData(reason.ToString()));
                 case VerifyResult.OutOfMemory:
-                    {
-                        throw new RpcException(RpcError.MempoolCapReached.WithData(reason.ToString()));
-                    }
+                    throw new RpcException(RpcError.MempoolCapReached.WithData(reason.ToString()));
                 case VerifyResult.InvalidScript:
-                    {
-                        throw new RpcException(RpcError.InvalidScript.WithData(reason.ToString()));
-                    }
+                    throw new RpcException(RpcError.InvalidScript.WithData(reason.ToString()));
                 case VerifyResult.InvalidAttribute:
-                    {
-                        throw new RpcException(RpcError.InvalidAttribute.WithData(reason.ToString()));
-                    }
+                    throw new RpcException(RpcError.InvalidAttribute.WithData(reason.ToString()));
                 case VerifyResult.InvalidSignature:
-                    {
-                        throw new RpcException(RpcError.InvalidSignature.WithData(reason.ToString()));
-                    }
+                    throw new RpcException(RpcError.InvalidSignature.WithData(reason.ToString()));
                 case VerifyResult.OverSize:
-                    {
-                        throw new RpcException(RpcError.InvalidSize.WithData(reason.ToString()));
-                    }
+                    throw new RpcException(RpcError.InvalidSize.WithData(reason.ToString()));
                 case VerifyResult.Expired:
-                    {
-                        throw new RpcException(RpcError.ExpiredTransaction.WithData(reason.ToString()));
-                    }
+                    throw new RpcException(RpcError.ExpiredTransaction.WithData(reason.ToString()));
                 case VerifyResult.InsufficientFunds:
-                    {
-                        throw new RpcException(RpcError.InsufficientFunds.WithData(reason.ToString()));
-                    }
+                    throw new RpcException(RpcError.InsufficientFunds.WithData(reason.ToString()));
                 case VerifyResult.PolicyFail:
-                    {
-                        throw new RpcException(RpcError.PolicyFailed.WithData(reason.ToString()));
-                    }
+                    throw new RpcException(RpcError.PolicyFailed.WithData(reason.ToString()));
                 default:
-                    {
-                        throw new RpcException(RpcError.VerificationFailed.WithData(reason.ToString()));
-                    }
+                    throw new RpcException(RpcError.VerificationFailed.WithData(reason.ToString()));
+
             }
         }
 

--- a/src/Plugins/RpcServer/RpcServer.SmartContract.cs
+++ b/src/Plugins/RpcServer/RpcServer.SmartContract.cs
@@ -80,11 +80,12 @@ namespace Neo.Plugins.RpcServer
                 json["exception"] = GetExceptionMessage(session.Engine.FaultException);
                 json["notifications"] = new JArray(session.Engine.Notifications.Select(n =>
                 {
-                    var obj = new JObject();
-                    obj["eventname"] = n.EventName;
-                    obj["contract"] = n.ScriptHash.ToString();
-                    obj["state"] = ToJson(n.State, session);
-                    return obj;
+                    return new JObject()
+                    {
+                        ["eventname"] = n.EventName,
+                        ["contract"] = n.ScriptHash.ToString(),
+                        ["state"] = ToJson(n.State, session),
+                    };
                 }));
                 if (useDiagnostic)
                 {
@@ -134,8 +135,7 @@ namespace Neo.Plugins.RpcServer
 
         protected static JObject ToJson(TreeNode<UInt160> node)
         {
-            JObject json = new();
-            json["hash"] = node.Item.ToString();
+            var json = new JObject() { ["hash"] = node.Item.ToString() };
             if (node.Children.Any())
             {
                 json["call"] = new JArray(node.Children.Select(ToJson));
@@ -145,7 +145,7 @@ namespace Neo.Plugins.RpcServer
 
         protected static JArray ToJson(IEnumerable<KeyValuePair<StorageKey, DataCache.Trackable>> changes)
         {
-            JArray array = new();
+            var array = new JArray();
             foreach (var entry in changes)
             {
                 array.Add(new JObject
@@ -160,7 +160,7 @@ namespace Neo.Plugins.RpcServer
 
         private static JObject ToJson(StackItem item, Session session)
         {
-            JObject json = item.ToJson();
+            var json = item.ToJson();
             if (item is InteropInterface interopInterface && interopInterface.GetInterface<object>() is IIterator iterator)
             {
                 Guid id = Guid.NewGuid();
@@ -281,12 +281,12 @@ namespace Neo.Plugins.RpcServer
         protected internal virtual JToken GetUnclaimedGas(JArray _params)
         {
             string address = Result.Ok_Or(() => _params[0].AsString(), RpcError.InvalidParams.WithData($"Invalid address {nameof(address)}"));
-            JObject json = new();
-            UInt160 script_hash = Result.Ok_Or(() => AddressToScriptHash(address, system.Settings.AddressVersion), RpcError.InvalidParams);
+            var json = new JObject();
+            UInt160 scriptHash = Result.Ok_Or(() => AddressToScriptHash(address, system.Settings.AddressVersion), RpcError.InvalidParams);
 
             var snapshot = system.StoreView;
-            json["unclaimed"] = NativeContract.NEO.UnclaimedGas(snapshot, script_hash, NativeContract.Ledger.CurrentIndex(snapshot) + 1).ToString();
-            json["address"] = script_hash.ToAddress(system.Settings.AddressVersion);
+            json["unclaimed"] = NativeContract.NEO.UnclaimedGas(snapshot, scriptHash, NativeContract.Ledger.CurrentIndex(snapshot) + 1).ToString();
+            json["address"] = scriptHash.ToAddress(system.Settings.AddressVersion);
             return json;
         }
 

--- a/src/Plugins/RpcServer/RpcServer.Utilities.cs
+++ b/src/Plugins/RpcServer/RpcServer.Utilities.cs
@@ -37,7 +37,6 @@ namespace Neo.Plugins.RpcServer
         protected internal virtual JToken ValidateAddress(JArray _params)
         {
             string address = Result.Ok_Or(() => _params[0].AsString(), RpcError.InvalidParams.WithData($"Invlid address format: {_params[0]}"));
-            JObject json = new();
             UInt160 scriptHash;
             try
             {
@@ -47,9 +46,12 @@ namespace Neo.Plugins.RpcServer
             {
                 scriptHash = null;
             }
-            json["address"] = address;
-            json["isvalid"] = scriptHash != null;
-            return json;
+
+            return new JObject()
+            {
+                ["address"] = address,
+                ["isvalid"] = scriptHash != null,
+            };
         }
     }
 }

--- a/tests/Neo.Network.RPC.Tests/UT_TransactionManager.cs
+++ b/tests/Neo.Network.RPC.Tests/UT_TransactionManager.cs
@@ -94,8 +94,7 @@ namespace Neo.Network.RPC.Tests
             mockRpc.Setup(p => p.RpcSendAsync("getblockcount")).ReturnsAsync(100).Verifiable();
 
             // calculatenetworkfee
-            var networkfee = new JObject();
-            networkfee["networkfee"] = 100000000;
+            var networkfee = new JObject() { ["networkfee"] = 100000000 };
             mockRpc.Setup(p => p.RpcSendAsync("calculatenetworkfee", It.Is<JToken[]>(u => true)))
                 .ReturnsAsync(networkfee)
                 .Verifiable();

--- a/tests/Neo.Network.RPC.Tests/UT_WalletAPI.cs
+++ b/tests/Neo.Network.RPC.Tests/UT_WalletAPI.cs
@@ -11,7 +11,6 @@
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
-using Neo.Cryptography.ECC;
 using Neo.Extensions;
 using Neo.Json;
 using Neo.Network.P2P.Payloads;
@@ -100,8 +99,7 @@ namespace Neo.Network.RPC.Tests
             byte[] testScript = NativeContract.NEO.Hash.MakeScript("transfer", sender, sender, new BigInteger(1_00000000), null);
             UT_TransactionManager.MockInvokeScript(rpcClientMock, testScript, new ContractParameter { Type = ContractParameterType.Integer, Value = new BigInteger(1_10000000) });
 
-            var json = new JObject();
-            json["hash"] = UInt256.Zero.ToString();
+            var json = new JObject() { ["hash"] = UInt256.Zero.ToString() };
             rpcClientMock.Setup(p => p.RpcSendAsync("sendrawtransaction", It.IsAny<JToken>())).ReturnsAsync(json);
 
             var tranaction = await walletAPI.ClaimGasAsync(keyPair1.Export(), false);
@@ -119,8 +117,7 @@ namespace Neo.Network.RPC.Tests
                 .ToArray();
             UT_TransactionManager.MockInvokeScript(rpcClientMock, testScript, new ContractParameter { Type = ContractParameterType.Integer, Value = new BigInteger(1_10000000) });
 
-            var json = new JObject();
-            json["hash"] = UInt256.Zero.ToString();
+            var json = new JObject() { ["hash"] = UInt256.Zero.ToString() };
             rpcClientMock.Setup(p => p.RpcSendAsync("sendrawtransaction", It.IsAny<JToken>())).ReturnsAsync(json);
 
             var tranaction = await walletAPI.TransferAsync(NativeContract.GAS.Hash.ToString(), keyPair1.Export(), UInt160.Zero.ToAddress(client.protocolSettings.AddressVersion), 100, null, true);
@@ -143,8 +140,7 @@ namespace Neo.Network.RPC.Tests
                 .ToArray();
             UT_TransactionManager.MockInvokeScript(rpcClientMock, testScript, new ContractParameter { Type = ContractParameterType.Integer, Value = new BigInteger(1_10000000) });
 
-            var json = new JObject();
-            json["hash"] = UInt256.Zero.ToString();
+            var json = new JObject() { ["hash"] = UInt256.Zero.ToString() };
             rpcClientMock.Setup(p => p.RpcSendAsync("sendrawtransaction", It.IsAny<JToken>())).ReturnsAsync(json);
 
             var tranaction = await walletAPI.TransferAsync(NativeContract.GAS.Hash, 1, new[] { keyPair1.PublicKey }, new[] { keyPair1 }, UInt160.Zero, NativeContract.GAS.Factor * 100, null, true);

--- a/tests/Neo.Plugins.RpcServer.Tests/UT_RpcErrorHandling.cs
+++ b/tests/Neo.Plugins.RpcServer.Tests/UT_RpcErrorHandling.cs
@@ -130,11 +130,13 @@ namespace Neo.Plugins.RpcServer.Tests
 
             // Create a context and request object to simulate a real RPC call
             var context = new DefaultHttpContext();
-            var request = new JObject();
-            request["jsonrpc"] = "2.0";
-            request["id"] = 1;
-            request["method"] = "sendrawtransaction";
-            request["params"] = new JArray { txString };
+            var request = new JObject()
+            {
+                ["jsonrpc"] = "2.0",
+                ["id"] = 1,
+                ["method"] = "sendrawtransaction",
+                ["params"] = new JArray { txString },
+            };
 
             // Process the request directly through the RPC server
             var response = await _rpcServer.ProcessRequestAsync(context, request);
@@ -293,11 +295,13 @@ namespace Neo.Plugins.RpcServer.Tests
 
             // Create a context and request object to simulate a real RPC call
             var context = new DefaultHttpContext();
-            var request = new JObject();
-            request["jsonrpc"] = "2.0";
-            request["id"] = 1;
-            request["method"] = "sendrawtransaction";
-            request["params"] = new JArray { txString };
+            var request = new JObject()
+            {
+                ["jsonrpc"] = "2.0",
+                ["id"] = 1,
+                ["method"] = "sendrawtransaction",
+                ["params"] = new JArray { txString },
+            };
 
             // Process the request - this should use the standard RPC processing
             var response = await _rpcServer.ProcessRequestAsync(context, request);
@@ -333,9 +337,7 @@ namespace Neo.Plugins.RpcServer.Tests
             catch (FormatException)
             {
                 // Simulate ProcessAsync behavior for malformed JSON
-                responseJson = new JObject();
-                responseJson["error"] = RpcError.BadRequest.ToJson();
-                return responseJson;
+                return new JObject() { ["error"] = RpcError.BadRequest.ToJson() };
             }
 
             if (requestJson is JObject singleRequest)
@@ -353,18 +355,22 @@ namespace Neo.Plugins.RpcServer.Tests
                         {
                             var result = _rpcServer.SendRawTransaction(parameters[0].AsString());
                             // Create a successful response
-                            responseJson = new JObject();
-                            responseJson["jsonrpc"] = "2.0";
-                            responseJson["id"] = singleRequest["id"];
-                            responseJson["result"] = result;
+                            responseJson = new JObject()
+                            {
+                                ["jsonrpc"] = "2.0",
+                                ["id"] = singleRequest["id"],
+                                ["result"] = result,
+                            };
                         }
                         catch (RpcException ex)
                         {
                             // Create an error response with the correct error code
-                            responseJson = new JObject();
-                            responseJson["jsonrpc"] = "2.0";
-                            responseJson["id"] = singleRequest["id"];
-                            responseJson["error"] = ex.GetError().ToJson();
+                            responseJson = new JObject()
+                            {
+                                ["jsonrpc"] = "2.0",
+                                ["id"] = singleRequest["id"],
+                                ["error"] = ex.GetError().ToJson(),
+                            };
                         }
                     }
                     else
@@ -384,10 +390,12 @@ namespace Neo.Plugins.RpcServer.Tests
                 if (batchRequest.Count == 0)
                 {
                     // Simulate ProcessAsync behavior for empty batch
-                    responseJson = new JObject();
-                    responseJson["jsonrpc"] = "2.0";
-                    responseJson["id"] = null;
-                    responseJson["error"] = RpcError.InvalidRequest.ToJson();
+                    responseJson = new JObject()
+                    {
+                        ["jsonrpc"] = "2.0",
+                        ["id"] = null,
+                        ["error"] = RpcError.InvalidRequest.ToJson(),
+                    };
                 }
                 else
                 {
@@ -400,8 +408,7 @@ namespace Neo.Plugins.RpcServer.Tests
             else
             {
                 // Should not happen with valid JSON
-                responseJson = new JObject();
-                responseJson["error"] = RpcError.InvalidRequest.ToJson();
+                responseJson = new JObject() { ["error"] = RpcError.InvalidRequest.ToJson() };
             }
 
             return responseJson;

--- a/tests/Neo.Plugins.RpcServer.Tests/UT_RpcServer.Blockchain.cs
+++ b/tests/Neo.Plugins.RpcServer.Tests/UT_RpcServer.Blockchain.cs
@@ -399,15 +399,20 @@ namespace Neo.Plugins.RpcServer.Tests
             snapshot.Commit();
             var result = _rpcServer.FindStorage(new(contractState.Hash), Convert.ToBase64String(key), 0);
 
-            var json = new JObject();
             var jarr = new JArray();
-            var j = new JObject();
-            j["key"] = Convert.ToBase64String(key);
-            j["value"] = Convert.ToBase64String(value);
+            var j = new JObject()
+            {
+                ["key"] = Convert.ToBase64String(key),
+                ["value"] = Convert.ToBase64String(value),
+            };
             jarr.Add(j);
-            json["truncated"] = false;
-            json["next"] = 1;
-            json["results"] = jarr;
+
+            var json = new JObject()
+            {
+                ["truncated"] = false,
+                ["next"] = 1,
+                ["results"] = jarr,
+            };
             Assert.AreEqual(json.ToString(), result.ToString());
 
             var result2 = _rpcServer.FindStorage(new(contractState.Hash), Convert.ToBase64String(key));
@@ -518,10 +523,11 @@ namespace Neo.Plugins.RpcServer.Tests
             var validators = NativeContract.NEO.GetNextBlockValidators(snapshot, _neoSystem.Settings.ValidatorsCount);
             var expected = validators.Select(p =>
             {
-                var validator = new JObject();
-                validator["publickey"] = p.ToString();
-                validator["votes"] = (int)NativeContract.NEO.GetCandidateVote(snapshot, p);
-                return validator;
+                return new JObject()
+                {
+                    ["publickey"] = p.ToString(),
+                    ["votes"] = (int)NativeContract.NEO.GetCandidateVote(snapshot, p),
+                };
             }).ToArray();
             Assert.AreEqual(new JArray(expected).ToString(), result.ToString());
         }
@@ -543,10 +549,12 @@ namespace Neo.Plugins.RpcServer.Tests
             result = _rpcServer.GetCandidates();
             foreach (var candidate in candidates)
             {
-                var item = new JObject();
-                item["publickey"] = candidate.PublicKey.ToString();
-                item["votes"] = candidate.Votes.ToString();
-                item["active"] = validators.Contains(candidate.PublicKey);
+                var item = new JObject()
+                {
+                    ["publickey"] = candidate.PublicKey.ToString(),
+                    ["votes"] = candidate.Votes.ToString(),
+                    ["active"] = validators.Contains(candidate.PublicKey),
+                };
                 json.Add(item);
             }
             Assert.AreEqual(json.ToString(), result.ToString());

--- a/tests/Neo.Plugins.RpcServer.Tests/UT_RpcServer.SmartContract.cs
+++ b/tests/Neo.Plugins.RpcServer.Tests/UT_RpcServer.SmartContract.cs
@@ -118,13 +118,14 @@ namespace Neo.Plugins.RpcServer.Tests
         {
             _rpcServer.wallet = _wallet;
 
-            HttpContext context = new DefaultHttpContext();
-
-            var json = new JObject();
-            json["id"] = 1;
-            json["jsonrpc"] = "2.0";
-            json["method"] = "invokefunction";
-            json["params"] = new JArray("0", "totalSupply", new JArray([]), validatorSigner, true);
+            var context = new DefaultHttpContext();
+            var json = new JObject()
+            {
+                ["id"] = 1,
+                ["jsonrpc"] = "2.0",
+                ["method"] = "invokefunction",
+                ["params"] = new JArray("0", "totalSupply", new JArray([]), validatorSigner, true),
+            };
 
             var resp = _rpcServer.ProcessRequestAsync(context, json).GetAwaiter().GetResult();
 

--- a/tests/Neo.Plugins.RpcServer.Tests/UT_RpcServer.cs
+++ b/tests/Neo.Plugins.RpcServer.Tests/UT_RpcServer.cs
@@ -146,9 +146,7 @@ namespace Neo.Plugins.RpcServer.Tests
             catch (FormatException)
             {
                 // Simulate ProcessAsync behavior for malformed JSON
-                responseJson = new JObject();
-                responseJson["error"] = RpcError.BadRequest.ToJson();
-                return responseJson;
+                return new JObject() { ["error"] = RpcError.BadRequest.ToJson() };
             }
 
             if (requestJson is JObject singleRequest)
@@ -160,10 +158,12 @@ namespace Neo.Plugins.RpcServer.Tests
                 if (batchRequest.Count == 0)
                 {
                     // Simulate ProcessAsync behavior for empty batch
-                    responseJson = new JObject();
-                    responseJson["jsonrpc"] = "2.0";
-                    responseJson["id"] = null;
-                    responseJson["error"] = RpcError.InvalidRequest.ToJson();
+                    responseJson = new JObject()
+                    {
+                        ["jsonrpc"] = "2.0",
+                        ["id"] = null,
+                        ["error"] = RpcError.InvalidRequest.ToJson(),
+                    };
                 }
                 else
                 {
@@ -178,8 +178,7 @@ namespace Neo.Plugins.RpcServer.Tests
             {
                 // Should not happen with valid JSON
                 // Revert to standard assignment
-                responseJson = new JObject();
-                responseJson["error"] = RpcError.InvalidRequest.ToJson();
+                responseJson = new JObject() { ["error"] = RpcError.InvalidRequest.ToJson() };
             }
 
             return responseJson;


### PR DESCRIPTION
# Description

Unify json initialization style for rpc client and rpc server with index initializers.

There are two styles to initialize a `JObject`.
This PR unifies these two styles, and make code more clearer.


## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Optimization (the change is only an optimization)
- [x] Style (the change is only a code style for better maintenance or standard purpose)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
