### PR TITLE
Fix: avoid NullReferenceException when account not found

### DIFF
--- a/src/Plugins/RpcServer/RpcError.cs
+++ b/src/Plugins/RpcServer/RpcError.cs
@@ -49,6 +49,7 @@ namespace Neo.Plugins.RpcServer
         public static readonly RpcError NoOpenedWallet = new(-302, "No opened wallet");
         public static readonly RpcError WalletNotFound = new(-303, "Wallet not found");
         public static readonly RpcError WalletNotSupported = new(-304, "Wallet not supported");
+        public static readonly RpcError UnknownAccount = new(-305, "Unknown account");
 
         public static readonly RpcError VerificationFailed = new(-500, "Inventory verification failed");
         public static readonly RpcError AlreadyExists = new(-501, "Inventory already exists");

--- a/src/Plugins/RpcServer/RpcServer.Wallet.cs
+++ b/src/Plugins/RpcServer/RpcServer.Wallet.cs
@@ -92,6 +92,8 @@ namespace Neo.Plugins.RpcServer
             CheckWallet();
             var scriptHash = _params[0].AsString().AddressToScriptHash(system.Settings.AddressVersion);
             var account = wallet.GetAccount(scriptHash);
+            if (account is null) throw new RpcException(RpcError.UnknownAccount.WithData($"{scriptHash}"));
+
             return account.GetKey().Export();
         }
 

--- a/tests/Neo.Plugins.RpcServer.Tests/UT_RpcServer.Wallet.cs
+++ b/tests/Neo.Plugins.RpcServer.Tests/UT_RpcServer.Wallet.cs
@@ -119,7 +119,9 @@ namespace Neo.Plugins.RpcServer.Tests
             var scriptHashNotInWallet = Contract.CreateSignatureRedeemScript(key.PublicKey).ToScriptHash();
             var addressNotInWallet = scriptHashNotInWallet.ToAddress(ProtocolSettings.Default.AddressVersion);
 
-            var ex = Assert.ThrowsExactly<NullReferenceException>(() => _rpcServer.DumpPrivKey(new JArray(addressNotInWallet)));
+            var ex = Assert.ThrowsExactly<RpcException>(() => _rpcServer.DumpPrivKey(new JArray(addressNotInWallet)));
+            Assert.AreEqual(RpcError.UnknownAccount.Code, ex.HResult);
+            Assert.Contains($"Unknown account - {scriptHashNotInWallet}", ex.Message);
             TestUtilCloseWallet();
         }
 


### PR DESCRIPTION
# Description

Avoid `NullReferenceException` when account not found.
Use explicit error code exception instead.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
