### PR TITLE
Fix: some default values not matched

### DIFF
--- a/src/Plugins/RpcServer/RcpServerSettings.cs
+++ b/src/Plugins/RpcServer/RcpServerSettings.cs
@@ -33,78 +33,87 @@ namespace Neo.Plugins.RpcServer
 
     public record RpcServersSettings
     {
-        public uint Network { get; init; }
-        public IPAddress BindAddress { get; init; }
-        public ushort Port { get; init; }
-        public string SslCert { get; init; }
-        public string SslCertPassword { get; init; }
-        public string[] TrustedAuthorities { get; init; }
-        public int MaxConcurrentConnections { get; init; }
-        public int MaxRequestBodySize { get; init; }
-        public string RpcUser { get; init; }
-        public string RpcPass { get; init; }
-        public bool EnableCors { get; init; }
-        public string[] AllowOrigins { get; init; }
-        public int KeepAliveTimeout { get; init; }
-        public uint RequestHeadersTimeout { get; init; }
-        // In the unit of datoshi, 1 GAS = 10^8 datoshi
-        public long MaxGasInvoke { get; init; }
-        // In the unit of datoshi, 1 GAS = 10^8 datoshi
-        public long MaxFee { get; init; }
-        public int MaxIteratorResultItems { get; init; }
-        public int MaxStackSize { get; init; }
-        public string[] DisabledMethods { get; init; }
-        public bool SessionEnabled { get; init; }
-        public TimeSpan SessionExpirationTime { get; init; }
-        public int FindStoragePageSize { get; init; }
+        public uint Network { get; init; } = 5195086u;
+        public IPAddress BindAddress { get; init; } = IPAddress.Loopback;
+        public ushort Port { get; init; } = 10332;
+        public string SslCert { get; init; } = string.Empty;
+        public string SslCertPassword { get; init; } = string.Empty;
+        public string[] TrustedAuthorities { get; init; } = [];
+        public int MaxConcurrentConnections { get; init; } = 40;
+        public int MaxRequestBodySize { get; init; } = 5 * 1024 * 1024;
+        public string RpcUser { get; init; } = string.Empty;
+        public string RpcPass { get; init; } = string.Empty;
+        public bool EnableCors { get; init; } = true;
+        public string[] AllowOrigins { get; init; } = [];
 
-        public static RpcServersSettings Default { get; } = new RpcServersSettings
-        {
-            Network = 5195086u,
-            BindAddress = IPAddress.None,
-            SslCert = string.Empty,
-            SslCertPassword = string.Empty,
-            MaxGasInvoke = (long)new BigDecimal(10M, NativeContract.GAS.Decimals).Value,
-            MaxFee = (long)new BigDecimal(0.1M, NativeContract.GAS.Decimals).Value,
-            TrustedAuthorities = Array.Empty<string>(),
-            EnableCors = true,
-            AllowOrigins = Array.Empty<string>(),
-            KeepAliveTimeout = 60,
-            RequestHeadersTimeout = 15,
-            MaxIteratorResultItems = 100,
-            MaxStackSize = ushort.MaxValue,
-            DisabledMethods = Array.Empty<string>(),
-            MaxConcurrentConnections = 40,
-            MaxRequestBodySize = 5 * 1024 * 1024,
-            SessionEnabled = false,
-            SessionExpirationTime = TimeSpan.FromSeconds(60),
-            FindStoragePageSize = 50
-        };
+        /// <summary>
+        /// The maximum time in seconds allowed for the keep-alive connection to be idle.
+        /// </summary>
+        public int KeepAliveTimeout { get; init; } = 60;
 
-        public static RpcServersSettings Load(IConfigurationSection section) => new()
+        /// <summary>
+        /// The maximum time in seconds allowed for the request headers to be read.
+        /// </summary>
+        public uint RequestHeadersTimeout { get; init; } = 15;
+
+        /// <summary>
+        /// In the unit of datoshi, 1 GAS = 10^8 datoshi
+        /// </summary>
+        public long MaxGasInvoke { get; init; } = (long)new BigDecimal(10M, NativeContract.GAS.Decimals).Value;
+
+        /// <summary>
+        /// In the unit of datoshi, 1 GAS = 10^8 datoshi
+        /// </summary>
+        public long MaxFee { get; init; } = (long)new BigDecimal(0.1M, NativeContract.GAS.Decimals).Value;
+        public int MaxIteratorResultItems { get; init; } = 100;
+        public int MaxStackSize { get; init; } = ushort.MaxValue;
+        public string[] DisabledMethods { get; init; } = [];
+        public bool SessionEnabled { get; init; } = false;
+        public TimeSpan SessionExpirationTime { get; init; } = TimeSpan.FromSeconds(60);
+        public int FindStoragePageSize { get; init; } = 50;
+
+        public static RpcServersSettings Default { get; } = new();
+
+        public static RpcServersSettings Load(IConfigurationSection section)
         {
-            Network = section.GetValue("Network", Default.Network),
-            BindAddress = IPAddress.Parse(section.GetSection("BindAddress").Value),
-            Port = ushort.Parse(section.GetSection("Port").Value),
-            SslCert = section.GetSection("SslCert").Value,
-            SslCertPassword = section.GetSection("SslCertPassword").Value,
-            TrustedAuthorities = section.GetSection("TrustedAuthorities").GetChildren().Select(p => p.Get<string>()).ToArray(),
-            RpcUser = section.GetSection("RpcUser").Value,
-            RpcPass = section.GetSection("RpcPass").Value,
-            EnableCors = section.GetValue(nameof(EnableCors), Default.EnableCors),
-            AllowOrigins = section.GetSection(nameof(AllowOrigins)).GetChildren().Select(p => p.Get<string>()).ToArray(),
-            KeepAliveTimeout = section.GetValue(nameof(KeepAliveTimeout), Default.KeepAliveTimeout),
-            RequestHeadersTimeout = section.GetValue(nameof(RequestHeadersTimeout), Default.RequestHeadersTimeout),
-            MaxGasInvoke = (long)new BigDecimal(section.GetValue<decimal>("MaxGasInvoke", Default.MaxGasInvoke), NativeContract.GAS.Decimals).Value,
-            MaxFee = (long)new BigDecimal(section.GetValue<decimal>("MaxFee", Default.MaxFee), NativeContract.GAS.Decimals).Value,
-            MaxIteratorResultItems = section.GetValue("MaxIteratorResultItems", Default.MaxIteratorResultItems),
-            MaxStackSize = section.GetValue("MaxStackSize", Default.MaxStackSize),
-            DisabledMethods = section.GetSection("DisabledMethods").GetChildren().Select(p => p.Get<string>()).ToArray(),
-            MaxConcurrentConnections = section.GetValue("MaxConcurrentConnections", Default.MaxConcurrentConnections),
-            MaxRequestBodySize = section.GetValue("MaxRequestBodySize", Default.MaxRequestBodySize),
-            SessionEnabled = section.GetValue("SessionEnabled", Default.SessionEnabled),
-            SessionExpirationTime = TimeSpan.FromSeconds(section.GetValue("SessionExpirationTime", (int)Default.SessionExpirationTime.TotalSeconds)),
-            FindStoragePageSize = section.GetValue("FindStoragePageSize", Default.FindStoragePageSize)
-        };
+            var @default = Default;
+            return new()
+            {
+                Network = section.GetValue("Network", @default.Network),
+                BindAddress = IPAddress.Parse(section.GetValue("BindAddress", @default.BindAddress.ToString())),
+                Port = section.GetValue("Port", @default.Port),
+                SslCert = section.GetValue("SslCert", string.Empty),
+                SslCertPassword = section.GetValue("SslCertPassword", string.Empty),
+                TrustedAuthorities = GetStrings(section, "TrustedAuthorities"),
+                RpcUser = section.GetValue("RpcUser", @default.RpcUser),
+                RpcPass = section.GetValue("RpcPass", @default.RpcPass),
+                EnableCors = section.GetValue(nameof(EnableCors), @default.EnableCors),
+                AllowOrigins = GetStrings(section, "AllowOrigins"),
+                KeepAliveTimeout = section.GetValue(nameof(KeepAliveTimeout), @default.KeepAliveTimeout),
+                RequestHeadersTimeout = section.GetValue(nameof(RequestHeadersTimeout), @default.RequestHeadersTimeout),
+                MaxGasInvoke = (long)new BigDecimal(section.GetValue<decimal>("MaxGasInvoke", @default.MaxGasInvoke), NativeContract.GAS.Decimals).Value,
+                MaxFee = (long)new BigDecimal(section.GetValue<decimal>("MaxFee", @default.MaxFee), NativeContract.GAS.Decimals).Value,
+                MaxIteratorResultItems = section.GetValue("MaxIteratorResultItems", @default.MaxIteratorResultItems),
+                MaxStackSize = section.GetValue("MaxStackSize", @default.MaxStackSize),
+                DisabledMethods = GetStrings(section, "DisabledMethods"),
+                MaxConcurrentConnections = section.GetValue("MaxConcurrentConnections", @default.MaxConcurrentConnections),
+                MaxRequestBodySize = section.GetValue("MaxRequestBodySize", @default.MaxRequestBodySize),
+                SessionEnabled = section.GetValue("SessionEnabled", @default.SessionEnabled),
+                SessionExpirationTime = TimeSpan.FromSeconds(section.GetValue("SessionExpirationTime", (long)@default.SessionExpirationTime.TotalSeconds)),
+                FindStoragePageSize = section.GetValue("FindStoragePageSize", @default.FindStoragePageSize)
+            };
+        }
+
+        private static string[] GetStrings(IConfigurationSection section, string key)
+        {
+            List<string> list = [];
+            foreach (var child in section.GetSection(key).GetChildren())
+            {
+                var value = child.Get<string>();
+                if (value is null) throw new ArgumentException($"Invalid value for {key}");
+                list.Add(value);
+            }
+            return list.ToArray();
+        }
     }
 }

--- a/src/Plugins/RpcServer/RpcServer.cs
+++ b/src/Plugins/RpcServer/RpcServer.cs
@@ -56,8 +56,8 @@ namespace Neo.Plugins.RpcServer
             this.system = system;
             this.settings = settings;
 
-            _rpcUser = settings.RpcUser is not null ? Encoding.UTF8.GetBytes(settings.RpcUser) : [];
-            _rpcPass = settings.RpcPass is not null ? Encoding.UTF8.GetBytes(settings.RpcPass) : [];
+            _rpcUser = string.IsNullOrEmpty(settings.RpcUser) ? [] : Encoding.UTF8.GetBytes(settings.RpcUser);
+            _rpcPass = string.IsNullOrEmpty(settings.RpcPass) ? [] : Encoding.UTF8.GetBytes(settings.RpcPass);
 
             var addressVersion = system.Settings.AddressVersion;
             ParameterConverter.RegisterConversion<SignersAndWitnesses>(token => token.ToSignersAndWitnesses(addressVersion));


### PR DESCRIPTION
# Description

All of `RpcServersSettings`  fields have default values.
However, when parsing `RpcServersSettings` from the configuration file, the fields not set in the configuration file are not assigned the default values.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
