### PR TITLE
Fix: Assertion arguments should be passed in the correct order

### DIFF
--- a/tests/Neo.ConsoleService.Tests/CommandTokenizerTest.cs
+++ b/tests/Neo.ConsoleService.Tests/CommandTokenizerTest.cs
@@ -21,8 +21,8 @@ namespace Neo.ConsoleService.Tests
         {
             var cmd = " ";
             var args = cmd.Tokenize();
-            Assert.AreEqual(args.Count, 1);
-            Assert.AreEqual(args[0].Value, " ");
+            Assert.AreEqual(1, args.Count);
+            Assert.AreEqual(" ", args[0].Value);
         }
 
         [TestMethod]
@@ -30,10 +30,10 @@ namespace Neo.ConsoleService.Tests
         {
             var cmd = "show  state";
             var args = cmd.Tokenize();
-            Assert.AreEqual(args.Count, 3);
-            Assert.AreEqual(args[0].Value, "show");
-            Assert.AreEqual(args[1].Value, "  ");
-            Assert.AreEqual(args[2].Value, "state");
+            Assert.AreEqual(3, args.Count);
+            Assert.AreEqual("show", args[0].Value);
+            Assert.AreEqual("  ", args[1].Value);
+            Assert.AreEqual("state", args[2].Value);
             Assert.AreEqual(cmd, args.JoinRaw());
         }
 
@@ -42,10 +42,10 @@ namespace Neo.ConsoleService.Tests
         {
             var cmd = "show \"hello world\"";
             var args = cmd.Tokenize();
-            Assert.AreEqual(args.Count, 3);
-            Assert.AreEqual(args[0].Value, "show");
-            Assert.AreEqual(args[1].Value, " ");
-            Assert.AreEqual(args[2].Value, "hello world");
+            Assert.AreEqual(3, args.Count);
+            Assert.AreEqual("show", args[0].Value);
+            Assert.AreEqual(" ", args[1].Value);
+            Assert.AreEqual("hello world", args[2].Value);
         }
 
         [TestMethod]
@@ -53,10 +53,10 @@ namespace Neo.ConsoleService.Tests
         {
             var cmd = "show \"'\"";
             var args = cmd.Tokenize();
-            Assert.AreEqual(args.Count, 3);
-            Assert.AreEqual(args[0].Value, "show");
-            Assert.AreEqual(args[1].Value, " ");
-            Assert.AreEqual(args[2].Value, "'");
+            Assert.AreEqual(3, args.Count);
+            Assert.AreEqual("show", args[0].Value);
+            Assert.AreEqual(" ", args[1].Value);
+            Assert.AreEqual("'", args[2].Value);
         }
 
         [TestMethod]
@@ -64,11 +64,11 @@ namespace Neo.ConsoleService.Tests
         {
             var cmd = "show \"123\\\"456\""; // Double quote because it is quoted twice in code and command.
             var args = CommandTokenizer.Tokenize(cmd);
-            Assert.AreEqual(args.Count, 3);
-            Assert.AreEqual(args[0].Value, "show");
-            Assert.AreEqual(args[1].Value, " ");
-            Assert.AreEqual(args[2].Value, "123\"456");
-            Assert.AreEqual(args[2].RawValue, "\"123\"456\"");
+            Assert.AreEqual(3, args.Count);
+            Assert.AreEqual("show", args[0].Value);
+            Assert.AreEqual(" ", args[1].Value);
+            Assert.AreEqual("123\"456", args[2].Value);
+            Assert.AreEqual("\"123\"456\"", args[2].RawValue);
         }
 
         [TestMethod]
@@ -76,42 +76,42 @@ namespace Neo.ConsoleService.Tests
         {
             var cmd = "show 'x1,x2,x3'";
             var args = CommandTokenizer.Tokenize(cmd);
-            Assert.AreEqual(args.Count, 3);
-            Assert.AreEqual(args[0].Value, "show");
-            Assert.AreEqual(args[1].Value, " ");
-            Assert.AreEqual(args[2].Value, "x1,x2,x3");
-            Assert.AreEqual(args[2].RawValue, "'x1,x2,x3'");
+            Assert.AreEqual(3, args.Count);
+            Assert.AreEqual("show", args[0].Value);
+            Assert.AreEqual(" ", args[1].Value);
+            Assert.AreEqual("x1,x2,x3", args[2].Value);
+            Assert.AreEqual("'x1,x2,x3'", args[2].RawValue);
 
             cmd = "show '\\n \\r \\t \\''"; // Double quote because it is quoted twice in code and command.
             args = CommandTokenizer.Tokenize(cmd);
-            Assert.AreEqual(args.Count, 3);
-            Assert.AreEqual(args[0].Value, "show");
-            Assert.AreEqual(args[1].Value, " ");
-            Assert.AreEqual(args[2].Value, "\n \r \t \'");
-            Assert.AreEqual(args[0].RawValue, "show");
-            Assert.AreEqual(args[1].RawValue, " ");
-            Assert.AreEqual(args[2].RawValue, "'\n \r \t \''");
+            Assert.AreEqual(3, args.Count);
+            Assert.AreEqual("show", args[0].Value);
+            Assert.AreEqual(" ", args[1].Value);
+            Assert.AreEqual("\n \r \t \'", args[2].Value);
+            Assert.AreEqual("show", args[0].RawValue);
+            Assert.AreEqual(" ", args[1].RawValue);
+            Assert.AreEqual("'\n \r \t \''", args[2].RawValue);
             Assert.AreEqual("show '\n \r \t \''", args.JoinRaw());
 
             var json = "[{\"type\":\"Hash160\",\"value\":\"0x0010922195a6c7cab3233f923716ad8e2dd63f8a\"}]";
             cmd = "invoke 0xef4073a0f2b305a38ec4050e4d3d28bc40ea63f5 balanceOf " + json;
             args = CommandTokenizer.Tokenize(cmd);
-            Assert.AreEqual(args.Count, 7);
-            Assert.AreEqual(args[0].Value, "invoke");
-            Assert.AreEqual(args[1].Value, " ");
-            Assert.AreEqual(args[2].Value, "0xef4073a0f2b305a38ec4050e4d3d28bc40ea63f5");
-            Assert.AreEqual(args[3].Value, " ");
-            Assert.AreEqual(args[4].Value, "balanceOf");
-            Assert.AreEqual(args[5].Value, " ");
+            Assert.AreEqual(7, args.Count);
+            Assert.AreEqual("invoke", args[0].Value);
+            Assert.AreEqual(" ", args[1].Value);
+            Assert.AreEqual("0xef4073a0f2b305a38ec4050e4d3d28bc40ea63f5", args[2].Value);
+            Assert.AreEqual(" ", args[3].Value);
+            Assert.AreEqual("balanceOf", args[4].Value);
+            Assert.AreEqual(" ", args[5].Value);
             Assert.AreEqual(args[6].Value, json);
 
             cmd = "show x'y'";
             args = CommandTokenizer.Tokenize(cmd);
-            Assert.AreEqual(args.Count, 3);
-            Assert.AreEqual(args[0].Value, "show");
-            Assert.AreEqual(args[1].Value, " ");
-            Assert.AreEqual(args[2].Value, "x'y'");
-            Assert.AreEqual(args[2].RawValue, "x'y'");
+            Assert.AreEqual(3, args.Count);
+            Assert.AreEqual("show", args[0].Value);
+            Assert.AreEqual(" ", args[1].Value);
+            Assert.AreEqual("x'y'", args[2].Value);
+            Assert.AreEqual("x'y'", args[2].RawValue);
         }
     }
 }

