### PR TITLE
Fix: `Settings` cannot load `config.json` if neo-cli doesn't exsit in current directory

### DIFF
--- a/src/Neo.CLI/Settings.cs
+++ b/src/Neo.CLI/Settings.cs
@@ -13,6 +13,7 @@ using Microsoft.Extensions.Configuration;
 using Neo.Network.P2P;
 using Neo.Persistence.Providers;
 using System;
+using System.IO;
 using System.Reflection;
 using System.Threading;
 
@@ -46,7 +47,8 @@ namespace Neo
             {
                 if (s_default == null)
                 {
-                    var config = new ConfigurationBuilder().AddJsonFile("config.json", optional: true).Build();
+                    var configFile = ProtocolSettings.FindFile("config.json", Environment.CurrentDirectory);
+                    var config = new ConfigurationBuilder().AddJsonFile(configFile, optional: true).Build();
                     Initialize(config);
                 }
                 return Custom ?? s_default!;


### PR DESCRIPTION
# Description

The `ProtocolSettings` loads `config.json` for current directory, 
https://github.com/neo-project/neo/blob/9b9be47357e9065de524005755212ed54c3f6a11/src/Neo/ProtocolSettings.cs#L191

But the `Settings` in `Neo.Cli` loads `config.json` where the `neo-cli` binary is located.

So if `neo-cli` does not exists current directory, the `Settings` in `Neo.Cli` cannot load  `config.json`

## Type of change

- [ ] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
