### PR TITLE
Fix: UInt160.Zero and UInt256.Zero can be modified to non-zero value.

### DIFF
--- a/src/Neo/UInt160.cs
+++ b/src/Neo/UInt160.cs
@@ -34,7 +34,7 @@ namespace Neo
         /// <summary>
         /// Represents 0.
         /// </summary>
-        public readonly static UInt160 Zero = new();
+        public static UInt160 Zero => new();
 
         [FieldOffset(0)] private ulong _value1;
         [FieldOffset(8)] private ulong _value2;

--- a/src/Neo/UInt256.cs
+++ b/src/Neo/UInt256.cs
@@ -34,7 +34,7 @@ namespace Neo
         /// <summary>
         /// Represents 0.
         /// </summary>
-        public static readonly UInt256 Zero = new();
+        public static UInt256 Zero => new();
 
         [FieldOffset(0)] private ulong _value1;
         [FieldOffset(8)] private ulong _value2;

--- a/tests/Neo.UnitTests/UT_UInt160.cs
+++ b/tests/Neo.UnitTests/UT_UInt160.cs
@@ -16,6 +16,7 @@ using Neo.Extensions;
 using Neo.Extensions.Factories;
 using Neo.IO;
 using System;
+using System.IO;
 
 namespace Neo.UnitTests.IO
 {
@@ -178,6 +179,23 @@ namespace Neo.UnitTests.IO
             var shortBuffer = new byte[UInt160.Length - 1];
             Assert.ThrowsExactly<ArgumentException>(() => value.Serialize(shortBuffer.AsSpan()));
             Assert.ThrowsExactly<ArgumentException>(() => value.SafeSerialize(shortBuffer.AsSpan()));
+        }
+
+        [TestMethod]
+        public void TestZero()
+        {
+            var value = UInt160.Zero;
+            var data = RandomNumberFactory.NextBytes(UInt160.Length);
+
+            using var stream = new MemoryStream();
+            using var writer = new BinaryWriter(stream);
+            writer.Write(data);
+
+            var reader = new MemoryReader(stream.ToArray());
+            value.Deserialize(ref reader);
+
+            var another = UInt160.Zero;
+            Assert.AreEqual("0x0000000000000000000000000000000000000000", another.ToString());
         }
     }
 }

--- a/tests/Neo.UnitTests/UT_UInt256.cs
+++ b/tests/Neo.UnitTests/UT_UInt256.cs
@@ -213,5 +213,22 @@ namespace Neo.UnitTests.IO
             Assert.ThrowsExactly<ArgumentException>(() => value.Serialize(shortBuffer.AsSpan()));
             Assert.ThrowsExactly<ArgumentException>(() => value.SafeSerialize(shortBuffer.AsSpan()));
         }
+
+        [TestMethod]
+        public void TestZero()
+        {
+            var value = UInt256.Zero;
+            var data = RandomNumberFactory.NextBytes(UInt256.Length);
+
+            using var stream = new MemoryStream();
+            using var writer = new BinaryWriter(stream);
+            writer.Write(data);
+
+            var reader = new MemoryReader(stream.ToArray());
+            value.Deserialize(ref reader);
+
+            var another = UInt256.Zero;
+            Assert.AreEqual("0x0000000000000000000000000000000000000000000000000000000000000000", another.ToString());
+        }
     }
 }


### PR DESCRIPTION
# Description

Fix: `UInt160.Zero` and `UInt256.Zero` can be modified to not zero value.
Because the content of UInt160 and UInt256 can be modified, `UInt160.Zero` and `UInt256.Zero` cannot be a static value.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Unit Testing
- [ ] Run Application
- [ ] Local Computer Tests
- [ ] No Testing


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x
- ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