--- a/tests/Neo.Extensions.Tests/UT_BigIntegerExtensions.cs
+++ b/tests/Neo.Extensions.Tests/UT_BigIntegerExtensions.cs
@@ -106,7 +106,7 @@ namespace Neo.Extensions.Tests
             Assert.AreNotEqual(long.MinValue % long.MaxValue, result, "Mod should always return non-negative values, unlike % operator");
 
             // Test case 5: Verifying % operator behavior
-            Assert.AreEqual((long)(minValue % maxValue), long.MinValue % long.MaxValue, "% operator should behave consistently for BigInteger and long");
+            Assert.AreEqual(long.MinValue % long.MaxValue, (long)(minValue % maxValue), "% operator should behave consistently for BigInteger and long");
 
             // Test case 6: Mod with prime numbers
             Assert.AreEqual(17, new BigInteger(17).Mod(19), "Mod with a larger prime should return the original number");

--- a/tests/Neo.Json.UnitTests/UT_JArray.cs
+++ b/tests/Neo.Json.UnitTests/UT_JArray.cs
@@ -252,7 +252,7 @@ namespace Neo.Json.UnitTests
                 bob,
             };
             var s = jArray.AsString();
-            Assert.AreEqual(s, "[{\"name\":\"alice\",\"age\":30,\"score\":100.001,\"gender\":\"female\",\"isMarried\":true,\"pet\":{\"name\":\"Tom\",\"type\":\"cat\"}},{\"name\":\"bob\",\"age\":100000,\"score\":0.001,\"gender\":\"male\",\"isMarried\":false,\"pet\":{\"name\":\"Paul\",\"type\":\"dog\"}}]");
+            Assert.AreEqual("[{\"name\":\"alice\",\"age\":30,\"score\":100.001,\"gender\":\"female\",\"isMarried\":true,\"pet\":{\"name\":\"Tom\",\"type\":\"cat\"}},{\"name\":\"bob\",\"age\":100000,\"score\":0.001,\"gender\":\"male\",\"isMarried\":false,\"pet\":{\"name\":\"Paul\",\"type\":\"dog\"}}]", s);
         }
 
         [TestMethod]

--- a/tests/Neo.Network.RPC.Tests/UT_WalletAPI.cs
+++ b/tests/Neo.Network.RPC.Tests/UT_WalletAPI.cs
@@ -153,7 +153,7 @@ namespace Neo.Network.RPC.Tests
             }
             catch (Exception e)
             {
-                Assert.AreEqual(e.Message, $"Need at least 2 KeyPairs for signing!");
+                Assert.AreEqual($"Need at least 2 KeyPairs for signing!", e.Message);
             }
 
             testScript = NativeContract.GAS.Hash.MakeScript("transfer", multiSender, UInt160.Zero, NativeContract.GAS.Factor * 100, string.Empty)

--- a/tests/Neo.Plugins.OracleService.Tests/UT_OracleService.cs
+++ b/tests/Neo.Plugins.OracleService.Tests/UT_OracleService.cs
@@ -51,10 +51,10 @@ namespace Neo.Plugins.OracleService.Tests
         {
             var snapshotCache = TestBlockchain.GetTestSnapshotCache();
             var executionFactor = NativeContract.Policy.GetExecFeeFactor(snapshotCache);
-            Assert.AreEqual(executionFactor, (uint)30);
+            Assert.AreEqual((uint)30, executionFactor);
 
             var feePerByte = NativeContract.Policy.GetFeePerByte(snapshotCache);
-            Assert.AreEqual(feePerByte, 1000);
+            Assert.AreEqual(1000, feePerByte);
 
             OracleRequest request = new OracleRequest
             {

--- a/tests/Neo.Plugins.RpcServer.Tests/UT_RpcServer.SmartContract.cs
+++ b/tests/Neo.Plugins.RpcServer.Tests/UT_RpcServer.SmartContract.cs
@@ -62,26 +62,26 @@ namespace Neo.Plugins.RpcServer.Tests
         {
             _rpcServer.wallet = _wallet;
             JObject resp = (JObject)_rpcServer.InvokeFunction(new JArray(NeoToken.NEO.Hash.ToString(), "totalSupply", new JArray([]), validatorSigner, true));
-            Assert.AreEqual(resp.Count, 8);
+            Assert.AreEqual(8, resp.Count);
             Assert.AreEqual(resp["script"], NeoTotalSupplyScript);
             Assert.IsTrue(resp.ContainsProperty("gasconsumed"));
             Assert.IsTrue(resp.ContainsProperty("diagnostics"));
             Assert.AreEqual(resp["diagnostics"]["invokedcontracts"]["call"][0]["hash"], NeoToken.NEO.Hash.ToString());
             Assert.AreEqual(0, ((JArray)resp["diagnostics"]["storagechanges"]).Count);
             Assert.AreEqual(resp["state"], nameof(VMState.HALT));
-            Assert.AreEqual(resp["exception"], null);
-            Assert.AreEqual(((JArray)resp["notifications"]).Count, 0);
+            Assert.AreEqual(null, resp["exception"]);
+            Assert.AreEqual(0, ((JArray)resp["notifications"]).Count);
             Assert.AreEqual(resp["stack"][0]["type"], nameof(Integer));
             Assert.AreEqual(resp["stack"][0]["value"], "100000000");
             Assert.IsTrue(resp.ContainsProperty("tx"));
 
             resp = (JObject)_rpcServer.InvokeFunction(new JArray(NeoToken.NEO.Hash.ToString(), "symbol"));
-            Assert.AreEqual(resp.Count, 6);
+            Assert.AreEqual(6, resp.Count);
             Assert.IsTrue(resp.ContainsProperty("script"));
             Assert.IsTrue(resp.ContainsProperty("gasconsumed"));
             Assert.AreEqual(resp["state"], nameof(VMState.HALT));
-            Assert.AreEqual(resp["exception"], null);
-            Assert.AreEqual(((JArray)resp["notifications"]).Count, 0);
+            Assert.AreEqual(null, resp["exception"]);
+            Assert.AreEqual(0, ((JArray)resp["notifications"]).Count);
             Assert.AreEqual(resp["stack"][0]["type"], nameof(ByteString));
             Assert.AreEqual(resp["stack"][0]["value"], Convert.ToBase64String(Encoding.UTF8.GetBytes("NEO")));
 
@@ -92,7 +92,7 @@ namespace Neo.Plugins.RpcServer.Tests
                 new JObject() { ["type"] = nameof(ContractParameterType.Integer), ["value"] = "1" },
                 new JObject() { ["type"] = nameof(ContractParameterType.Any) },
             ]), multisigSigner, true));
-            Assert.AreEqual(resp.Count, 7);
+            Assert.AreEqual(7, resp.Count);
             Assert.AreEqual(resp["script"], NeoTransferScript);
             Assert.IsTrue(resp.ContainsProperty("gasconsumed"));
             Assert.IsTrue(resp.ContainsProperty("diagnostics"));
@@ -102,11 +102,11 @@ namespace Neo.Plugins.RpcServer.Tests
             Assert.AreEqual(resp["exception"], $"The smart contract or address {MultisigScriptHash} ({MultisigAddress}) is not found. " +
                                 $"If this is your wallet address and you want to sign a transaction with it, make sure you have opened this wallet.");
             JArray notifications = (JArray)resp["notifications"];
-            Assert.AreEqual(notifications.Count, 2);
-            Assert.AreEqual(notifications[0]["eventname"].AsString(), "Transfer");
+            Assert.AreEqual(2, notifications.Count);
+            Assert.AreEqual("Transfer", notifications[0]["eventname"].AsString());
             Assert.AreEqual(notifications[0]["contract"].AsString(), NeoToken.NEO.Hash.ToString());
             Assert.AreEqual(notifications[0]["state"]["value"][2]["value"], "1");
