### PR TITLE
[`Bug`] Fix MemorySnapshot bug

### DIFF
--- a/src/Neo/Persistence/Providers/MemorySnapshot.cs
+++ b/src/Neo/Persistence/Providers/MemorySnapshot.cs
@@ -31,6 +31,8 @@ namespace Neo.Persistence.Providers
 
         public IStore Store { get; }
 
+        internal int WriteBatchLength => _writeBatch.Count;
+
         internal MemorySnapshot(MemoryStore store, ConcurrentDictionary<byte[], byte[]> innerData)
         {
             Store = store;
@@ -46,6 +48,8 @@ namespace Neo.Persistence.Providers
                     _innerData.TryRemove(pair.Key, out _);
                 else
                     _innerData[pair.Key] = pair.Value;
+
+            _writeBatch.Clear();
         }
 
         public void Delete(byte[] key)

--- a/tests/Neo.UnitTests/Persistence/UT_MemorySnapshot.cs
+++ b/tests/Neo.UnitTests/Persistence/UT_MemorySnapshot.cs
@@ -35,6 +35,25 @@ namespace Neo.UnitTests.Persistence
         }
 
         [TestMethod]
+        public void TestDobleCommit()
+        {
+            var key1 = new byte[] { 0x05, 0x02 };
+            var value1 = new byte[] { 0x06, 0x04 };
+
+            var snapshot = (MemorySnapshot)_memoryStore.GetSnapshot();
+            Assert.AreEqual(0, snapshot.WriteBatchLength);
+
+            snapshot.Put(key1, value1);
+            Assert.AreEqual(1, snapshot.WriteBatchLength);
+
+            snapshot.Delete(key1);
+            Assert.AreEqual(1, snapshot.WriteBatchLength);
+            snapshot.Commit();
+
+            Assert.AreEqual(0, snapshot.WriteBatchLength);
+        }
+
+        [TestMethod]
         public void SingleSnapshotTest()
         {
             var key1 = new byte[] { 0x01, 0x02 };

--- a/tests/Neo.UnitTests/Persistence/UT_MemorySnapshot.cs
+++ b/tests/Neo.UnitTests/Persistence/UT_MemorySnapshot.cs
@@ -54,6 +54,32 @@ namespace Neo.UnitTests.Persistence
         }
 
         [TestMethod]
+        public void TestDobleCommitTwo()
+        {
+            var key1 = new byte[] { 0x51, 0x02 };
+            var value1 = new byte[] { 0x06, 0x04 };
+
+            var snapshotA = (MemorySnapshot)_memoryStore.GetSnapshot();
+            var snapshotB = (MemorySnapshot)_memoryStore.GetSnapshot();
+
+            Assert.IsFalse(_memoryStore.Contains(key1));
+            snapshotA.Put(key1, value1);
+            snapshotA.Commit();
+            Assert.IsTrue(_memoryStore.Contains(key1));
+
+            snapshotB.Delete(key1);
+            snapshotB.Commit();
+            Assert.IsFalse(_memoryStore.Contains(key1));
+
+            snapshotA.Put(key1, value1);
+            snapshotA.Commit();
+            Assert.IsTrue(_memoryStore.Contains(key1));
+
+            snapshotB.Commit(); // Already committed
+            Assert.IsTrue(_memoryStore.Contains(key1)); // It fails before #3953
+        }
+
+        [TestMethod]
         public void SingleSnapshotTest()
         {
             var key1 = new byte[] { 0x01, 0x02 };


### PR DESCRIPTION
# Description

When the `MemorySnapshot` is committed, the batch is not cleaned, it must be cleaned or otherwise can produce undesired results.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] TestDobleCommit
- [x] TestDobleCommitTwo

**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
