### PR TITLE
fix(cli): improve macOS leveldb error messages with dependency details

### DIFF
--- a/src/Neo.CLI/CLI/MainService.cs
+++ b/src/Neo.CLI/CLI/MainService.cs
@@ -303,8 +303,27 @@ namespace Neo.CLI
                 }
                 else if (OperatingSystem.IsMacOS() || OperatingSystem.IsMacCatalyst())
                 {
-                    DisplayError("Shared library libleveldb.dylib not found, please get libleveldb.dylib.",
-                        $"Use command \"brew install leveldb\" in terminal or download from {levelDbUrl}");
+                    // Check if the error message contains information about missing dependencies
+                    if (ex.Message.Contains("libtcmalloc") && ex.Message.Contains("gperftools"))
+                    {
+                        DisplayError("LevelDB dependency 'gperftools' not found. This is required for libleveldb on macOS.",
+                            "To fix this issue:\n" +
+                            "1. Install gperftools: brew install gperftools\n" +
+                            "2. Install leveldb: brew install leveldb\n" +
+                            "3. If the issue persists, try: brew reinstall gperftools leveldb\n" +
+                            "\n" +
+                            "Note: The system is looking for libtcmalloc.4.dylib which is provided by gperftools.");
+                    }
+                    else
+                    {
+                        DisplayError("Shared library libleveldb.dylib not found or has missing dependencies.",
+                            "To fix this issue:\n" +
+                            "1. Install dependencies: brew install gperftools snappy\n" +
+                            "2. Install leveldb: brew install leveldb\n" +
+                            "3. If already installed, try: brew reinstall gperftools leveldb\n" +
+                            $"\n" +
+                            $"Alternative: Download pre-compiled binaries from {levelDbUrl}");
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
# Description

  This PR improves the error messages shown when Neo CLI fails to load
  libleveldb on macOS due to missing dependencies. The previous error
  message only suggested installing leveldb via brew, but didn't mention
  the required gperftools dependency that provides libtcmalloc.

  # Change Log

  - Modified `ShowDllNotFoundError` method in `MainService.cs` to detect
  specific missing dependency errors
  - Added detailed instructions for installing gperftools and leveldb via
  Homebrew
  - Included troubleshooting steps for reinstalling corrupted dependencies

  ## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

  # How Has This Been Tested?

  - [x] Local Computer Tests
  - Tested error message display when libleveldb.dylib is missing on macOS
  - Verified that the new error messages provide clear actionable steps

  # Checklist:

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my code
  - [x] My changes generate no new warnings
  - [x] New and existing unit tests pass locally with my changes