-            Assert.AreEqual(notifications[1]["eventname"].AsString(), "Transfer");
+            Assert.AreEqual("Transfer", notifications[1]["eventname"].AsString());
             Assert.AreEqual(notifications[1]["contract"].AsString(), GasToken.GAS.Hash.ToString());
             Assert.AreEqual(notifications[1]["state"]["value"][2]["value"], "50000000");
 
@@ -130,7 +130,7 @@ namespace Neo.Plugins.RpcServer.Tests
             var resp = _rpcServer.ProcessRequestAsync(context, json).GetAwaiter().GetResult();
 
             Console.WriteLine(resp);
-            Assert.AreEqual(resp.Count, 3);
+            Assert.AreEqual(3, resp.Count);
             Assert.IsNotNull(resp["error"]);
             Assert.AreEqual(resp["error"]["code"], -32602);
 
@@ -141,18 +141,18 @@ namespace Neo.Plugins.RpcServer.Tests
         public void TestInvokeScript()
         {
             JObject resp = (JObject)_rpcServer.InvokeScript(new JArray(NeoTotalSupplyScript, validatorSigner, true));
-            Assert.AreEqual(resp.Count, 7);
+            Assert.AreEqual(7, resp.Count);
             Assert.IsTrue(resp.ContainsProperty("gasconsumed"));
             Assert.IsTrue(resp.ContainsProperty("diagnostics"));
             Assert.AreEqual(resp["diagnostics"]["invokedcontracts"]["call"][0]["hash"], NeoToken.NEO.Hash.ToString());
             Assert.AreEqual(resp["state"], nameof(VMState.HALT));
-            Assert.AreEqual(resp["exception"], null);
-            Assert.AreEqual(((JArray)resp["notifications"]).Count, 0);
+            Assert.AreEqual(null, resp["exception"]);
+            Assert.AreEqual(0, ((JArray)resp["notifications"]).Count);
             Assert.AreEqual(resp["stack"][0]["type"], nameof(Integer));
             Assert.AreEqual(resp["stack"][0]["value"], "100000000");
 
             resp = (JObject)_rpcServer.InvokeScript(new JArray(NeoTransferScript));
-            Assert.AreEqual(resp.Count, 6);
+            Assert.AreEqual(6, resp.Count);
             Assert.AreEqual(resp["stack"][0]["type"], nameof(Boolean));
             Assert.AreEqual(resp["stack"][0]["value"], false);
         }
@@ -349,7 +349,7 @@ namespace Neo.Plugins.RpcServer.Tests
             string sessionId = resp["session"].AsString();
             string iteratorId = resp["stack"][0]["id"].AsString();
             JArray respArray = (JArray)_rpcServer.TraverseIterator([sessionId, iteratorId, 100]);
-            Assert.AreEqual(respArray.Count, 0);
+            Assert.AreEqual(0, respArray.Count);
             _rpcServer.TerminateSession([sessionId]);
             Assert.ThrowsExactly<RpcException>(() => _ = (JArray)_rpcServer.TraverseIterator([sessionId, iteratorId, 100]), "Unknown session");
 
@@ -379,10 +379,10 @@ namespace Neo.Plugins.RpcServer.Tests
             sessionId = resp["session"].AsString();
             iteratorId = resp["stack"][0]["id"].AsString();
             respArray = (JArray)_rpcServer.TraverseIterator([sessionId, iteratorId, 100]);
-            Assert.AreEqual(respArray.Count, 1);
+            Assert.AreEqual(1, respArray.Count);
             Assert.AreEqual(respArray[0]["type"], nameof(Struct));
             JArray value = (JArray)respArray[0]["value"];
-            Assert.AreEqual(value.Count, 2);
+            Assert.AreEqual(2, value.Count);
             Assert.AreEqual(value[0]["type"], nameof(ByteString));
             Assert.AreEqual(value[0]["value"], Convert.ToBase64String(TestProtocolSettings.SoleNode.StandbyCommittee[0].ToArray()));
             Assert.AreEqual(value[1]["type"], nameof(Integer));
@@ -390,7 +390,7 @@ namespace Neo.Plugins.RpcServer.Tests
 
             // No result when traversed again
             respArray = (JArray)_rpcServer.TraverseIterator([sessionId, iteratorId, 100]);
-            Assert.AreEqual(respArray.Count, 0);
+            Assert.AreEqual(0, respArray.Count);
 
             // GetAllCandidates again
             resp = (JObject)_rpcServer.InvokeFunction(new JArray(NeoToken.NEO.Hash.ToString(), "getAllCandidates", new JArray([]), validatorSigner, true));
@@ -399,11 +399,11 @@ namespace Neo.Plugins.RpcServer.Tests
 
             // Insufficient result count limit
             respArray = (JArray)_rpcServer.TraverseIterator([sessionId, iteratorId, 0]);
-            Assert.AreEqual(respArray.Count, 0);
+            Assert.AreEqual(0, respArray.Count);
             respArray = (JArray)_rpcServer.TraverseIterator([sessionId, iteratorId, 1]);
-            Assert.AreEqual(respArray.Count, 1);
+            Assert.AreEqual(1, respArray.Count);
             respArray = (JArray)_rpcServer.TraverseIterator([sessionId, iteratorId, 1]);
-            Assert.AreEqual(respArray.Count, 0);
+            Assert.AreEqual(0, respArray.Count);
 
             // Mocking session timeout
             Thread.Sleep((int)_rpcServerSettings.SessionExpirationTime.TotalMilliseconds + 1);
@@ -414,7 +414,7 @@ namespace Neo.Plugins.RpcServer.Tests
             _rpcServer.OnTimer(new object());
             Assert.ThrowsExactly<RpcException>(() => _ = (JArray)_rpcServer.TraverseIterator([sessionId, iteratorId, 100]), "Unknown session");
             respArray = (JArray)_rpcServer.TraverseIterator([notExpiredSessionId, notExpiredIteratorId, 1]);
-            Assert.AreEqual(respArray.Count, 1);
+            Assert.AreEqual(1, respArray.Count);
 
             // Mocking disposal
             resp = (JObject)_rpcServer.InvokeFunction(new JArray(NeoToken.NEO.Hash.ToString(), "getAllCandidates", new JArray([]), validatorSigner, true));

--- a/tests/Neo.Plugins.RpcServer.Tests/UT_RpcServer.Utilities.cs
+++ b/tests/Neo.Plugins.RpcServer.Tests/UT_RpcServer.Utilities.cs
@@ -20,10 +20,10 @@ namespace Neo.Plugins.RpcServer.Tests
         public void TestListPlugins()
         {
             JArray resp = (JArray)_rpcServer.ListPlugins([]);
-            Assert.AreEqual(resp.Count, 0);
+            Assert.AreEqual(0, resp.Count);
             Plugin.Plugins.Add(new RpcServerPlugin());
             resp = (JArray)_rpcServer.ListPlugins([]);
-            Assert.AreEqual(resp.Count, 2);
+            Assert.AreEqual(2, resp.Count);
             foreach (JObject p in resp)
                 Assert.AreEqual(p["name"], nameof(RpcServer));
         }

--- a/tests/Neo.Plugins.RpcServer.Tests/UT_RpcServer.Wallet.cs
+++ b/tests/Neo.Plugins.RpcServer.Tests/UT_RpcServer.Wallet.cs
@@ -40,7 +40,7 @@ namespace Neo.Plugins.RpcServer.Tests
             var res = _rpcServer.OpenWallet(paramsArray);
             Assert.IsTrue(res.AsBoolean());
             Assert.IsNotNull(_rpcServer.wallet);
