### PR TITLE
Fix: avoid data copy for Keccak256

### DIFF
--- a/src/Neo/Cryptography/Helper.cs
+++ b/src/Neo/Cryptography/Helper.cs
@@ -203,10 +203,17 @@ namespace Neo.Cryptography
         /// </summary>
         /// <param name="value">The input to compute the hash code for.</param>
         /// <returns>The computed hash code.</returns>
-        public static byte[] Keccak256(this byte[] value)
+        public static byte[] Keccak256(this byte[] value) => value.AsSpan().Keccak256();
+
+        /// <summary>
+        /// Computes the hash value for the specified byte array using the keccak256 algorithm.
+        /// </summary>
+        /// <param name="value">The input to compute the hash code for.</param>
+        /// <returns>The computed hash code.</returns>
+        public static byte[] Keccak256(this ReadOnlySpan<byte> value)
         {
             var keccak = new KeccakDigest(256);
-            keccak.BlockUpdate(value, 0, value.Length);
+            keccak.BlockUpdate(value);
             var result = new byte[keccak.GetDigestSize()];
             keccak.DoFinal(result, 0);
             return result;
@@ -217,20 +224,7 @@ namespace Neo.Cryptography
         /// </summary>
         /// <param name="value">The input to compute the hash code for.</param>
         /// <returns>The computed hash code.</returns>
-        public static byte[] Keccak256(this ReadOnlySpan<byte> value)
-        {
-            return Keccak256(value.ToArray());
-        }
-
-        /// <summary>
-        /// Computes the hash value for the specified byte array using the keccak256 algorithm.
-        /// </summary>
-        /// <param name="value">The input to compute the hash code for.</param>
-        /// <returns>The computed hash code.</returns>
-        public static byte[] Keccak256(this Span<byte> value)
-        {
-            return Keccak256(value.ToArray());
-        }
+        public static byte[] Keccak256(this Span<byte> value) => ((ReadOnlySpan<byte>)value).Keccak256();
 
         public static byte[] AES256Encrypt(this byte[] plainData, byte[] key, byte[] nonce, byte[] associatedData = null)
         {


### PR DESCRIPTION
# Description

A minor optimization: avoid data copy for `Keccak256(ReadOnlySpan<byte>)`, `Keccak256(Span<byte>)`

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Unit Testing
- [ ] Run Application
- [ ] Local Computer Tests
- [ ] No Testing


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
