### PR TITLE
Add runtime-aware gas accounting

### DIFF
--- a/docs/DynamicGas.md
+++ b/docs/DynamicGas.md
@@ -1,0 +1,86 @@
+# Dynamic Gas Pricing
+
+This release replaces the legacy fixed fee schedule with a runtime-aware
+resource model that charges contracts for the CPU, transient memory, and
+persistent storage they actually consume. The change affects every opcode,
+syscall, and native contract entrypoint.
+
+## Execution Model
+
+- **ResourceCost** – A new struct that tracks `cpuUnits`, `memoryBytes`, and
+  `storageBytes`. `ApplicationEngine` now exposes helpers (`ChargeCpu`,
+  `ChargeMemory`, `ChargeStorage`, and `AddResourceCost`) which translate
+  resource usage into datoshi using three policy-controlled multipliers:
+  `ExecFeeFactor`, `MemoryFeeFactor`, and `StoragePrice`.
+- **Memory Fee Factor** – Managed alongside the existing execution and storage
+  multipliers by the native `PolicyContract`. The defaults are available even
+  on historical state, and governance can tune the factor at runtime through
+  the existing policy RPC surface (`PolicyAPI.GetMemoryFeeFactorAsync`).
+- **Diagnostic Support** – Per-opcode resource contributions flow through the
+  existing `IDiagnostic` hook chain, enabling custom instrumentation and
+  trace tooling.
+
+## Opcode Accounting
+
+- `PreExecuteInstruction` now charges the static cost through `ChargeCpu` and
+  layers a dynamic adjustment via `CalculateDynamicOpcodeCost`. The estimator
+  inspects the evaluation stack to account for operand byte length, element
+  counts, and container sizes when executing string, buffer, and collection
+  opcodes (`PUSHDATA*`, `CAT`, `SUBSTR`, `LEFT/RIGHT`, `PACK`, `NEWARRAY*`,
+  `NEWBUFFER`, `MEMCPY`, etc.).
+- Container mutations (`APPEND`, `SETITEM`, `REVERSEITEMS`, map projections)
+  add CPU and memory proportional to the element footprint using a small
+  heuristic (`AverageElementOverhead`).
+- Iterator materialisation (`System.Iterator.Value`) bills the value size while
+  preserving immutability on the evaluation stack.
+- Numeric, bitwise, and shift opcodes scale with operand size: the estimator
+  caps total cost to avoid runaway multiplications while still reflecting the
+  expense of big integer arithmetic, modular exponentiation, or wide bitfield
+  operations.
+
+## Syscalls & Native Contracts
+
+- Interop descriptors accept optional dynamic calculators. The engine captures
+  raw stack arguments before conversion and evaluates any additional resource
+  cost prior to dispatching the handler.
+- Storage operations meter key lookups, value loads, iterator creation, and
+  writes: `System.Storage.Put`/`Delete` now charge CPU per-byte and convert the
+  existing storage delta logic to `ChargeStorage`; reads apply CPU + memory
+  proportional to the returned value size.
+- Storage iterators charge per entry during enumeration, aligning the cost of
+  `Iterator.Next` with the key/value data retrieved from the underlying store.
+- Runtime facilities (`System.Runtime.Log/Notify/LoadScript/CheckWitness`) are
+  instrumented to charge for serialized payloads, script size, and validation
+  inputs. Notifications charge per encoded byte at the point of serialization.
+- Native contracts leverage the new helpers. Method invocation now maps the
+  descriptor metadata (`CpuFee`, `StorageFee`) into resource costs without
+  manual datoshi arithmetic. Contract deployment/update charges are expressed
+  in terms of storage bytes plus a make-whole component to honour the minimum
+  deployment fee.
+
+## Policy & Tooling Updates
+
+- `PolicyContract` persists the `MemoryFeeFactor` alongside existing policy
+  knobs. Setter/getter entrypoints and RPC bindings mirror the execution and
+  storage controls.
+- `PolicyAPI` adds `GetMemoryFeeFactorAsync`, and unit/integration tests cover
+  the new RPC method.
+- Documentation and CLI examples now reference the memory fee factor and
+  describe the conversion pipeline for all three resource classes.
+
+## Migration Guidance
+
+1. **Contract Authors** – Expect gas consumption to scale with payload size.
+   Re-run critical flows on testnet and ensure off-chain estimators use the
+   updated policy API before mainnet activation. Storage writes remain priced
+   per byte; transient allocations and large notifications are now metered.
+2. **Node Operators** – Review policy multipliers (`exec`, `memory`,
+   `storage`) and adjust to reflect infrastructure costs. The defaults match
+   previous behaviour for small payloads and maintain deterministic execution.
+3. **Tooling Vendors** – Update SDKs and wallets to query
+   `GetMemoryFeeFactorAsync` when modelling gas, and surface richer diagnostics
+   where available.
+
+Activation should be coordinated through a dedicated hardfork flag so legacy
+state (which lacks the memory fee slot) absorbs the default without manual
+migration.