-            Assert.AreEqual(_rpcServer.wallet.GetAccounts().FirstOrDefault()!.Address, "NVizn8DiExdmnpTQfjiVY3dox8uXg3Vrxv");
+            Assert.AreEqual("NVizn8DiExdmnpTQfjiVY3dox8uXg3Vrxv", _rpcServer.wallet.GetAccounts().FirstOrDefault()!.Address);
             _rpcServer.CloseWallet([]);
             File.Delete(Path);
             Assert.IsNull(_rpcServer.wallet);
@@ -67,7 +67,7 @@ namespace Neo.Plugins.RpcServer.Tests
             File.WriteAllText(Path, "{\"name\":null,\"version\":\"1.0\",\"scrypt\":{\"n\":16384,\"r\":8,\"p\":8},\"accounts\":[{\"address\":\"NVizn8DiExdmnpTQfjiVY3dox8uXg3Vrxv\",\"label\":null,\"isDefault\":false,\"lock\":false,\"key\":\"6PYPMrsCJ3D4AXJCFWYT2WMSBGF7dLoaNipW14t4UFAkZw3Z9vQRQV1bEU\",\"contract\":{\"script\":\"DCEDaR\\u002BFVb8lOdiMZ/wCHLiI\\u002Bzuf17YuGFReFyHQhB80yMpBVuezJw==\",\"parameters\":[{\"name\":\"signature\",\"type\":\"Signature\"}],\"deployed\":false},\"extra\":null}],\"extra\":null}");
             exception = Assert.ThrowsExactly<RpcException>(() => _ = _rpcServer.OpenWallet(paramsArray), "Should throw RpcException for unsupported wallet");
             Assert.AreEqual(RpcError.WalletNotSupported.Code, exception.HResult);
-            Assert.AreEqual(exception.Message, "Wallet not supported - Invalid password.");
+            Assert.AreEqual("Wallet not supported - Invalid password.", exception.Message);
             File.Delete(Path);
         }
 
@@ -292,10 +292,10 @@ namespace Neo.Plugins.RpcServer.Tests
 
             _rpcServer.wallet = _wallet;
             JObject resp = (JObject)_rpcServer.SendFrom(paramsArray);
-            Assert.AreEqual(resp.Count, 12);
+            Assert.AreEqual(12, resp.Count);
             Assert.AreEqual(resp["sender"], ValidatorAddress);
             JArray signers = (JArray)resp["signers"];
-            Assert.AreEqual(signers.Count, 1);
+            Assert.AreEqual(1, signers.Count);
             Assert.AreEqual(signers[0]["account"], ValidatorScriptHash.ToString());
             Assert.AreEqual(signers[0]["scopes"], nameof(WitnessScope.CalledByEntry));
             _rpcServer.wallet = null;
@@ -312,10 +312,10 @@ namespace Neo.Plugins.RpcServer.Tests
 
             _rpcServer.wallet = _wallet;
             JObject resp = (JObject)_rpcServer.SendMany(paramsArray);
-            Assert.AreEqual(resp.Count, 12);
+            Assert.AreEqual(12, resp.Count);
             Assert.AreEqual(resp["sender"], ValidatorAddress);
             JArray signers = (JArray)resp["signers"];
-            Assert.AreEqual(signers.Count, 1);
+            Assert.AreEqual(1, signers.Count);
             Assert.AreEqual(signers[0]["account"], ValidatorScriptHash.ToString());
             Assert.AreEqual(signers[0]["scopes"], nameof(WitnessScope.CalledByEntry));
             _rpcServer.wallet = null;
@@ -333,10 +333,10 @@ namespace Neo.Plugins.RpcServer.Tests
 
             _rpcServer.wallet = _wallet;
             JObject resp = (JObject)_rpcServer.SendToAddress(paramsArray);
-            Assert.AreEqual(resp.Count, 12);
+            Assert.AreEqual(12, resp.Count);
             Assert.AreEqual(resp["sender"], ValidatorAddress);
             JArray signers = (JArray)resp["signers"];
-            Assert.AreEqual(signers.Count, 1);
+            Assert.AreEqual(1, signers.Count);
             Assert.AreEqual(signers[0]["account"], ValidatorScriptHash.ToString());
             Assert.AreEqual(signers[0]["scopes"], nameof(WitnessScope.CalledByEntry));
             _rpcServer.wallet = null;
@@ -546,10 +546,10 @@ namespace Neo.Plugins.RpcServer.Tests
             JObject resp = (JObject)_rpcServer.SendFrom(new JArray(NativeContract.GAS.Hash.ToString(), _walletAccount.Address, _walletAccount.Address, "1"));
             string txHash = resp["hash"].AsString();
             resp = (JObject)_rpcServer.CancelTransaction(new JArray(txHash, new JArray(ValidatorAddress), "1"));
-            Assert.AreEqual(resp.Count, 12);
+            Assert.AreEqual(12, resp.Count);
             Assert.AreEqual(resp["sender"], ValidatorAddress);
             JArray signers = (JArray)resp["signers"];
-            Assert.AreEqual(signers.Count, 1);
+            Assert.AreEqual(1, signers.Count);
             Assert.AreEqual(signers[0]["account"], ValidatorScriptHash.ToString());
             Assert.AreEqual(signers[0]["scopes"], nameof(WitnessScope.None));
             Assert.AreEqual(resp["attributes"][0]["type"], nameof(TransactionAttributeType.Conflicts));
@@ -594,11 +594,11 @@ namespace Neo.Plugins.RpcServer.Tests
             // invoke verify without signer; should return false
             JObject resp = (JObject)_rpcServer.InvokeContractVerify([deployedScriptHash.ToString()]);
             Assert.AreEqual(resp["state"], nameof(VMState.HALT));
-            Assert.AreEqual(resp["stack"][0]["value"].AsBoolean(), false);
+            Assert.AreEqual(false, resp["stack"][0]["value"].AsBoolean());
             // invoke verify with signer; should return true
             resp = (JObject)_rpcServer.InvokeContractVerify([deployedScriptHash.ToString(), new JArray([]), validatorSigner]);
             Assert.AreEqual(resp["state"], nameof(VMState.HALT));
-            Assert.AreEqual(resp["stack"][0]["value"].AsBoolean(), true);
+            Assert.AreEqual(true, resp["stack"][0]["value"].AsBoolean());
             // invoke verify with wrong input value; should FAULT
             resp = (JObject)_rpcServer.InvokeContractVerify([deployedScriptHash.ToString(), new JArray([new JObject() { ["type"] = nameof(ContractParameterType.Integer), ["value"] = "0" }]), validatorSigner]);
             Assert.AreEqual(resp["state"], nameof(VMState.FAULT));
@@ -606,7 +606,7 @@ namespace Neo.Plugins.RpcServer.Tests
             // invoke verify with 1 param and signer; should return true
             resp = (JObject)_rpcServer.InvokeContractVerify([deployedScriptHash.ToString(), new JArray([new JObject() { ["type"] = nameof(ContractParameterType.Integer), ["value"] = "32" }]), validatorSigner]);
             Assert.AreEqual(resp["state"], nameof(VMState.HALT));
-            Assert.AreEqual(resp["stack"][0]["value"].AsBoolean(), true);
+            Assert.AreEqual(true, resp["stack"][0]["value"].AsBoolean());
             // invoke verify with 2 param (which does not exist); should throw Exception
             Assert.ThrowsExactly<RpcException>(() => _ = _rpcServer.InvokeContractVerify([deployedScriptHash.ToString(), new JArray([new JObject() { ["type"] = nameof(ContractParameterType.Integer), ["value"] = "32" }, new JObject() { ["type"] = nameof(ContractParameterType.Integer), ["value"] = "32" }]), validatorSigner]),
                 $"Invalid contract verification function - The smart contract {deployedScriptHash} haven't got verify method with 2 input parameters.");

