### PR TITLE
Fix: the parameter signers and witnesses use the same param index

### DIFF
--- a/src/Plugins/RpcServer/RpcServer.Wallet.cs
+++ b/src/Plugins/RpcServer/RpcServer.Wallet.cs
@@ -718,11 +718,18 @@ namespace Neo.Plugins.RpcServer
         [RpcMethod]
         protected internal virtual JToken InvokeContractVerify(JArray _params)
         {
-            UInt160 script_hash = Result.Ok_Or(() => UInt160.Parse(_params[0].AsString()), RpcError.InvalidParams.WithData($"Invalid script hash: {_params[0]}"));
-            ContractParameter[] args = _params.Count >= 2 ? ((JArray)_params[1]).Select(p => ContractParameter.FromJson((JObject)p)).ToArray() : Array.Empty<ContractParameter>();
-            Signer[] signers = _params.Count >= 3 ? SignersFromJson((JArray)_params[2], system.Settings) : null;
-            Witness[] witnesses = _params.Count >= 3 ? WitnessesFromJson((JArray)_params[2]) : null;
-            return GetVerificationResult(script_hash, args, signers, witnesses);
+            var scriptHash = Result.Ok_Or(
+                () => UInt160.Parse(_params[0].AsString()),
+                RpcError.InvalidParams.WithData($"Invalid script hash: {_params[0]}"));
+
+            var args = _params.Count >= 2 ?
+                ((JArray)_params[1]).Select(p => ContractParameter.FromJson((JObject)p)).ToArray()
+                : [];
+
+            var signers = _params.Count >= 3 ? SignersFromJson((JArray)_params[2], system.Settings) : null;
+            var witnesses = _params.Count >= 4 ? WitnessesFromJson((JArray)_params[3]) : null;
+
+            return GetVerificationResult(scriptHash, args, signers, witnesses);
         }
 
         /// <summary>


### PR DESCRIPTION
# Description

The parameter `signers` and `witnesses` in `InvokeContractVerify` use the same param index `2`.

Different parameters cannot be in the same position.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
