### PR TITLE
Optimize: more detailed info for `help` command

### DIFF
--- a/src/Neo.ConsoleService/ConsoleServiceBase.cs
+++ b/src/Neo.ConsoleService/ConsoleServiceBase.cs
@@ -49,9 +49,9 @@ namespace Neo.ConsoleService
         /// For example, if a method defined as `void Method(string arg1, int arg2, bool arg3)`,
         /// the arguments will be parsed as `"arg1" 2 true`.
         /// </summary>
-        /// <param name="method">Method</param>
-        /// <param name="args">Arguments</param>
-        /// <returns>Arguments</returns>
+        /// <param name="method">the MethodInfo of the called method</param>
+        /// <param name="args">the raw arguments</param>
+        /// <returns>the parsed arguments</returns>
         /// <exception cref="ArgumentException">Missing argument</exception>
         internal object?[] ParseSequentialArguments(MethodInfo method, IList<CommandToken> args)
         {
@@ -78,8 +78,9 @@ namespace Neo.ConsoleService
         /// For example, if a method defined as `void Method(string arg1, int arg2, bool arg3)`,
         /// the arguments will be parsed as `Method --arg1 "arg1" --arg2 2 --arg3`.
         /// </summary>
-        /// <param name="method">Method</param>
-        /// <param name="args">Arguments</param>
+        /// <param name="method">the MethodInfo of the called method</param>
+        /// <param name="args">the raw arguments</param>
+        /// <returns>the parsed arguments</returns>
         internal object?[] ParseIndicatorArguments(MethodInfo method, IList<CommandToken> args)
         {
             var parameters = method.GetParameters();
@@ -199,6 +200,18 @@ namespace Neo.ConsoleService
 
         #region Commands
 
+        private static string ParameterGuide(ParameterInfo info)
+        {
+            if (info.HasDefaultValue)
+            {
+                var defaultValue = info.DefaultValue?.ToString();
+                return string.IsNullOrEmpty(defaultValue) ?
+                    $"[ --{info.Name} {info.ParameterType.Name} ]" :
+                    $"[ --{info.Name} {info.ParameterType.Name}({defaultValue}) ]";
+            }
+            return $"--{info.Name} {info.ParameterType.Name}";
+        }
+
         /// <summary>
         /// Process "help" command
         /// </summary>
@@ -229,17 +242,10 @@ namespace Neo.ConsoleService
             // Sort and show
             withHelp.Sort((a, b) =>
             {
-                var cate = string.Compare(a.HelpCategory, b.HelpCategory, StringComparison.Ordinal);
-                if (cate == 0)
-                {
-                    cate = string.Compare(a.Key, b.Key, StringComparison.Ordinal);
-                }
-                return cate;
+                var category = string.Compare(a.HelpCategory, b.HelpCategory, StringComparison.Ordinal);
+                return category == 0 ? string.Compare(a.Key, b.Key, StringComparison.Ordinal) : category;
             });
 
-            var guide = (ParameterInfo parameterInfo) => parameterInfo.HasDefaultValue
-                    ? $"[ --{parameterInfo.Name} {parameterInfo.DefaultValue?.ToString() ?? ""}]"
-                    : $"--{parameterInfo.Name}";
             if (string.IsNullOrEmpty(key) || key.Equals("help", StringComparison.InvariantCultureIgnoreCase))
             {
                 string? last = null;
@@ -252,40 +258,94 @@ namespace Neo.ConsoleService
                     }
 
                     Console.Write($"\t{command.Key}");
-                    Console.WriteLine(" " + string.Join(' ', command.Method.GetParameters().Select(guide)));
+                    Console.WriteLine(" " + string.Join(' ', command.Method.GetParameters().Select(ParameterGuide)));
                 }
             }
             else
             {
-                // Show help for this specific command
-                string? last = null;
-                string? lastKey = null;
-                bool found = false;
+                ShowHelpForCommand(key, withHelp);
+            }
+        }
 