--- a/tests/Neo.UnitTests/Ledger/UT_MemoryPool.cs
+++ b/tests/Neo.UnitTests/Ledger/UT_MemoryPool.cs
@@ -428,8 +428,8 @@ namespace Neo.UnitTests.Ledger
             Assert.AreEqual(1, _unit.SortedTxCount);
             Assert.AreEqual(0, _unit.UnverifiedSortedTxCount);
 
-            Assert.AreEqual(_unit.TryAdd(mp1, engine.SnapshotCache), VerifyResult.HasConflicts); // mp1 conflicts with mp2 but has lower network fee
-            Assert.AreEqual(_unit.SortedTxCount, 1);
+            Assert.AreEqual(VerifyResult.HasConflicts, _unit.TryAdd(mp1, engine.SnapshotCache)); // mp1 conflicts with mp2 but has lower network fee
+            Assert.AreEqual(1, _unit.SortedTxCount);
             CollectionAssert.Contains(_unit.GetVerifiedTransactions().ToList(), mp2);
 
             // Act & Assert: try to invalidate verified transactions and push conflicting one.

--- a/tests/Neo.UnitTests/Network/P2P/Payloads/UT_NetworkAddressWithTime.cs
+++ b/tests/Neo.UnitTests/Network/P2P/Payloads/UT_NetworkAddressWithTime.cs
@@ -26,11 +26,11 @@ namespace Neo.UnitTests.Network.P2P.Payloads
         {
             var test = new NetworkAddressWithTime() { Capabilities = [], Address = IPAddress.Any, Timestamp = 1 };
             Assert.AreEqual(21, test.Size);
-            Assert.AreEqual(test.EndPoint.Port, 0);
+            Assert.AreEqual(0, test.EndPoint.Port);
 
             test = NetworkAddressWithTime.Create(IPAddress.Any, 1, [new ServerCapability(NodeCapabilityType.TcpServer, 22)]);
             Assert.AreEqual(24, test.Size);
-            Assert.AreEqual(test.EndPoint.Port, 22);
+            Assert.AreEqual(22, test.EndPoint.Port);
         }
 
         [TestMethod]

--- a/tests/Neo.UnitTests/SmartContract/Manifest/UT_ContractManifest.cs
+++ b/tests/Neo.UnitTests/SmartContract/Manifest/UT_ContractManifest.cs
@@ -364,7 +364,7 @@ namespace Neo.UnitTests.SmartContract.Manifest
             var clone = new ContractManifest();
             ((IInteroperable)clone).FromStackItem(expected.ToStackItem(null));
 
-            Assert.AreEqual(expected.Extra.ToString(), @"{""a"":123}");
+            Assert.AreEqual(@"{""a"":123}", expected.Extra.ToString());
             Assert.AreEqual(expected.ToString(), clone.ToString());
 
             expected.Extra = null;
@@ -386,7 +386,7 @@ namespace Neo.UnitTests.SmartContract.Manifest
 
             var actualTrusts = ((Array)si)[6];
 
-            Assert.AreEqual(((Array)actualTrusts).Count, 2);
+            Assert.AreEqual(2, ((Array)actualTrusts).Count);
             Assert.AreEqual(((Array)actualTrusts)[0], new ByteString(UInt160.Parse("0x0000000000000000000000000000000000000001").ToArray()));
             // Wildcard trust should be represented as Null stackitem (not as zero-length ByteString):
             Assert.AreEqual(((Array)actualTrusts)[1], StackItem.Null);

--- a/tests/Neo.UnitTests/SmartContract/Native/UT_NativeContract.cs
+++ b/tests/Neo.UnitTests/SmartContract/Native/UT_NativeContract.cs
@@ -152,15 +152,15 @@ namespace Neo.UnitTests.SmartContract.Native
         public void TestNativeContractId()
         {
             // native contract id is implicitly defined in NativeContract.cs(the defined order)
-            Assert.AreEqual(NativeContract.ContractManagement.Id, -1);
-            Assert.AreEqual(NativeContract.StdLib.Id, -2);
-            Assert.AreEqual(NativeContract.CryptoLib.Id, -3);
-            Assert.AreEqual(NativeContract.Ledger.Id, -4);
-            Assert.AreEqual(NativeContract.NEO.Id, -5);
-            Assert.AreEqual(NativeContract.GAS.Id, -6);
-            Assert.AreEqual(NativeContract.Policy.Id, -7);
-            Assert.AreEqual(NativeContract.RoleManagement.Id, -8);
-            Assert.AreEqual(NativeContract.Oracle.Id, -9);
+            Assert.AreEqual(-1, NativeContract.ContractManagement.Id);
+            Assert.AreEqual(-2, NativeContract.StdLib.Id);
+            Assert.AreEqual(-3, NativeContract.CryptoLib.Id);
+            Assert.AreEqual(-4, NativeContract.Ledger.Id);
+            Assert.AreEqual(-5, NativeContract.NEO.Id);
+            Assert.AreEqual(-6, NativeContract.GAS.Id);
+            Assert.AreEqual(-7, NativeContract.Policy.Id);
+            Assert.AreEqual(-8, NativeContract.RoleManagement.Id);
+            Assert.AreEqual(-9, NativeContract.Oracle.Id);
         }
 
 

--- a/tests/Neo.UnitTests/SmartContract/Native/UT_NeoToken.cs
+++ b/tests/Neo.UnitTests/SmartContract/Native/UT_NeoToken.cs
@@ -79,8 +79,8 @@ namespace Neo.UnitTests.SmartContract.Native
                     var methods = NativeContract.NEO.GetContractMethods(engine);
                     var entries = methods.Values.Where(u => u.Name == method).ToArray();
 
-                    Assert.AreEqual(entries.Length, 1);
-                    Assert.AreEqual(entries[0].RequiredCallFlags, CallFlags.States);
+                    Assert.AreEqual(1, entries.Length);
+                    Assert.AreEqual(CallFlags.States, entries[0].RequiredCallFlags);
                 }
 
                 // Test WITH HF_Echidna
@@ -93,8 +93,8 @@ namespace Neo.UnitTests.SmartContract.Native
                     var methods = NativeContract.NEO.GetContractMethods(engine);
                     var entries = methods.Values.Where(u => u.Name == method).ToArray();
 
-                    Assert.AreEqual(entries.Length, 1);
-                    Assert.AreEqual(entries[0].RequiredCallFlags, CallFlags.States | CallFlags.AllowNotify);
+                    Assert.AreEqual(1, entries.Length);
+                    Assert.AreEqual(CallFlags.States | CallFlags.AllowNotify, entries[0].RequiredCallFlags);
                 }
             }
         }

--- a/tests/Neo.UnitTests/SmartContract/Native/UT_StdLib.cs
+++ b/tests/Neo.UnitTests/SmartContract/Native/UT_StdLib.cs
@@ -77,7 +77,7 @@ namespace Neo.UnitTests.SmartContract.Native
                 using var engine = ApplicationEngine.Create(TriggerType.Application, null, snapshotCache, settings: TestProtocolSettings.Default);
                 engine.LoadScript(script.ToArray());
 
-                Assert.AreEqual(engine.Execute(), VMState.HALT);
+                Assert.AreEqual(VMState.HALT, engine.Execute());
                 Assert.AreEqual(4, engine.ResultStack.Count);
 
                 Assert.AreEqual(-1, engine.ResultStack.Pop<Integer>().GetInteger());
@@ -99,7 +99,7 @@ namespace Neo.UnitTests.SmartContract.Native
                 using var engine = ApplicationEngine.Create(TriggerType.Application, null, snapshotCache, settings: TestProtocolSettings.Default);
                 engine.LoadScript(script.ToArray());
 
