### PR TITLE
[N3] Allow to cancel tx in plugins

### DIFF
--- a/tests/Neo.UnitTests/Ledger/UT_MemoryPool.cs
+++ b/tests/Neo.UnitTests/Ledger/UT_MemoryPool.cs
@@ -164,10 +164,9 @@ namespace Neo.UnitTests.Ledger
         {
             // Add over the capacity items, verify that the verified count increases each time
 
-            var cancel = new CancelEventHandler((o, c) => { c.Cancel = true; });
-            _unit.TransactionNew += cancel;
+            _unit.PolicyValidator = new Func<Transaction, IReadOnlyStore, bool>((tx, sn) => false);
             AddTransactions(1);
-            _unit.TransactionNew -= cancel;
+            _unit.PolicyValidator = null;
 
             Assert.AreEqual(0, _unit.SortedTxCount);
             Assert.AreEqual(0, _unit.VerifiedCount);


### PR DESCRIPTION
# Description

Required for https://github.com/neo-project/neo-node/pull/920
Replace https://github.com/neo-project/neo/pull/4335

Because we have the consensus in a plugin, with his settings, and the memorypool in the core, we need a way to deny some tx according the consensus policy.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Unit Testing
- [ ] Run Application
- [ ] Local Computer Tests
- [ ] No Testing


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
