### PR TITLE
Optimize: reduce one memory copy in UInt160.ToString and UInt256.ToString

### DIFF
--- a/src/Neo.Extensions/ByteExtensions.cs
+++ b/src/Neo.Extensions/ByteExtensions.cs
@@ -88,6 +88,7 @@ namespace Neo.Extensions
         /// <param name="value">The byte array to convert.</param>
         /// <param name="reverse">Indicates whether it should be converted in the reversed byte order.</param>
         /// <returns>The converted hex <see cref="string"/>.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="value"/> is null.</exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string ToHexString(this byte[]? value, bool reverse = false)
         {

--- a/src/Neo.Extensions/ByteExtensions.cs
+++ b/src/Neo.Extensions/ByteExtensions.cs
@@ -88,14 +88,24 @@ namespace Neo.Extensions
         /// <param name="value">The byte array to convert.</param>
         /// <param name="reverse">Indicates whether it should be converted in the reversed byte order.</param>
         /// <returns>The converted hex <see cref="string"/>.</returns>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="value"/> is null.</exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string ToHexString(this byte[]? value, bool reverse = false)
         {
-            if (!reverse)
-                return ToHexString(value);
-
             ArgumentNullException.ThrowIfNull(value);
+
+            return ToHexString(value.AsSpan(), reverse);
+        }
+
+        /// <summary>
+        /// Converts a byte span to hex <see cref="string"/>.
+        /// </summary>
+        /// <param name="value">The byte array to convert.</param>
+        /// <param name="reverse">Indicates whether it should be converted in the reversed byte order.</param>
+        /// <returns>The converted hex <see cref="string"/>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static string ToHexString(this ReadOnlySpan<byte> value, bool reverse = false)
+        {
+            if (!reverse) return ToHexString(value);
 
             return string.Create(value.Length * 2, value, (span, bytes) =>
             {

--- a/src/Neo/UInt160.cs
+++ b/src/Neo/UInt160.cs
@@ -163,7 +163,7 @@ namespace Neo
 
         public override string ToString()
         {
-            return "0x" + this.ToArray().ToHexString(reverse: true);
+            return "0x" + GetSpan().ToHexString(reverse: true);
         }
 
         /// <summary>

--- a/src/Neo/UInt256.cs
+++ b/src/Neo/UInt256.cs
@@ -171,7 +171,7 @@ namespace Neo
 
         public override string ToString()
         {
-            return "0x" + this.ToArray().ToHexString(reverse: true);
+            return "0x" + GetSpan().ToHexString(reverse: true);
         }
 
         /// <summary>

--- a/tests/Neo.UnitTests/UT_UInt160.cs
+++ b/tests/Neo.UnitTests/UT_UInt160.cs
@@ -47,6 +47,10 @@ namespace Neo.UnitTests.IO
             UInt160 uInt160 = "0xff00000000000000000000000000000000000001";
             Assert.IsNotNull(uInt160);
             Assert.AreEqual("0xff00000000000000000000000000000000000001", uInt160.ToString());
+
+            UInt160 value = "0x0102030405060708090a0b0c0d0e0f1011121314";
+            Assert.IsNotNull(value);
+            Assert.AreEqual("0x0102030405060708090a0b0c0d0e0f1011121314", value.ToString());
         }
 
         [TestMethod]

--- a/tests/Neo.UnitTests/UT_UInt256.cs
+++ b/tests/Neo.UnitTests/UT_UInt256.cs
@@ -49,6 +49,10 @@ namespace Neo.UnitTests.IO
             UInt256 uInt256 = "0xff00000000000000000000000000000000000000000000000000000000000001";
             Assert.IsNotNull(uInt256);
             Assert.AreEqual("0xff00000000000000000000000000000000000000000000000000000000000001", uInt256.ToString());
+
+            UInt256 value = "0x0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20";
+            Assert.IsNotNull(value);
+            Assert.AreEqual("0x0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20", value.ToString());
         }
 
         [TestMethod]


### PR DESCRIPTION
# Description

Reduce one memory copy in UInt160.ToString and UInt256.ToString

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