-                Assert.AreEqual(engine.Execute(), VMState.HALT);
+                Assert.AreEqual(VMState.HALT, engine.Execute());
                 Assert.AreEqual(1, engine.ResultStack.Count);
 
                 Assert.AreEqual("3DUz7ncyT", engine.ResultStack.Pop<ByteString>().GetString());
@@ -112,7 +112,7 @@ namespace Neo.UnitTests.SmartContract.Native
                 using var engine = ApplicationEngine.Create(TriggerType.Application, null, snapshotCache, settings: TestProtocolSettings.Default);
                 engine.LoadScript(script.ToArray());
 
-                Assert.AreEqual(engine.Execute(), VMState.HALT);
+                Assert.AreEqual(VMState.HALT, engine.Execute());
                 Assert.AreEqual(1, engine.ResultStack.Count);
 
                 CollectionAssert.AreEqual(new byte[] { 1, 2, 3 }, engine.ResultStack.Pop<ByteString>().GetSpan().ToArray());
@@ -127,7 +127,7 @@ namespace Neo.UnitTests.SmartContract.Native
                 using var engine = ApplicationEngine.Create(TriggerType.Application, null, snapshotCache, settings: TestProtocolSettings.Default);
                 engine.LoadScript(script.ToArray());
 
-                Assert.AreEqual(engine.Execute(), VMState.FAULT);
+                Assert.AreEqual(VMState.FAULT, engine.Execute());
             }
 
             using (ScriptBuilder script = new())
@@ -137,7 +137,7 @@ namespace Neo.UnitTests.SmartContract.Native
                 using var engine = ApplicationEngine.Create(TriggerType.Application, null, snapshotCache, settings: TestProtocolSettings.Default);
                 engine.LoadScript(script.ToArray());
 
-                Assert.AreEqual(engine.Execute(), VMState.FAULT);
+                Assert.AreEqual(VMState.FAULT, engine.Execute());
             }
         }
 
@@ -157,7 +157,7 @@ namespace Neo.UnitTests.SmartContract.Native
                 using var engine = ApplicationEngine.Create(TriggerType.Application, null, snapshotCache, settings: TestProtocolSettings.Default);
                 engine.LoadScript(script.ToArray());
 
-                Assert.AreEqual(engine.Execute(), VMState.HALT);
+                Assert.AreEqual(VMState.HALT, engine.Execute());
                 Assert.AreEqual(5, engine.ResultStack.Count);
 
                 Assert.AreEqual(-1, engine.ResultStack.Pop<Integer>().GetInteger());
@@ -177,7 +177,7 @@ namespace Neo.UnitTests.SmartContract.Native
                 using var engine = ApplicationEngine.Create(TriggerType.Application, null, snapshotCache, settings: TestProtocolSettings.Default);
                 engine.LoadScript(script.ToArray());
 
-                Assert.AreEqual(engine.Execute(), VMState.HALT);
+                Assert.AreEqual(VMState.HALT, engine.Execute());
                 Assert.AreEqual(5, engine.ResultStack.Count);
 
                 Assert.AreEqual(-1, engine.ResultStack.Pop<Integer>().GetInteger());
@@ -197,7 +197,7 @@ namespace Neo.UnitTests.SmartContract.Native
                 using var engine = ApplicationEngine.Create(TriggerType.Application, null, snapshotCache, settings: TestProtocolSettings.Default);
                 engine.LoadScript(script.ToArray());
 
-                Assert.AreEqual(engine.Execute(), VMState.HALT);
+                Assert.AreEqual(VMState.HALT, engine.Execute());
                 Assert.AreEqual(5, engine.ResultStack.Count);
 
                 Assert.AreEqual(-1, engine.ResultStack.Pop<Integer>().GetInteger());
@@ -218,7 +218,7 @@ namespace Neo.UnitTests.SmartContract.Native
             using var engine = ApplicationEngine.Create(TriggerType.Application, null, snapshotCache, settings: TestProtocolSettings.Default);
             engine.LoadScript(script.ToArray());
 
-            Assert.AreEqual(engine.Execute(), VMState.HALT);
+            Assert.AreEqual(VMState.HALT, engine.Execute());
             Assert.AreEqual(1, engine.ResultStack.Count);
 
             var arr = engine.ResultStack.Pop<VM.Types.Array>();
@@ -240,7 +240,7 @@ namespace Neo.UnitTests.SmartContract.Native
             using var engine = ApplicationEngine.Create(TriggerType.Application, null, snapshotCache, settings: TestProtocolSettings.Default);
             engine.LoadScript(script.ToArray());
 
-            Assert.AreEqual(engine.Execute(), VMState.HALT);
+            Assert.AreEqual(VMState.HALT, engine.Execute());
             Assert.AreEqual(3, engine.ResultStack.Count);
             Assert.AreEqual(1, engine.ResultStack.Pop().GetInteger());
             Assert.AreEqual(1, engine.ResultStack.Pop().GetInteger());
@@ -262,7 +262,7 @@ namespace Neo.UnitTests.SmartContract.Native
             using var engine = ApplicationEngine.Create(TriggerType.Application, null, snapshotCache, settings: TestProtocolSettings.Default);
             engine.LoadScript(script.ToArray());
 
-            Assert.AreEqual(engine.Execute(), VMState.HALT);
+            Assert.AreEqual(VMState.HALT, engine.Execute());
             Assert.AreEqual(2, engine.ResultStack.Count);
             Assert.AreEqual(3, engine.ResultStack.Pop().GetInteger());
             Assert.AreEqual(1, engine.ResultStack.Pop().GetInteger());
@@ -283,7 +283,7 @@ namespace Neo.UnitTests.SmartContract.Native
                 using var engine = ApplicationEngine.Create(TriggerType.Application, null, snapshotCache, settings: TestProtocolSettings.Default);
                 engine.LoadScript(script.ToArray());
 
-                Assert.AreEqual(engine.Execute(), VMState.HALT);
+                Assert.AreEqual(VMState.HALT, engine.Execute());
                 Assert.AreEqual(2, engine.ResultStack.Count);
 
                 engine.ResultStack.Pop<Null>();
@@ -299,7 +299,7 @@ namespace Neo.UnitTests.SmartContract.Native
                 using var engine = ApplicationEngine.Create(TriggerType.Application, null, snapshotCache, settings: TestProtocolSettings.Default);
                 engine.LoadScript(script.ToArray());
 
-                Assert.AreEqual(engine.Execute(), VMState.FAULT);
+                Assert.AreEqual(VMState.FAULT, engine.Execute());
                 Assert.AreEqual(0, engine.ResultStack.Count);
             }
 
@@ -312,7 +312,7 @@ namespace Neo.UnitTests.SmartContract.Native
                 using var engine = ApplicationEngine.Create(TriggerType.Application, null, snapshotCache, settings: TestProtocolSettings.Default);
                 engine.LoadScript(script.ToArray());
 
-                Assert.AreEqual(engine.Execute(), VMState.FAULT);
+                Assert.AreEqual(VMState.FAULT, engine.Execute());
                 Assert.AreEqual(0, engine.ResultStack.Count);
             }
         }
@@ -343,7 +343,7 @@ namespace Neo.UnitTests.SmartContract.Native
                 using var engine = ApplicationEngine.Create(TriggerType.Application, null, snapshotCache, settings: TestProtocolSettings.Default);
                 engine.LoadScript(script.ToArray());
 
-                Assert.AreEqual(engine.Execute(), VMState.HALT);
+                Assert.AreEqual(VMState.HALT, engine.Execute());
                 Assert.AreEqual(5, engine.ResultStack.Count);
 
                 Assert.AreEqual("{\"key\":\"value\"}", engine.ResultStack.Pop<ByteString>().GetString());
