### PR TITLE
Allow remove from memPool

### DIFF
--- a/src/Neo/Ledger/MemoryPool.cs
+++ b/src/Neo/Ledger/MemoryPool.cs
@@ -177,7 +177,7 @@ namespace Neo.Ledger
         /// <summary>
         /// Remove the <see cref="Transaction"/> associated with the specified hash.
         /// </summary>
-        /// <param name="hash">The hash of the <see cref="Transaction"/> to get.</param>
+        /// <param name="hash">The hash of the <see cref="Transaction"/> to remove.</param>
         /// <param name="tx">When this method returns, contains the <see cref="Transaction"/> associated with the specified hash, if the hash is found; otherwise, <see langword="null"/>.</param>
         /// <returns><see langword="true"/> if the <see cref="MemoryPool"/> contains a <see cref="Transaction"/> with the specified hash; otherwise, <see langword="false"/>.</returns>
         public bool TryRemove(UInt256 hash, [NotNullWhen(true)] out Transaction? tx)


### PR DESCRIPTION
# Description

Required for https://github.com/neo-project/neo-node/pull/920 https://github.com/neo-project/neo/issues/4333

This pull request introduces a new method to the `MemoryPool` class in `MemoryPool.cs` that allows for the removal of a transaction by its hash in a thread-safe manner. This addition improves the ability to manage transactions within the memory pool by providing a way to safely remove and clean up associated data.

**Transaction removal functionality:**

* Added a new `TryRemove` method to the `MemoryPool` class, which attempts to remove a transaction by its hash and returns the transaction if found. This method ensures thread safety using a write lock and also cleans up related data structures and verification context.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Unit Testing
- [ ] Run Application
- [ ] Local Computer Tests
- [ ] No Testing


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
