### PR TITLE
Fix ut CheckNextBytes

### DIFF
--- a/tests/Neo.Extensions.Tests/Factories/UT_RandomNumberFactory.cs
+++ b/tests/Neo.Extensions.Tests/Factories/UT_RandomNumberFactory.cs
@@ -287,5 +287,15 @@ namespace Neo.Extensions.Tests.Factories
             actualValue = RandomNumberFactory.NextBigInteger(expectedMax);
             Assert.IsTrue(actualValue >= expectedMin && actualValue <= expectedMax);
         }
+
+        [TestMethod]
+        public void CheckNextBytes()
+        {
+            var actualValue = RandomNumberFactory.NextBytes(10);
+            Assert.AreEqual(10, actualValue.Length);
+
+            actualValue = RandomNumberFactory.NextBytes(10, cryptography: true);
+            Assert.AreEqual(10, actualValue.Length);
+        }
     }
 }

--- a/tests/Neo.Extensions.Tests/Factories/UT_RandomNumberFactory.cs
+++ b/tests/Neo.Extensions.Tests/Factories/UT_RandomNumberFactory.cs
@@ -287,19 +287,5 @@ namespace Neo.Extensions.Tests.Factories
             actualValue = RandomNumberFactory.NextBigInteger(expectedMax);
             Assert.IsTrue(actualValue >= expectedMin && actualValue <= expectedMax);
         }
-
-        [TestMethod]
-        public void CheckNextBytes()
-        {
-            var actualValue = RandomNumberFactory.NextBytes(10);
-            Assert.AreEqual(10, actualValue.Length);
-            foreach (var b in actualValue)
-                Assert.AreNotEqual(0, b);
-
-            actualValue = RandomNumberFactory.NextBytes(10, cryptography: true);
-            Assert.AreEqual(10, actualValue.Length);
-            foreach (var b in actualValue)
-                Assert.AreNotEqual(0, b);
-        }
     }
 }

--- a/tests/Neo.Extensions.Tests/Factories/UT_RandomNumberFactory.cs
+++ b/tests/Neo.Extensions.Tests/Factories/UT_RandomNumberFactory.cs
@@ -291,11 +291,12 @@ namespace Neo.Extensions.Tests.Factories
         [TestMethod]
         public void CheckNextBytes()
         {
-            var actualValue = RandomNumberFactory.NextBytes(10);
-            Assert.AreEqual(10, actualValue.Length);
+            var a = RandomNumberFactory.NextBytes(10);
+            Assert.AreEqual(10, a.Length);
 
-            actualValue = RandomNumberFactory.NextBytes(10, cryptography: true);
-            Assert.AreEqual(10, actualValue.Length);
+            var b = RandomNumberFactory.NextBytes(10, cryptography: true);
+            Assert.AreEqual(10, b.Length);
+            CollectionAssert.AreNotEqual(a, b);
         }
     }
 }


### PR DESCRIPTION
# Description

Check zeros in `CheckNextBytes` test is removed because the `NextBytes` method can return 0 which causes the test to fail sometimes when submitting any PR (case of #4208)

If `NextBytes` can return 0 then we should delete this checks. If it cannot return 0 then we should modify `NextBytes` method.

## Type of change

- [ ] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?


**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
