### PR TITLE
Fix: unexpected log source from akka

### DIFF
--- a/src/Neo.Extensions/Utility.cs
+++ b/src/Neo.Extensions/Utility.cs
@@ -29,7 +29,7 @@ namespace Neo
             public Logger()
             {
                 Receive<InitializeLogger>(_ => Sender.Tell(new LoggerInitialized()));
-                Receive<LogEvent>(e => Log(e.LogSource, (LogLevel)e.LogLevel(), $"Akka.LogEvent: {e.Message}{Environment.NewLine}{e.Cause?.StackTrace ?? ""}"));
+                Receive<LogEvent>(e => Log("Akka", (LogLevel)e.LogLevel(), $"[{e.LogSource}] {e.Message}{Environment.NewLine}{e.Cause?.StackTrace ?? ""}"));
             }
         }
 


### PR DESCRIPTION
# Description

Different log sources have different log directories in current neo log.
So, the akka `LogEvent` may create unexpected log source because of `LogEvent.LogSource`.
![Screenshot 2025-11-01 at 19 55 06](https://github.com/user-attachments/assets/2fcc743e-6c5d-4cfd-9d51-fa5df9930952)

Avoid creating too many log directories.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update



# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
