### PR TITLE
Optimize: use CommonPrefixLength instead in Trie.Put

### DIFF
--- a/src/Neo.Cryptography.MPTTrie/Cryptography/MPTTrie/Trie.Put.cs
+++ b/src/Neo.Cryptography.MPTTrie/Cryptography/MPTTrie/Trie.Put.cs
@@ -10,23 +10,17 @@
 // modifications are permitted.
 
 using System;
+using System.Runtime.CompilerServices;
 
 namespace Neo.Cryptography.MPTTrie
 {
     partial class Trie
     {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static ReadOnlySpan<byte> CommonPrefix(ReadOnlySpan<byte> a, ReadOnlySpan<byte> b)
         {
-            var minLen = a.Length <= b.Length ? a.Length : b.Length;
-            var i = 0;
-            if (a.Length != 0 && b.Length != 0)
-            {
-                for (i = 0; i < minLen; i++)
-                {
-                    if (a[i] != b[i]) break;
-                }
-            }
-            return a[..i];
+            int offset = a.CommonPrefixLength(b);
+            return a[..offset];
         }
 
         public void Put(byte[] key, byte[] value)


### PR DESCRIPTION
# Description

Use standard library extension `CommonPrefixLength` instead in `Trie.Put`

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
