### PR TITLE
[N4] Optimize KeyBuilder

### DIFF
--- a/src/Neo/SmartContract/KeyBuilder.cs
+++ b/src/Neo/SmartContract/KeyBuilder.cs
@@ -98,11 +98,42 @@ public class KeyBuilder : IEnumerable
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public KeyBuilder Add<T>(T key) where T : unmanaged
     {
-        if (!typeof(T).IsPrimitive)
-            throw new InvalidOperationException("The argument must be a primitive.");
-        Span<byte> data = MemoryMarshal.AsBytes(MemoryMarshal.CreateSpan(ref key, 1));
-        if (BitConverter.IsLittleEndian) data.Reverse();
-        return Add(data);
+        switch (key)
+        {
+            case byte v:
+                _cacheData[_keyLength++] = v;
+                break;
+            case sbyte v:
+                _cacheData[_keyLength++] = (byte)v;
+                break;
+            case ushort v:
+                BinaryPrimitives.WriteUInt16BigEndian(_cacheData.AsSpan(_keyLength), v);
+                _keyLength += 2;
+                break;
+            case short v:
+                BinaryPrimitives.WriteInt16BigEndian(_cacheData.AsSpan(_keyLength), v);
+                _keyLength += 2;
+                break;
+            case uint v:
+                BinaryPrimitives.WriteUInt32BigEndian(_cacheData.AsSpan(_keyLength), v);
+                _keyLength += 4;
+                break;
+            case int v:
+                BinaryPrimitives.WriteInt32BigEndian(_cacheData.AsSpan(_keyLength), v);
+                _keyLength += 4;
+                break;
+            case ulong v:
+                BinaryPrimitives.WriteUInt64BigEndian(_cacheData.AsSpan(_keyLength), v);
+                _keyLength += 8;
+                break;
+            case long v:
+                BinaryPrimitives.WriteInt64BigEndian(_cacheData.AsSpan(_keyLength), v);
+                _keyLength += 8;
+                break;
+            default: throw new InvalidOperationException("Unsupported primitive type.");
+        }
+
+        return this;
     }
 
     /// <summary>


### PR DESCRIPTION
# Description

Related to https://github.com/neo-project/neo/pull/4358/files#r2580624932

This pull request refactors the `Add<T>(T key)` method in `KeyBuilder` to directly handle primitive types using a type switch, improving efficiency and clarity. The previous generic approach with reflection and memory marshaling is replaced by explicit handling for each supported primitive type, ensuring correct big-endian encoding and reducing overhead.

Primitive type handling improvements:

* Replaced the generic primitive check and memory marshaling logic with a type switch that explicitly handles each supported primitive type (`byte`, `sbyte`, `ushort`, `short`, `uint`, `int`, `ulong`, `long`), writing their values directly in big-endian format to `_cacheData`.
* Throws an `InvalidOperationException` for unsupported types, providing clearer error feedback.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Unit Testing
- [ ] Run Application
- [ ] Local Computer Tests
- [ ] No Testing


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