-                foreach (var command in withHelp.Where(u => u.Key == key))
+        /// <summary>
+        /// Show help for a specific command
+        /// </summary>
+        /// <param name="key">Command key</param>
+        /// <param name="withHelp">List of commands</param>
+        private void ShowHelpForCommand(string key, List<ConsoleCommandMethod> withHelp)
+        {
+            bool found = false;
+            string helpMessage = string.Empty;
+            string lastKey = string.Empty;
+            foreach (var command in withHelp.Where(u => u.Key == key))
+            {
+                found = true;
+                if (helpMessage != command.HelpMessage)
                 {
-                    found = true;
-                    if (last != command.HelpMessage)
-                    {
-                        Console.WriteLine($"{command.HelpMessage}");
-                        last = command.HelpMessage;
-                    }
-
-                    if (lastKey != command.Key)
-                    {
-                        Console.WriteLine("You can call this command like this:");
-                        lastKey = command.Key;
-                    }
-
-                    Console.Write($"\t{command.Key}");
-                    Console.WriteLine(" " + string.Join(' ', command.Method.GetParameters().Select(guide)));
+                    Console.WriteLine($"{command.HelpMessage}");
+                    helpMessage = command.HelpMessage;
                 }
 
-                if (!found)
+                if (lastKey != command.Key)
                 {
-                    throw new ArgumentException($"Command '{key}' not found. Use 'help' to see available commands.");
+                    Console.WriteLine("You can call this command like this:");
+                    lastKey = command.Key;
+                }
+
+                Console.Write($"\t{command.Key}");
+                Console.WriteLine(" " + string.Join(' ', command.Method.GetParameters().Select(ParameterGuide)));
+
+                var parameters = command.Method.GetParameters();
+                if (parameters.Length > 0)  // Show parameter info for this command
+                {
+                    Console.WriteLine($"Parameters for command `{command.Key}`:");
+                    foreach (var item in parameters)
+                    {
+                        var info = item.HasDefaultValue ? $"(optional, default: {item.DefaultValue?.ToString() ?? "null"})" : "(required)";
+                        Console.WriteLine($"\t{item.Name}: {item.ParameterType.Name} {info}");
+                    }
                 }
             }
+
+            if (!found)
+                throw new ArgumentException($"Command '{key}' not found. Use 'help' to see available commands.");
+
+            Console.WriteLine();
+            Console.WriteLine("You can also use 'how to input' to see how to input arguments.");
+        }
+
+        /// <summary>
+        /// Show `how to input` guide
+        /// </summary>
+        [ConsoleCommand("how to input", Category = "Base Commands")]
+        internal void OnHowToInput()
+        {
+            Console.WriteLine("""
+            1. Sequential Arguments (Positional)
+            Arguments are provided in the order they appear in the method signature.
+            Usage:
+            > create wallet "path/to/wallet"
+            > create wallet "path/to/wallet" "wif-or-file" "wallet-name"
+
+            Note: String values can be quoted or unquoted. Use quotes for values with spaces.
+
+            2. Indicator Arguments (Named Parameters)
+            Arguments are provided with parameter names prefixed with "--", and parameter order doesn't matter.
+            Usage:
+            > create wallet --path "path/to/wallet"
+            > create wallet --path "path/to/wallet" --wifOrFile "wif-or-file" --walletName "wallet-name"
+
+            3. Tips:
+             - String: Can be quoted or unquoted, use quotes for spaces. It's recommended to use quotes for complex values.
+             - String[]: Use comma-separated or space-separated values, If space separated, it must be the last argument.
+             - UInt160, UInt256: Specified in hex format, for example: 0x1234567890abcdef1234567890abcdef12345678
+             - Numeric: Standard number parsing
+             - Boolean: Can be specified without a value (defaults to true), true/false, 1/0, yes/no, y/n
+             - Enum: Case-insensitive enum value names
+             - JSON: Input as JSON string
+             - Escape characters: \\, \", \', \n, \r, \t, \v, \b, \f, \a, \e, \0, \ (whitespace).
+                If want to input without escape, quote the value with backtick(`).
+            """);
         }
 
         /// <summary>


### PR DESCRIPTION
# Description

This PR adds some features to make input in the `neo-cli` more user-friendly:

1. The help command outputs more information:
For example:
```
neo> help cancel
You can call this command like this:
	cancel --txid UInt256 [ --sender UInt160 ] [ --signerAccounts UInt160[] ]
Parameters for command `cancel`:
	txid: UInt256 (required)
	sender: UInt160 (optional, default: null)
	signerAccounts: UInt160[] (optional, default: null)
```

2. add `how to input` command.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