@@ -362,7 +362,7 @@ namespace Neo.UnitTests.SmartContract.Native
                 using var engine = ApplicationEngine.Create(TriggerType.Application, null, snapshotCache, settings: TestProtocolSettings.Default);
                 engine.LoadScript(script.ToArray());
 
-                Assert.AreEqual(engine.Execute(), VMState.FAULT);
+                Assert.AreEqual(VMState.FAULT, engine.Execute());
                 Assert.AreEqual(0, engine.ResultStack.Count);
             }
         }
@@ -381,11 +381,11 @@ namespace Neo.UnitTests.SmartContract.Native
             using var engine = ApplicationEngine.Create(TriggerType.Application, null, snapshotCache, settings: TestProtocolSettings.Default);
             engine.LoadScript(script.ToArray());
 
-            Assert.AreEqual(engine.Execute(), VMState.HALT);
+            Assert.AreEqual(VMState.HALT, engine.Execute());
             Assert.AreEqual(2, engine.ResultStack.Count);
 
-            Assert.AreEqual(engine.ResultStack.Pop<ByteString>().GetSpan().ToHexString(), "280474657374");
-            Assert.AreEqual(engine.ResultStack.Pop<ByteString>().GetSpan().ToHexString(), "210164");
+            Assert.AreEqual("280474657374", engine.ResultStack.Pop<ByteString>().GetSpan().ToHexString());
+            Assert.AreEqual("210164", engine.ResultStack.Pop<ByteString>().GetSpan().ToHexString());
         }
 
         [TestMethod]
@@ -402,11 +402,11 @@ namespace Neo.UnitTests.SmartContract.Native
             using var engine = ApplicationEngine.Create(TriggerType.Application, null, snapshotCache, settings: TestProtocolSettings.Default);
             engine.LoadScript(script.ToArray());
 
-            Assert.AreEqual(engine.Execute(), VMState.HALT);
+            Assert.AreEqual(VMState.HALT, engine.Execute());
             Assert.AreEqual(2, engine.ResultStack.Count);
 
             Assert.AreEqual(engine.ResultStack.Pop<Integer>().GetInteger(), 100);
-            Assert.AreEqual(engine.ResultStack.Pop<ByteString>().GetString(), "test");
+            Assert.AreEqual("test", engine.ResultStack.Pop<ByteString>().GetString());
         }
 
         [TestMethod]
@@ -423,7 +423,7 @@ namespace Neo.UnitTests.SmartContract.Native
                 using var engine = ApplicationEngine.Create(TriggerType.Application, null, snapshotCache, settings: TestProtocolSettings.Default);
                 engine.LoadScript(script.ToArray());
 
-                Assert.AreEqual(engine.Execute(), VMState.HALT);
+                Assert.AreEqual(VMState.HALT, engine.Execute());
                 Assert.AreEqual(3, engine.ResultStack.Count);
                 Assert.AreEqual("Subject=test@example.com&Issuer=https://example.com", engine.ResultStack.Pop<ByteString>());
                 Assert.AreEqual("Subject=test@example.com&Issuer=https://example.com", engine.ResultStack.Pop<ByteString>());

--- a/tests/Neo.UnitTests/SmartContract/UT_ApplicationEngineProvider.cs
+++ b/tests/Neo.UnitTests/SmartContract/UT_ApplicationEngineProvider.cs
@@ -68,7 +68,7 @@ namespace Neo.UnitTests.SmartContract
                 .GetField("nonceData", BindingFlags.NonPublic | BindingFlags.Instance)
                 .GetValue(app) as byte[];
             Assert.IsNotNull(nonceData);
-            Assert.AreEqual(nonceData.ToHexString(), "08070605040302010000000000000000");
+            Assert.AreEqual("08070605040302010000000000000000", nonceData.ToHexString());
         }
 
         class TestProvider : IApplicationEngineProvider

--- a/tests/Neo.UnitTests/SmartContract/UT_InteropService.cs
+++ b/tests/Neo.UnitTests/SmartContract/UT_InteropService.cs
@@ -408,7 +408,7 @@ namespace Neo.UnitTests.SmartContract
 
             engineA.LoadScript(script.ToArray());
             engineA.Execute();
-            Assert.AreEqual(engineA.State, VMState.HALT);
+            Assert.AreEqual(VMState.HALT, engineA.State);
 
             var result = engineA.ResultStack.Pop();
             Assert.IsInstanceOfType(result, typeof(Null));
@@ -419,7 +419,7 @@ namespace Neo.UnitTests.SmartContract
 
             engineB.LoadScript(script.ToArray());
             engineB.Execute();
-            Assert.AreEqual(engineB.State, VMState.HALT);
+            Assert.AreEqual(VMState.HALT, engineB.State);
 
             result = engineB.ResultStack.Pop();
             Assert.IsInstanceOfType(result, typeof(VM.Types.Array));
@@ -497,7 +497,7 @@ namespace Neo.UnitTests.SmartContract
             script.EmitDynamicCall(NativeContract.Ledger.Hash, "getTransactionHeight", state.Transaction.Hash);
             engine.LoadScript(script.ToArray());
             engine.Execute();
-            Assert.AreEqual(engine.State, VMState.HALT);
+            Assert.AreEqual(VMState.HALT, engine.State);
 
             var result = engine.ResultStack.Pop();
             Assert.IsInstanceOfType(result, typeof(Integer));

--- a/tests/Neo.UnitTests/SmartContract/UT_JsonSerializer.cs
+++ b/tests/Neo.UnitTests/SmartContract/UT_JsonSerializer.cs
@@ -222,7 +222,7 @@ namespace Neo.UnitTests.SmartContract
             var entry = new Map();
             var json = JsonSerializer.Serialize(entry).ToString();
 
-            Assert.AreEqual(json, "{}");
+            Assert.AreEqual("{}", json);
         }
 
         [TestMethod]
@@ -246,7 +246,7 @@ namespace Neo.UnitTests.SmartContract
             var items = JsonSerializer.Deserialize(engine, JObject.Parse("{}"), ExecutionEngineLimits.Default);
 
             Assert.IsInstanceOfType(items, typeof(Map));
-            Assert.AreEqual(((Map)items).Count, 0);
+            Assert.AreEqual(0, ((Map)items).Count);
         }
 
         [TestMethod]
@@ -255,7 +255,7 @@ namespace Neo.UnitTests.SmartContract
             var entry = new Array();
             var json = JsonSerializer.Serialize(entry).ToString();
 
-            Assert.AreEqual(json, "[]");
+            Assert.AreEqual("[]", json);
         }
 
         [TestMethod]
@@ -266,7 +266,7 @@ namespace Neo.UnitTests.SmartContract
             var items = JsonSerializer.Deserialize(engine, JObject.Parse("[]"), ExecutionEngineLimits.Default);
 
             Assert.IsInstanceOfType(items, typeof(Array));
-            Assert.AreEqual(((Array)items).Count, 0);
+            Assert.AreEqual(0, ((Array)items).Count);
         }
 
         [TestMethod]
@@ -281,7 +281,7 @@ namespace Neo.UnitTests.SmartContract
 
             var json = JsonSerializer.Serialize(entry).ToString();
 
-            Assert.AreEqual(json, "{\"test1\":1,\"test3\":3,\"test2\":2}");
+            Assert.AreEqual("{\"test1\":1,\"test3\":3,\"test2\":2}", json);
         }
 
         [TestMethod]
@@ -292,7 +292,7 @@ namespace Neo.UnitTests.SmartContract
             var items = JsonSerializer.Deserialize(engine, JObject.Parse("{\"test1\":123,\"test2\":321}"), ExecutionEngineLimits.Default);
 
             Assert.IsInstanceOfType(items, typeof(Map));
-            Assert.AreEqual(((Map)items).Count, 2);
+            Assert.AreEqual(2, ((Map)items).Count);
 
             var map = (Map)items;
 
