### PR TITLE
Optimize: keep more exception info in UInt160.Parse and UInt256.Parse

### DIFF
--- a/src/Neo.Extensions/StringExtensions.cs
+++ b/src/Neo.Extensions/StringExtensions.cs
@@ -175,7 +175,7 @@ namespace Neo.Extensions
         /// </summary>
         /// <param name="value">The <see cref="string"/> to trim.</param>
         /// <param name="prefix">The prefix to trim.</param>
-        /// <returns>The trimmed <see cref="string"/>.</returns>
+        /// <returns>The trimmed <see cref="string"/> without prefix. If no prefix is found than the input <see cref="string"/> is returned unmodified.</returns>
         public static ReadOnlySpan<char> TrimStartIgnoreCase(this ReadOnlySpan<char> value, ReadOnlySpan<char> prefix)
         {
             if (value.StartsWith(prefix, StringComparison.InvariantCultureIgnoreCase))

--- a/src/Neo.Extensions/StringExtensions.cs
+++ b/src/Neo.Extensions/StringExtensions.cs
@@ -175,7 +175,10 @@ namespace Neo.Extensions
         /// </summary>
         /// <param name="value">The <see cref="string"/> to trim.</param>
         /// <param name="prefix">The prefix to trim.</param>
-        /// <returns>The trimmed <see cref="string"/> without prefix. If no prefix is found than the input <see cref="string"/> is returned unmodified.</returns>
+        /// <returns>
+        /// The trimmed ReadOnlySpan without prefix. If no prefix is found, the input is returned unmodified.
+        /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ReadOnlySpan<char> TrimStartIgnoreCase(this ReadOnlySpan<char> value, ReadOnlySpan<char> prefix)
         {
             if (value.StartsWith(prefix, StringComparison.InvariantCultureIgnoreCase))

--- a/src/Neo.Extensions/StringExtensions.cs
+++ b/src/Neo.Extensions/StringExtensions.cs
@@ -149,7 +149,7 @@ namespace Neo.Extensions
             if (value.IsEmpty)
                 return [];
             if (value.Length % 2 == 1)
-                throw new FormatException();
+                throw new FormatException($"value.Length({value.Length}) not multiple of 2");
             var result = new byte[value.Length / 2];
             for (var i = 0; i < result.Length; i++)
                 result[i] = byte.Parse(value.Slice(i * 2, 2), NumberStyles.AllowHexSpecifier);
@@ -168,6 +168,19 @@ namespace Neo.Extensions
         {
             var size = value.GetStrictUtf8ByteCount();
             return size.GetVarSize() + size;
+        }
+
+        /// <summary>
+        /// Trims the specified prefix from the start of the <see cref="string"/>, ignoring case.
+        /// </summary>
+        /// <param name="value">The <see cref="string"/> to trim.</param>
+        /// <param name="prefix">The prefix to trim.</param>
+        /// <returns>The trimmed <see cref="string"/>.</returns>
+        public static ReadOnlySpan<char> TrimStartIgnoreCase(this ReadOnlySpan<char> value, ReadOnlySpan<char> prefix)
+        {
+            if (value.StartsWith(prefix, StringComparison.InvariantCultureIgnoreCase))
+                return value[prefix.Length..];
+            return value;
         }
     }
 }

--- a/src/Neo/UInt160.cs
+++ b/src/Neo/UInt160.cs
@@ -159,7 +159,6 @@ namespace Neo
             return "0x" + this.ToArray().ToHexString(reverse: true);
         }
 
-
         /// <summary>
         /// Parses an <see cref="UInt160"/> from the specified <see cref="string"/>.
         /// </summary>

--- a/src/Neo/UInt160.cs
+++ b/src/Neo/UInt160.cs
@@ -147,18 +147,6 @@ namespace Neo
             BinaryPrimitives.WriteUInt32LittleEndian(destination[IxValue3..], _value3);
         }
 
-        /// <summary>
-        /// Parses an <see cref="UInt160"/> from the specified <see cref="string"/>.
-        /// </summary>
-        /// <param name="value">An <see cref="UInt160"/> represented by a <see cref="string"/>.</param>
-        /// <returns>The parsed <see cref="UInt160"/>.</returns>
-        /// <exception cref="FormatException"><paramref name="value"/> is not in the correct format.</exception>
-        public static UInt160 Parse(string value)
-        {
-            if (!TryParse(value, out var result)) throw new FormatException();
-            return result;
-        }
-
         public void Serialize(BinaryWriter writer)
         {
             writer.Write(_value1);
@@ -171,21 +159,20 @@ namespace Neo
             return "0x" + this.ToArray().ToHexString(reverse: true);
         }
 
+
         /// <summary>
         /// Parses an <see cref="UInt160"/> from the specified <see cref="string"/>.
         /// </summary>
-        /// <param name="str">An <see cref="UInt160"/> represented by a <see cref="string"/>.</param>
+        /// <param name="value">An <see cref="UInt160"/> represented by a <see cref="string"/>.</param>
         /// <param name="result">The parsed <see cref="UInt160"/>.</param>
