### PR TITLE
Fix: null reference exception on start

### DIFF
--- a/src/Neo/Ledger/Blockchain.cs
+++ b/src/Neo/Ledger/Blockchain.cs
@@ -542,7 +542,8 @@ namespace Neo.Ledger
                 }
                 catch (Exception ex) when (handler.Target is Plugin plugin)
                 {
-                    Utility.Log(nameof(plugin.Name), LogLevel.Error, $"{plugin.Name} exception: {ex.Message}{Environment.NewLine}{ex.StackTrace}");
+                    var cause = ex.InnerException ?? ex;
+                    Utility.Log(nameof(plugin.Name), LogLevel.Error, $"{plugin.Name} exception: {cause.Message}{Environment.NewLine}{cause.StackTrace}");
                     switch (plugin.ExceptionPolicy)
                     {
                         case UnhandledExceptionPolicy.StopNode:

--- a/src/Neo/Network/P2P/Peer.cs
+++ b/src/Neo/Network/P2P/Peer.cs
@@ -12,7 +12,6 @@
 using Akka.Actor;
 using Akka.IO;
 using Neo.Extensions;
-using Neo.Extensions.Factories;
 using System;
 using System.Buffers.Binary;
 using System.Collections.Concurrent;
@@ -201,6 +200,11 @@ namespace Neo.Network.P2P
                     ConnectToPeer(connect.EndPoint, connect.IsTrusted);
                     break;
                 case Tcp.Connected connected:
+                    if (connected.RemoteAddress is null)
+                    {
+                        Sender.Tell(Tcp.Abort.Instance);
+                        break;
+                    }
                     OnTcpConnected(((IPEndPoint)connected.RemoteAddress).UnMap(), ((IPEndPoint)connected.LocalAddress).UnMap());
                     break;
                 case Tcp.Bound _:
@@ -249,6 +253,12 @@ namespace Neo.Network.P2P
         /// <param name="local">The local endpoint of TCP connection.</param>
         private void OnTcpConnected(IPEndPoint remote, IPEndPoint local)
         {
+            if (Config is null) // OnStart is not called yet
+            {
+                Sender.Tell(Tcp.Abort.Instance);
+                return;
+            }
+
             ImmutableInterlocked.Update(ref ConnectingPeers, p => p.Remove(remote));
             if (Config.MaxConnections != -1 && ConnectedPeers.Count >= Config.MaxConnections && !TrustedIpAddresses.Contains(remote.Address))
             {


### PR DESCRIPTION
# Description

If `LocalNode` receives `Tcp.Connected` before `OnStart`, it will throw null reference exception, and cannot work.

```
ERROR [00:15:15.384]    Akka.LogEvent: Object reference not set to an instance of an object.
   at Neo.Extensions.IpAddressExtensions.UnMap(IPEndPoint endPoint) in neo/src/Neo.Extensions/Net/IpAddressExtensions.cs:line 35
   at Neo.Network.P2P.Peer.OnReceive(Object message) in neo/src/Neo/Network/P2P/Peer.cs:line 208
   at Neo.Network.P2P.LocalNode.OnReceive(Object message) in neo/src/Neo/Network/P2P/LocalNode.cs:line 219
   at Akka.Actor.UntypedActor.Receive(Object message)
   at Akka.Actor.ActorBase.AroundReceive(Receive receive, Object message)
   at Akka.Actor.ActorCell.ReceiveMessage(Object message)
   at Akka.Actor.ActorCell.Invoke(Envelope envelope)

INFO [00:15:15.391]  OnStart             
ERROR [00:15:15.393]    Akka.LogEvent: Object reference not set to an instance of an object.
   at Neo.Network.P2P.Peer.OnTcpConnected(IPEndPoint remote, IPEndPoint local) in neo/src/Neo/Network/P2P/Peer.cs:line 263
   at Neo.Network.P2P.Peer.OnReceive(Object message) in neo/src/Neo/Network/P2P/Peer.cs:line 208
   at Neo.Network.P2P.LocalNode.OnReceive(Object message) in neo/src/Neo/Network/P2P/LocalNode.cs:line 219
   at Akka.Actor.UntypedActor.Receive(Object message)
   at Akka.Actor.ActorBase.AroundReceive(Receive receive, Object message)
   at Akka.Actor.ActorCell.ReceiveMessage(Object message)
   at Akka.Actor.ActorCell.Invoke(Envelope envelope)
```

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
