### PR TITLE
Fix: wrong reference count after invalid `Map[key] = value`

### DIFF
--- a/src/Neo.VM/Types/Array.cs
+++ b/src/Neo.VM/Types/Array.cs
@@ -83,10 +83,11 @@ namespace Neo.VM.Types
             foreach (var item in _array)
             {
                 if (item is CompoundType { ReferenceCounter: null })
-                {
                     throw new InvalidOperationException("Can not set a CompoundType without a ReferenceCounter.");
-                }
+            }
 
+            foreach (var item in _array)
+            {
                 referenceCounter.AddReference(item, this);
             }
         }

--- a/src/Neo.VM/Types/Map.cs
+++ b/src/Neo.VM/Types/Map.cs
@@ -51,14 +51,14 @@ namespace Neo.VM.Types
                 if (IsReadOnly) throw new InvalidOperationException("The map is readonly, can not set value.");
                 if (ReferenceCounter != null)
                 {
+                    if (value is CompoundType { ReferenceCounter: null })
+                        throw new InvalidOperationException("Can not set value to Map(with ReferenceCounter) without ReferenceCounter.");
+
                     if (dictionary.TryGetValue(key, out StackItem? old_value))
                         ReferenceCounter.RemoveReference(old_value, this);
                     else
                         ReferenceCounter.AddReference(key, this);
-                    if (value is CompoundType { ReferenceCounter: null })
-                    {
-                        throw new InvalidOperationException("Can not set a Map without a ReferenceCounter.");
-                    }
+
                     ReferenceCounter.AddReference(value, this);
                 }
                 dictionary[key] = value;

--- a/tests/Neo.VM.Tests/UT_ReferenceCounter.cs
+++ b/tests/Neo.VM.Tests/UT_ReferenceCounter.cs
@@ -257,5 +257,22 @@ namespace Neo.Test
 
             Assert.ThrowsExactly<InvalidOperationException>(() => arr.Add(arr2));
         }
+
+        [TestMethod]
+        public void TestInvalidMapSet()
+        {
+            var reference = new ReferenceCounter();
+            var map = new Map(reference);
+            Assert.AreEqual(0, reference.Count); // map is zero-referred
+
+            map["test"] = new Array(reference);
+            Assert.AreEqual(2, reference.Count); // one key + one value
+
+            Assert.ThrowsExactly<InvalidOperationException>(() => map["test"] = new Array());
+            Assert.AreEqual(2, reference.Count); // not changed after invalid set
+
+            map["test"] = new Integer(1); // overwrite the value
+            Assert.AreEqual(2, reference.Count); // not changed after overwrite
+        }
     }
 }

--- a/tests/Neo.VM.Tests/UT_ReferenceCounter.cs
+++ b/tests/Neo.VM.Tests/UT_ReferenceCounter.cs
@@ -261,18 +261,32 @@ namespace Neo.Test
         [TestMethod]
         public void TestInvalidMapSet()
         {
-            var reference = new ReferenceCounter();
-            var map = new Map(reference);
-            Assert.AreEqual(0, reference.Count); // map is zero-referred
+            {
+                var reference = new ReferenceCounter();
+                var map = new Map(reference);
+                Assert.AreEqual(0, reference.Count); // map is zero-referred
 
-            map["test"] = new Array(reference);
-            Assert.AreEqual(2, reference.Count); // one key + one value
+                map["test"] = new Array(reference);
+                Assert.AreEqual(2, reference.Count); // one key + one value
 
-            Assert.ThrowsExactly<InvalidOperationException>(() => map["test"] = new Array());
-            Assert.AreEqual(2, reference.Count); // not changed after invalid set
+                Assert.ThrowsExactly<InvalidOperationException>(() => map["test"] = new Array());
+                Assert.AreEqual(2, reference.Count); // not changed after invalid set
 
-            map["test"] = new Integer(1); // overwrite the value
-            Assert.AreEqual(2, reference.Count); // not changed after overwrite
+                map["test"] = new Integer(1); // overwrite the value
+                Assert.AreEqual(2, reference.Count); // not changed after overwrite
+            }
+
+
+            {
+                var reference = new ReferenceCounter();
+                var map = new Map();
+                Assert.ThrowsExactly<InvalidOperationException>(() => new Array(reference, [map]));
+
+                map = new Map(reference);
+                var array = new Array(reference, [map]);
+                Assert.AreEqual(1, reference.Count);
+                Assert.AreEqual(1, array.Count);
+            }
         }
     }
 }


### PR DESCRIPTION
# Description

When set a value to map, The old value reference removed in `Line 55` or the new key reference added in `Line 57`.

But if `Line 60` throws a `InvalidOperationException`, the reference count will be wrong, 
because the `ReferenceCounter` has been updated, but the internal collection not.

https://github.com/neo-project/neo/blob/6c7f6c435e2fb308737b97cb1bc783c6a296bcc5/src/Neo.VM/Types/Map.cs#L52-L62


## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
