### PR TITLE
Remove OrderedDictionary From Neo.Json

### DIFF
--- a/src/Neo.Json/JArray.cs
+++ b/src/Neo.Json/JArray.cs
@@ -9,6 +9,9 @@
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
+using System.Collections;
+using System.Text.Json;
+
 namespace Neo.Json
 {
     /// <summary>

--- a/src/Neo.Json/JBoolean.cs
+++ b/src/Neo.Json/JBoolean.cs
@@ -9,6 +9,8 @@
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
+using System.Text.Json;
+
 namespace Neo.Json
 {
     /// <summary>

--- a/src/Neo.Json/JNumber.cs
+++ b/src/Neo.Json/JNumber.cs
@@ -9,6 +9,9 @@
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
+using System.Globalization;
+using System.Text.Json;
+
 namespace Neo.Json
 {
     /// <summary>

--- a/src/Neo.Json/JObject.cs
+++ b/src/Neo.Json/JObject.cs
@@ -9,6 +9,8 @@
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
+using System.Text.Json;
+
 namespace Neo.Json
 {
     /// <summary>

--- a/src/Neo.Json/JString.cs
+++ b/src/Neo.Json/JString.cs
@@ -9,6 +9,9 @@
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
+using System.Globalization;
+using System.Text.Json;
+
 namespace Neo.Json
 {
     /// <summary>

--- a/src/Neo.Json/JToken.cs
+++ b/src/Neo.Json/JToken.cs
@@ -9,6 +9,8 @@
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
 using static Neo.Json.Utility;
 
 namespace Neo.Json

--- a/src/Neo.Json/Utility.cs
+++ b/src/Neo.Json/Utility.cs
@@ -9,6 +9,8 @@
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
+using System.Text;
+
 namespace Neo.Json
 {
     static class Utility


### PR DESCRIPTION
# Description

Remove the implementation of `OrderedDictionary` from the `Neo.Json` library and replace it with the built-in .NET implementation.

# Change Log

- Removed File 'src/Neo.Json/GlobalSuppressions.cs'
- Removed File 'src/Neo.Json/OrderedDictionary.KeyCollection.cs'
- Removed File 'src/Neo.Json/OrderedDictionary.ValueCollection.cs'
- Removed File 'src/Neo.Json/OrderedDictionary.cs'
- Removed File 'tests/Neo.Json.UnitTests/UT_OrderedDictionary.cs'

# Type of change

- [x] Optimization (the change is only an optimization)

# How Has This Been Tested?

- [x] Unit Testing
- [ ] Run Application
- [ ] Local Computer Tests
- [ ] No Testing


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