--- a/src/Neo/SmartContract/ApplicationEngine.Contract.cs
+++ b/src/Neo/SmartContract/ApplicationEngine.Contract.cs
@@ -124,7 +124,7 @@ namespace Neo.SmartContract
             long fee = IsHardforkEnabled(Hardfork.HF_Aspidochelone)
                 ? CheckSigPrice
                 : 1 << 8;
-            AddFee(fee * ExecFeeFactor);
+            ChargeCpu(fee);
             return Contract.CreateSignatureRedeemScript(pubKey).ToScriptHash();
         }
 
@@ -141,7 +141,7 @@ namespace Neo.SmartContract
             long fee = IsHardforkEnabled(Hardfork.HF_Aspidochelone)
                 ? CheckSigPrice * pubKeys.Length
                 : 1 << 8;
-            AddFee(fee * ExecFeeFactor);
+            ChargeCpu(fee);
             return Contract.CreateMultiSigRedeemScript(m, pubKeys).ToScriptHash();
         }
 

--- a/src/Neo/SmartContract/ApplicationEngine.Crypto.cs
+++ b/src/Neo/SmartContract/ApplicationEngine.Crypto.cs
@@ -69,7 +69,7 @@ namespace Neo.SmartContract
             if (n == 0) throw new ArgumentException("pubkeys array cannot be empty.");
             if (m == 0) throw new ArgumentException("signatures array cannot be empty.");
             if (m > n) throw new ArgumentException($"signatures count ({m}) cannot be greater than pubkeys count ({n}).");
-            AddFee(CheckSigPrice * n * ExecFeeFactor);
+            ChargeCpu(CheckSigPrice * n);
             try
             {
                 for (int i = 0, j = 0; i < m && j < n;)

--- a/src/Neo/SmartContract/ApplicationEngine.Fees.cs
+++ b/src/Neo/SmartContract/ApplicationEngine.Fees.cs
@@ -1,0 +1,94 @@
+// Copyright (C) 2015-2025 The Neo Project.
+//
+// ApplicationEngine.Fees.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using System;
+
+namespace Neo.SmartContract
+{
+    public readonly struct ResourceCost
+    {
+        public long CpuUnits { get; }
+        public long MemoryBytes { get; }
+        public long StorageBytes { get; }
+
+        public static ResourceCost Zero => default;
+
+        public ResourceCost(long cpuUnits, long memoryBytes, long storageBytes)
+        {
+            if (cpuUnits < 0) throw new ArgumentOutOfRangeException(nameof(cpuUnits));
+            if (memoryBytes < 0) throw new ArgumentOutOfRangeException(nameof(memoryBytes));
+            if (storageBytes < 0) throw new ArgumentOutOfRangeException(nameof(storageBytes));
+
+            CpuUnits = cpuUnits;
+            MemoryBytes = memoryBytes;
+            StorageBytes = storageBytes;
+        }
+
+        public ResourceCost Add(ResourceCost other)
+        {
+            checked
+            {
+                return new ResourceCost(
+                    CpuUnits + other.CpuUnits,
+                    MemoryBytes + other.MemoryBytes,
+                    StorageBytes + other.StorageBytes);
+            }
+        }
+
+        public bool IsZero => CpuUnits == 0 && MemoryBytes == 0 && StorageBytes == 0;
+
+        public static ResourceCost FromCpu(long cpuUnits) => new(cpuUnits, 0, 0);
+
+        public static ResourceCost FromMemory(long memoryBytes) => new(0, memoryBytes, 0);
+
+        public static ResourceCost FromStorage(long storageBytes) => new(0, 0, storageBytes);
+    }
+
+    partial class ApplicationEngine
+    {
+        protected internal void AddResourceCost(ResourceCost resourceCost)
+        {
+            if (resourceCost.IsZero)
+                return;
+
+            checked
+            {
+                long datoshi = resourceCost.CpuUnits * ExecFeeFactor
+                                + resourceCost.MemoryBytes * MemoryFeeFactor
+                                + resourceCost.StorageBytes * StoragePrice;
+                if (datoshi != 0)
+                    AddFee(datoshi);
+            }
+        }
+
+        protected internal void ChargeCpu(long cpuUnits)
+        {
+            if (cpuUnits < 0) throw new ArgumentOutOfRangeException(nameof(cpuUnits));
+            if (cpuUnits == 0) return;
+            AddResourceCost(ResourceCost.FromCpu(cpuUnits));
+        }
+
+        protected internal void ChargeMemory(long memoryBytes)
+        {
+            if (memoryBytes < 0) throw new ArgumentOutOfRangeException(nameof(memoryBytes));
+            if (memoryBytes == 0) return;
+            AddResourceCost(ResourceCost.FromMemory(memoryBytes));
+        }
+
+        protected internal void ChargeStorage(long storageBytes)
+        {
+            if (storageBytes < 0) throw new ArgumentOutOfRangeException(nameof(storageBytes));
+            if (storageBytes == 0) return;
+            AddResourceCost(ResourceCost.FromStorage(storageBytes));
+        }
+    }
+}
+

--- a/src/Neo/SmartContract/ApplicationEngine.Iterator.cs
+++ b/src/Neo/SmartContract/ApplicationEngine.Iterator.cs
@@ -47,7 +47,14 @@ namespace Neo.SmartContract
         /// <returns>The element in the collection at the current position of the iterator.</returns>
         internal protected StackItem IteratorValue(IIterator iterator)
         {
-            return iterator.Value(ReferenceCounter);
+            StackItem value = iterator.Value(ReferenceCounter);
+            long approximateSize = GetApproximateItemSize(value);
+            if (approximateSize > 0)
+            {
+                ChargeCpu(approximateSize);
+                ChargeMemory(approximateSize);
+            }
+            return value;
         }
     }
 }

