### PR TITLE
Fix syscall `getRandom` with `nonceData`

### DIFF
--- a/src/Neo/SmartContract/ApplicationEngine.Runtime.cs
+++ b/src/Neo/SmartContract/ApplicationEngine.Runtime.cs
@@ -317,6 +317,11 @@ namespace Neo.SmartContract
                 buffer = Cryptography.Helper.Murmur128(nonceData, ProtocolSettings.Network + random_times++);
                 price = 1 << 13;
             }
+            else if (IsHardforkEnabled(Hardfork.HF_Echidna)) // please add new hardfork name
+            {
+                buffer = nonceData = Cryptography.Helper.Murmur128(nonceData, ProtocolSettings.Network + random_times++);
+                price = 1 << 13;
+            }
             else
             {
                 buffer = nonceData = Cryptography.Helper.Murmur128(nonceData, ProtocolSettings.Network);


### PR DESCRIPTION
# Description

`nonceData` was not being set when using `syscall [getRandom]` in hardfork `HF_Aspidochelone`.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
- [ ] Unit Testing

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules