### PR TITLE
Replace `RotateLeft` extension with `dotnet` one

### DIFF
--- a/src/Neo/Cryptography/Helper.cs
+++ b/src/Neo/Cryptography/Helper.cs
@@ -322,29 +322,5 @@ namespace Neo.Cryptography
                 return true;
             return false;
         }
-
-        /// <summary>
-        /// Rotates the specified value left by the specified number of bits.
-        /// Similar in behavior to the x86 instruction ROL.
-        /// </summary>
-        /// <param name="value">The value to rotate.</param>
-        /// <param name="offset">The number of bits to rotate by.
-        /// Any value outside the range [0..31] is treated as congruent mod 32.</param>
-        /// <returns>The rotated value.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static uint RotateLeft(uint value, int offset)
-            => (value << offset) | (value >> (32 - offset));
-
-        /// <summary>
-        /// Rotates the specified value left by the specified number of bits.
-        /// Similar in behavior to the x86 instruction ROL.
-        /// </summary>
-        /// <param name="value">The value to rotate.</param>
-        /// <param name="offset">The number of bits to rotate by.
-        /// Any value outside the range [0..63] is treated as congruent mod 64.</param>
-        /// <returns>The rotated value.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static ulong RotateLeft(ulong value, int offset)
-            => (value << offset) | (value >> (64 - offset));
     }
 }

--- a/src/Neo/Cryptography/Murmur128.cs
+++ b/src/Neo/Cryptography/Murmur128.cs
@@ -12,6 +12,7 @@
 using System;
 using System.Buffers.Binary;
 using System.IO.Hashing;
+using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -103,8 +104,8 @@ namespace Neo.Cryptography
                 var tail = _tail.AsSpan();
                 ulong k1 = BinaryPrimitives.ReadUInt64LittleEndian(tail);
                 ulong k2 = BinaryPrimitives.ReadUInt64LittleEndian(tail[8..]);
-                H2 ^= Helper.RotateLeft(k2 * c2, r2) * c1;
-                H1 ^= Helper.RotateLeft(k1 * c1, r1) * c2;
+                H2 ^= BitOperations.RotateLeft(k2 * c2, r2) * c1;
+                H1 ^= BitOperations.RotateLeft(k1 * c1, r1) * c2;
             }
 
             H1 ^= (ulong)_length;
@@ -139,12 +140,12 @@ namespace Neo.Cryptography
             ulong k1 = BinaryPrimitives.ReadUInt64LittleEndian(source);
             ulong k2 = BinaryPrimitives.ReadUInt64LittleEndian(source[8..]);
 
-            H1 ^= Helper.RotateLeft(k1 * c1, r1) * c2;
-            H1 = Helper.RotateLeft(H1, 27) + H2;
+            H1 ^= BitOperations.RotateLeft(k1 * c1, r1) * c2;
+            H1 = BitOperations.RotateLeft(H1, 27) + H2;
             H1 = H1 * m + n1;
 
-            H2 ^= Helper.RotateLeft(k2 * c2, r2) * c1;
-            H2 = Helper.RotateLeft(H2, 31) + H1;
+            H2 ^= BitOperations.RotateLeft(k2 * c2, r2) * c1;
+            H2 = BitOperations.RotateLeft(H2, 31) + H1;
             H2 = H2 * m + n2;
         }
 

--- a/src/Neo/Cryptography/Murmur32.cs
+++ b/src/Neo/Cryptography/Murmur32.cs
@@ -12,6 +12,7 @@
 using System;
 using System.Buffers.Binary;
 using System.IO.Hashing;
+using System.Numerics;
 using System.Runtime.CompilerServices;
 
 namespace Neo.Cryptography
@@ -109,7 +110,7 @@ namespace Neo.Cryptography
         internal uint GetCurrentHashUInt32()
         {
             if (_tailLength > 0)
-                _hash ^= Helper.RotateLeft(_tail * c1, r1) * c2;
+                _hash ^= BitOperations.RotateLeft(_tail * c1, r1) * c2;
 
             var state = _hash ^ (uint)_length;
             state ^= state >> 16;
@@ -124,10 +125,10 @@ namespace Neo.Cryptography
         private void Mix(uint k)
         {
             k *= c1;
-            k = Helper.RotateLeft(k, r1);
+            k = BitOperations.RotateLeft(k, r1);
             k *= c2;
             _hash ^= k;
-            _hash = Helper.RotateLeft(_hash, r2);
+            _hash = BitOperations.RotateLeft(_hash, r2);
             _hash = _hash * m + n;
         }
 


### PR DESCRIPTION
# Description

Replace the `RotateLeft` Helper methods with `BitOperations.RotateLeft`.

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Test A
- [ ] Test B

**Test Configuration**:


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