--- a/src/Neo/SmartContract/InteropDescriptor.cs
+++ b/src/Neo/SmartContract/InteropDescriptor.cs
@@ -10,6 +10,8 @@
 // modifications are permitted.
 
 using Neo.Cryptography;
+using Neo.VM.Types;
+using System;
 using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Linq;
@@ -57,6 +59,12 @@ namespace Neo.SmartContract
         /// The fixed price for calling the interoperable service. It can be 0 if the interoperable service has a variable price.
         /// </summary>
         public long FixedPrice { get; init; }
+
+        /// <summary>
+        /// An optional delegate used to compute dynamic resource cost for the interoperable service.
+        /// Receives the engine and the raw stack arguments popped for the call (top-first order).
+        /// </summary>
+        public Func<ApplicationEngine, StackItem[], ResourceCost> DynamicCostCalculator { get; init; }
 
         /// <summary>
         /// Required Hardfork to be active.

--- a/src/Neo/SmartContract/Native/NativeContract.cs
+++ b/src/Neo/SmartContract/Native/NativeContract.cs
@@ -428,7 +428,7 @@ namespace Neo.SmartContract.Native
                 if (!state.CallFlags.HasFlag(method.RequiredCallFlags))
                     throw new InvalidOperationException($"Cannot call this method with the flag {state.CallFlags}.");
                 // In the unit of datoshi, 1 datoshi = 1e-8 GAS
-                engine.AddFee(method.CpuFee * engine.ExecFeeFactor + method.StorageFee * engine.StoragePrice);
+                engine.AddResourceCost(new ResourceCost(method.CpuFee, 0, method.StorageFee));
                 List<object> parameters = new();
                 if (method.NeedApplicationEngine) parameters.Add(engine);
                 if (method.NeedSnapshot) parameters.Add(engine.SnapshotCache);

--- a/src/RpcClient/PolicyAPI.cs
+++ b/src/RpcClient/PolicyAPI.cs
@@ -49,6 +49,16 @@ namespace Neo.Network.RPC
         }
 
         /// <summary>
+        /// Get Memory Fee Factor
+        /// </summary>
+        /// <returns></returns>
+        public async Task<uint> GetMemoryFeeFactorAsync()
+        {
+            var result = await TestInvokeAsync(scriptHash, "getMemoryFeeFactor").ConfigureAwait(false);
+            return (uint)result.Stack.Single().GetInteger();
+        }
+
+        /// <summary>
         /// Get Network Fee Per Byte
         /// </summary>
         /// <returns></returns>

--- a/tests/Neo.RpcClient.Tests/UT_PolicyAPI.cs
+++ b/tests/Neo.RpcClient.Tests/UT_PolicyAPI.cs
@@ -58,6 +58,16 @@ namespace Neo.Network.RPC.Tests
         }
 
         [TestMethod]
+        public async Task TestGetMemoryFeeFactor()
+        {
+            byte[] testScript = NativeContract.Policy.Hash.MakeScript("getMemoryFeeFactor");
+            UT_TransactionManager.MockInvokeScript(rpcClientMock, testScript, new ContractParameter { Type = ContractParameterType.Integer, Value = new BigInteger(30) });
+
+            var result = await policyAPI.GetMemoryFeeFactorAsync();
+            Assert.AreEqual(30u, result);
+        }
+
+        [TestMethod]
         public async Task TestGetFeePerByte()
         {
             byte[] testScript = NativeContract.Policy.Hash.MakeScript("getFeePerByte");


### PR DESCRIPTION
this pr is experimental, do not review. 

## Motivation
  The current fee schedule applies static, worst-case prices to opcodes and syscalls. Real workloads
  show wide variance in CPU, memory, and storage usage, so contracts can significantly underpay (e.g.,
  concatenating big buffers or emitting large notifications) while attackers can exploit cheap opcodes
  to force expensive work. We also lack a policy knob to tune in-memory allocations independently of
  storage writes.

  ## Summary
  * Introduce a `ResourceCost` model and hook it into the VM so opcodes, syscalls, and native methods
  charge for actual CPU, transient memory, and persistent storage.
  * Meter inline push-byte opcodes, data-copy primitives, iterators, runtime logging, storage APIs, and
  native contract entry points proportionally to the data they touch.
  * Expose a `MemoryFeeFactor` managed by the Policy contract and surface it through RPC, enabling
  governance to tune transient memory pricing.
  * Update docs/tests to reflect the dynamic schedule and add regression coverage for the new pricing
  rules.