-        /// <returns><see langword="true"/> if an <see cref="UInt160"/> is successfully parsed; otherwise, <see langword="false"/>.</returns>
-        public static bool TryParse(string str, [NotNullWhen(true)] out UInt160 result)
+        /// <returns>
+        /// <see langword="true"/> if an <see cref="UInt160"/> is successfully parsed; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool TryParse(string value, [NotNullWhen(true)] out UInt160 result)
         {
             result = null;
-            var data = str.AsSpan(); // AsSpan is null safe
-            if (data.StartsWith("0x", StringComparison.InvariantCultureIgnoreCase))
-                data = data[2..];
-
+            var data = value.AsSpan().TrimStartIgnoreCase("0x");
             if (data.Length != Length * 2) return false;
-
             try
             {
                 result = new UInt160(data.HexToBytesReversed());
@@ -195,6 +182,21 @@ namespace Neo
             {
                 return false;
             }
+        }
+
+
+        /// <summary>
+        /// Parses an <see cref="UInt160"/> from the specified <see cref="string"/>.
+        /// </summary>
+        /// <param name="value">An <see cref="UInt160"/> represented by a <see cref="string"/>.</param>
+        /// <returns>The parsed <see cref="UInt160"/>.</returns>
+        /// <exception cref="FormatException"><paramref name="value"/> is not in the correct format.</exception>
+        public static UInt160 Parse(string value)
+        {
+            var data = value.AsSpan().TrimStartIgnoreCase("0x");
+            if (data.Length != Length * 2)
+                throw new FormatException($"value.Length({data.Length}) != {Length * 2}");
+            return new UInt160(data.HexToBytesReversed());
         }
 
         public static implicit operator UInt160(string s)

--- a/src/Neo/UInt256.cs
+++ b/src/Neo/UInt256.cs
@@ -124,18 +124,6 @@ namespace Neo
             return buffer; // Keep the same output as Serialize when BigEndian
         }
 
-        /// <summary>
-        /// Parses an <see cref="UInt256"/> from the specified <see cref="string"/>.
-        /// </summary>
-        /// <param name="value">An <see cref="UInt256"/> represented by a <see cref="string"/>.</param>
-        /// <returns>The parsed <see cref="UInt256"/>.</returns>
-        /// <exception cref="FormatException"><paramref name="value"/> is not in the correct format.</exception>
-        public static UInt256 Parse(string value)
-        {
-            if (!TryParse(value, out var result)) throw new FormatException();
-            return result;
-        }
-
         public void Serialize(BinaryWriter writer)
         {
             writer.Write(_value1);
@@ -183,18 +171,17 @@ namespace Neo
         /// <summary>
         /// Parses an <see cref="UInt256"/> from the specified <see cref="string"/>.
         /// </summary>
-        /// <param name="s">An <see cref="UInt256"/> represented by a <see cref="string"/>.</param>
+        /// <param name="value">An <see cref="UInt256"/> represented by a <see cref="string"/>.</param>
         /// <param name="result">The parsed <see cref="UInt256"/>.</param>
-        /// <returns><see langword="true"/> if an <see cref="UInt256"/> is successfully parsed; otherwise, <see langword="false"/>.</returns>
-        public static bool TryParse(string s, [NotNullWhen(true)] out UInt256 result)
+        /// <returns>
+        /// <see langword="true"/> if an <see cref="UInt256"/> is successfully parsed; otherwise, <see langword="false"/>.
+        /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryParse(string value, [NotNullWhen(true)] out UInt256 result)
         {
             result = null;
-            var data = s.AsSpan(); // AsSpan is null safe
-            if (data.StartsWith("0x", StringComparison.InvariantCultureIgnoreCase))
-                data = data[2..];
-
+            var data = value.AsSpan().TrimStartIgnoreCase("0x");
             if (data.Length != Length * 2) return false;
-
             try
             {
                 result = new UInt256(data.HexToBytesReversed());
@@ -204,6 +191,20 @@ namespace Neo
             {
                 return false;
             }
+        }
+
+        /// <summary>
+        /// Parses an <see cref="UInt256"/> from the specified <see cref="string"/>.
+        /// </summary>
+        /// <param name="value">An <see cref="UInt256"/> represented by a <see cref="string"/>.</param>
+        /// <returns>The parsed <see cref="UInt256"/>.</returns>
+        /// <exception cref="FormatException"><paramref name="value"/> is not in the correct format.</exception>
+        public static UInt256 Parse(string value)
+        {
+            var data = value.AsSpan().TrimStartIgnoreCase("0x");
+            if (data.Length != Length * 2)
+                throw new FormatException($"value.Length({data.Length}) != {Length * 2}");
+            return new UInt256(data.HexToBytesReversed());
         }
 
         public static bool operator ==(UInt256 left, UInt256 right)

--- a/tests/Neo.Extensions.Tests/UT_StringExtensions.cs
+++ b/tests/Neo.Extensions.Tests/UT_StringExtensions.cs
@@ -94,6 +94,14 @@ namespace Neo.Extensions.Tests
         }
 
         [TestMethod]
+        public void TestTrimStartIgnoreCase()
+        {
+            Assert.AreEqual("010203", "0x010203".AsSpan().TrimStartIgnoreCase("0x").ToString());
+            Assert.AreEqual("010203", "0x010203".AsSpan().TrimStartIgnoreCase("0X").ToString());
+            Assert.AreEqual("010203", "0X010203".AsSpan().TrimStartIgnoreCase("0x").ToString());
+        }
+
+        [TestMethod]
         public void TestGetVarSizeGeneric()
         {
             for (int i = 0; i < 9; i++)


### PR DESCRIPTION
Keep more exception info when UInt160.Parse and UInt256.Parse throw exception:

The current implementation of `UInt160.Parse` and `UInt256.Parse` use `TryParse`, but the exception message will be lost if throw `FormatException`.

Now `UInt160.TryParse` and `UInt256.TryParse` use `Parse`, the exception message not be lost.


<!-- Please delete options that are not relevant. -->

- [x] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
