### PR TITLE
[Fix] Allow publishing on master-n3 branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: .NET Core Test and Publish
 
 on:
   push:
-    branches: [master]
+    branches: [master, master-n3]
   pull_request:
 
 env:
@@ -68,7 +68,7 @@ jobs:
         file: ${{ github.workspace }}/TestResults/coverage/coverage.info
 
   PublishMyGet:
-    if: github.ref == 'refs/heads/master' && startsWith(github.repository, 'neo-project/')
+    if: (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/master-n3' ) && startsWith(github.repository, 'neo-project/')
     needs: [Test]
     runs-on: ubuntu-latest
     steps:
@@ -90,7 +90,7 @@ jobs:
         MYGET_TOKEN: ${{ secrets.MYGET_TOKEN }}
         
   Release:
-    if: github.ref == 'refs/heads/master' && startsWith(github.repository, 'neo-project/')
+    if: (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/master-n3') && startsWith(github.repository, 'neo-project/')
     needs: Test
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
# Description

This pull request updates the GitHub Actions workflow configuration to support both the `master` and `master-n3` branches for test runs and publishing tasks. The main changes ensure that CI/CD processes are triggered for both branches, improving flexibility for parallel development or maintenance.

Workflow trigger updates:

* The workflow is now triggered on pushes to both the `master` and `master-n3` branches, instead of only `master`.

Branch support for publishing and releasing:

* The `PublishMyGet` job will run for pushes to either `master` or `master-n3` branches, allowing package publishing from both branches.
* The `Release` job will also run for pushes to either `master` or `master-n3`, enabling releases from both branches.

# Change Log
<!-- Use a list

- Add File 'filename here'
- Removed File 'filename here'
- Add Class 'class name here'
- etc

-->

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Unit Testing
- [ ] Run Application
- [ ] Local Computer Tests
- [x] No Testing


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