@@ -312,7 +312,7 @@ namespace Neo.UnitTests.SmartContract
 
             var json = JsonSerializer.Serialize(entry).ToString();
 
-            Assert.AreEqual(json, "[true,\"test\",123]");
+            Assert.AreEqual("[true,\"test\",123]", json);
         }
 
         [TestMethod]
@@ -323,12 +323,12 @@ namespace Neo.UnitTests.SmartContract
             var items = JsonSerializer.Deserialize(engine, JObject.Parse("[true,\"test\",123,9.05E+28]"), ExecutionEngineLimits.Default);
 
             Assert.IsInstanceOfType(items, typeof(Array));
-            Assert.AreEqual(((Array)items).Count, 4);
+            Assert.AreEqual(4, ((Array)items).Count);
 
             var array = (Array)items;
 
             Assert.IsTrue(array[0].GetBoolean());
-            Assert.AreEqual(array[1].GetString(), "test");
+            Assert.AreEqual("test", array[1].GetString());
             Assert.AreEqual(array[2].GetInteger(), 123);
             Assert.AreEqual(array[3].GetInteger(), BigInteger.Parse("90500000000000000000000000000"));
         }
@@ -344,7 +344,7 @@ namespace Neo.UnitTests.SmartContract
 
             var json = JsonSerializer.Serialize(entry).ToString();
 
-            Assert.AreEqual(json, "[[true,\"test1\",123],[true,\"test2\",321]]");
+            Assert.AreEqual("[[true,\"test1\",123],[true,\"test2\",321]]", json);
         }
 
         [TestMethod]
@@ -355,26 +355,26 @@ namespace Neo.UnitTests.SmartContract
             var items = JsonSerializer.Deserialize(engine, JObject.Parse("[[true,\"test1\",123],[true,\"test2\",321]]"), ExecutionEngineLimits.Default);
 
             Assert.IsInstanceOfType(items, typeof(Array));
-            Assert.AreEqual(((Array)items).Count, 2);
+            Assert.AreEqual(2, ((Array)items).Count);
 
             var array = (Array)items;
 
             Assert.IsInstanceOfType(array[0], typeof(Array));
-            Assert.AreEqual(((Array)array[0]).Count, 3);
+            Assert.AreEqual(3, ((Array)array[0]).Count);
 
             array = (Array)array[0];
-            Assert.AreEqual(array.Count, 3);
+            Assert.AreEqual(3, array.Count);
 
             Assert.IsTrue(array[0].GetBoolean());
-            Assert.AreEqual(array[1].GetString(), "test1");
+            Assert.AreEqual("test1", array[1].GetString());
             Assert.AreEqual(array[2].GetInteger(), 123);
 
             array = (Array)items;
             array = (Array)array[1];
-            Assert.AreEqual(array.Count, 3);
+            Assert.AreEqual(3, array.Count);
 
             Assert.IsTrue(array[0].GetBoolean());
-            Assert.AreEqual(array[1].GetString(), "test2");
+            Assert.AreEqual("test2", array[1].GetString());
             Assert.AreEqual(array[2].GetInteger(), 321);
         }
     }

--- a/tests/Neo.UnitTests/SmartContract/UT_Syscalls.cs
+++ b/tests/Neo.UnitTests/SmartContract/UT_Syscalls.cs
@@ -77,7 +77,7 @@ namespace Neo.UnitTests.SmartContract
             var engine = ApplicationEngine.Create(TriggerType.Application, null, snapshot, settings: TestProtocolSettings.Default);
             engine.LoadScript(script.ToArray());
 
-            Assert.AreEqual(engine.Execute(), VMState.HALT);
+            Assert.AreEqual(VMState.HALT, engine.Execute());
             Assert.AreEqual(1, engine.ResultStack.Count);
             Assert.IsTrue(engine.ResultStack.Peek().IsNull);
 
@@ -100,7 +100,7 @@ namespace Neo.UnitTests.SmartContract
             engine = ApplicationEngine.Create(TriggerType.Application, null, snapshot, settings: TestProtocolSettings.Default);
             engine.LoadScript(script.ToArray());
 
-            Assert.AreEqual(engine.Execute(), VMState.HALT);
+            Assert.AreEqual(VMState.HALT, engine.Execute());
             Assert.AreEqual(1, engine.ResultStack.Count);
             Assert.IsTrue(engine.ResultStack.Peek().IsNull);
 
@@ -112,7 +112,7 @@ namespace Neo.UnitTests.SmartContract
             engine = ApplicationEngine.Create(TriggerType.Application, null, snapshot, settings: TestProtocolSettings.Default);
             engine.LoadScript(script.ToArray());
 
-            Assert.AreEqual(engine.Execute(), VMState.HALT);
+            Assert.AreEqual(VMState.HALT, engine.Execute());
             Assert.AreEqual(1, engine.ResultStack.Count);
 
             var array = engine.ResultStack.Pop<VM.Types.Array>();
@@ -131,7 +131,7 @@ namespace Neo.UnitTests.SmartContract
             var engine = ApplicationEngine.Create(TriggerType.Application, null, snapshot);
             engine.LoadScript(script.ToArray());
 
-            Assert.AreEqual(engine.Execute(), VMState.FAULT);
+            Assert.AreEqual(VMState.FAULT, engine.Execute());
             Assert.AreEqual(0, engine.ResultStack.Count);
 
             // With tx
@@ -162,7 +162,7 @@ namespace Neo.UnitTests.SmartContract
             engine = ApplicationEngine.Create(TriggerType.Application, tx, snapshot);
             engine.LoadScript(script.ToArray());
 
-            Assert.AreEqual(engine.Execute(), VMState.HALT);
+            Assert.AreEqual(VMState.HALT, engine.Execute());
             Assert.AreEqual(1, engine.ResultStack.Count);
 
             var array = engine.ResultStack.Pop<VM.Types.Array>();
@@ -189,7 +189,7 @@ namespace Neo.UnitTests.SmartContract
 
                 var engine = ApplicationEngine.Create(TriggerType.Application, null, snapshot, gas: 100_000_000);
                 engine.LoadScript(script.ToArray());
-                Assert.AreEqual(engine.Execute(), VMState.HALT);
+                Assert.AreEqual(VMState.HALT, engine.Execute());
 
                 // Check the results
 
@@ -213,7 +213,7 @@ namespace Neo.UnitTests.SmartContract
 
                 // Check the results
 
-                Assert.AreEqual(engine.Execute(), VMState.HALT);
+                Assert.AreEqual(VMState.HALT, engine.Execute());
                 Assert.AreEqual(1, engine.ResultStack.Count);
                 Assert.IsInstanceOfType(engine.ResultStack.Peek(), typeof(Integer));
                 Assert.AreEqual(1999999520, engine.ResultStack.Pop().GetInteger());

--- a/tests/Neo.UnitTests/Wallets/UT_Wallet.cs
+++ b/tests/Neo.UnitTests/Wallets/UT_Wallet.cs
@@ -449,7 +449,7 @@ namespace Neo.UnitTests.Wallets
 
             var signature = wallet.SignBlock(block, glkey.PublicKey, network);
             Assert.IsNotNull(signature);
-            Assert.AreEqual(signature.Length, 64);
+            Assert.AreEqual(64, signature.Length);
 
             var signData = block.GetSignData(network);
             var isValid = Crypto.VerifySignature(signData, signature.Span, glkey.PublicKey);


### PR DESCRIPTION
# Description

The definition of `Assert.AreEqual` is `Assert.AreEqual(Type expected, Type actual, ...)`,
So assertion arguments should be passed in the correct order.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Optimization (the change is only an optimization)
- [x] Style (the change is only a code style for better maintenance or standard purpose)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
