### PR TITLE
Ensure Native Id in N4

### DIFF
--- a/src/Neo/SmartContract/Native/ContractManagement.cs
+++ b/src/Neo/SmartContract/Native/ContractManagement.cs
@@ -37,7 +37,7 @@ public sealed class ContractManagement : NativeContract
     private const byte Prefix_Contract = 8;
     private const byte Prefix_ContractHash = 12;
 
-    internal ContractManagement() { }
+    internal ContractManagement() : base(-1) { }
 
     private int GetNextAvailableId(DataCache snapshot)
     {

--- a/src/Neo/SmartContract/Native/CryptoLib.cs
+++ b/src/Neo/SmartContract/Native/CryptoLib.cs
@@ -29,7 +29,7 @@ public sealed partial class CryptoLib : NativeContract
         [NamedCurveHash.secp256r1Keccak256] = (ECCurve.Secp256r1, HashAlgorithm.Keccak256),
     };
 
-    internal CryptoLib() : base() { }
+    internal CryptoLib() : base(-3) { }
 
     /// <summary>
     /// Recovers the public key from a secp256k1 signature in a single byte array format.

--- a/src/Neo/SmartContract/Native/FungibleToken.cs
+++ b/src/Neo/SmartContract/Native/FungibleToken.cs
@@ -57,7 +57,8 @@ public abstract class FungibleToken<TState> : NativeContract
     /// <summary>
     /// Initializes a new instance of the <see cref="FungibleToken{TState}"/> class.
     /// </summary>
-    protected FungibleToken()
+    /// <param name="id">Native contract id</param>
+    protected FungibleToken(int id) : base(id)
     {
         Factor = BigInteger.Pow(10, Decimals);
     }

--- a/src/Neo/SmartContract/Native/GasToken.cs
+++ b/src/Neo/SmartContract/Native/GasToken.cs
@@ -22,9 +22,7 @@ public sealed class GasToken : FungibleToken<AccountState>
     public override string Symbol => "GAS";
     public override byte Decimals => 8;
 
-    internal GasToken()
-    {
-    }
+    internal GasToken() : base(-6) { }
 
     internal override ContractTask InitializeAsync(ApplicationEngine engine, Hardfork? hardfork)
     {

--- a/src/Neo/SmartContract/Native/LedgerContract.cs
+++ b/src/Neo/SmartContract/Native/LedgerContract.cs
@@ -32,7 +32,7 @@ public sealed class LedgerContract : NativeContract
 
     private readonly StorageKey _currentBlock;
 
-    internal LedgerContract() : base()
+    internal LedgerContract() : base(-4)
     {
         _currentBlock = CreateStorageKey(Prefix_CurrentBlock);
     }

--- a/src/Neo/SmartContract/Native/NativeContract.cs
+++ b/src/Neo/SmartContract/Native/NativeContract.cs
@@ -48,7 +48,6 @@ public abstract class NativeContract
     private readonly ImmutableHashSet<Hardfork> _usedHardforks;
     private readonly ReadOnlyCollection<ContractMethodMetadata> _methodDescriptors;
     private readonly ReadOnlyCollection<ContractEventAttribute> _eventsDescriptors;
-    private static int idCounter = 0;
 
     #region Named Native Contracts
 
@@ -132,13 +131,14 @@ public abstract class NativeContract
     /// <summary>
     /// The id of the native contract.
     /// </summary>
-    public int Id { get; } = --idCounter;
+    public int Id { get; }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="NativeContract"/> class.
     /// </summary>
-    protected NativeContract()
+    protected NativeContract(int id)
     {
+        Id = id;
         Hash = Helper.GetContractHash(UInt160.Zero, 0, Name);
 
         // Reflection to get the methods

--- a/src/Neo/SmartContract/Native/NeoToken.cs
+++ b/src/Neo/SmartContract/Native/NeoToken.cs
@@ -70,7 +70,7 @@ public sealed class NeoToken : FungibleToken<NeoToken.NeoAccountState>
     private readonly StorageKey _votersCount;
     private readonly StorageKey _registerPrice;
 
-    internal NeoToken()
+    internal NeoToken() : base(-5)
     {
         TotalAmount = 100000000 * Factor;
         _votersCount = CreateStorageKey(Prefix_VotersCount);

--- a/src/Neo/SmartContract/Native/Notary.cs
+++ b/src/Neo/SmartContract/Native/Notary.cs
@@ -42,7 +42,7 @@ public sealed class Notary : NativeContract
     private const byte Prefix_Deposit = 1;
     private const byte Prefix_MaxNotValidBeforeDelta = 10;
 
-    internal Notary() : base() { }
+    internal Notary() : base(-10) { }
 
     internal override ContractTask InitializeAsync(ApplicationEngine engine, Hardfork? hardfork)
     {

--- a/src/Neo/SmartContract/Native/OracleContract.cs
+++ b/src/Neo/SmartContract/Native/OracleContract.cs
@@ -45,7 +45,7 @@ public sealed class OracleContract : NativeContract
     private const byte Prefix_Request = 7;
     private const byte Prefix_IdList = 6;
 
-    internal OracleContract() { }
+    internal OracleContract() : base(-9) { }
 
     /// <summary>
     /// Sets the price for an Oracle request. Only committee members can call this method.

--- a/src/Neo/SmartContract/Native/PolicyContract.cs
+++ b/src/Neo/SmartContract/Native/PolicyContract.cs
@@ -86,7 +86,7 @@ public sealed class PolicyContract : NativeContract
 
     private const string WhitelistChangedEventName = "WhitelistFeeChanged";
 
-    internal PolicyContract()
+    internal PolicyContract() : base(-7)
     {
         _feePerByte = CreateStorageKey(Prefix_FeePerByte);
         _execFeeFactor = CreateStorageKey(Prefix_ExecFeeFactor);

--- a/src/Neo/SmartContract/Native/RoleManagement.cs
+++ b/src/Neo/SmartContract/Native/RoleManagement.cs
@@ -28,7 +28,7 @@ namespace Neo.SmartContract.Native;
     )]
 public sealed class RoleManagement : NativeContract
 {
-    internal RoleManagement() { }
+    internal RoleManagement() : base(-8) { }
 
     /// <summary>
     /// Gets the list of nodes for the specified role.

--- a/src/Neo/SmartContract/Native/StdLib.cs
+++ b/src/Neo/SmartContract/Native/StdLib.cs
@@ -27,7 +27,7 @@ public sealed class StdLib : NativeContract
 {
     private const int MaxInputLength = 1024;
 
-    internal StdLib() : base() { }
+    internal StdLib() : base(-2) { }
 
     [ContractMethod(CpuFee = 1 << 12)]
     private static byte[] Serialize(ApplicationEngine engine, StackItem item)

--- a/src/Neo/SmartContract/Native/Treasury.cs
+++ b/src/Neo/SmartContract/Native/Treasury.cs
@@ -20,6 +20,8 @@ namespace Neo.SmartContract.Native;
 /// </summary>
 public sealed class Treasury : NativeContract
 {
+    internal Treasury() : base(-11) { }
+
     protected override void OnManifestCompose(IsHardforkEnabledDelegate hfChecker, uint blockHeight, ContractManifest manifest)
     {
         manifest.SupportedStandards = ["NEP-26", "NEP-27"];

--- a/tests/Neo.UnitTests/SmartContract/Native/UT_NativeContract.cs
+++ b/tests/Neo.UnitTests/SmartContract/Native/UT_NativeContract.cs
@@ -106,7 +106,6 @@ public class UT_NativeContract
         Assert.AreEqual(-11, NativeContract.Treasury.Id);
     }
 
-
     class TestSpecialParameter
     {
         [ContractMethod]


### PR DESCRIPTION
# Description

Because in N4 we can have different native contracts, at least it will be expected for users and developers to have the same id for the same contracts, this ensure that we can remove NEO and GAS from native contracts without moving the id of the others.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Unit Testing
- [ ] Run Application
- [ ] Local Computer Tests
- [ ] No Testing

```csharp
            Assert.AreEqual(-1, NativeContract.ContractManagement.Id);
            Assert.AreEqual(-2, NativeContract.StdLib.Id);
            Assert.AreEqual(-3, NativeContract.CryptoLib.Id);
            Assert.AreEqual(-4, NativeContract.Ledger.Id);
            Assert.AreEqual(-5, NativeContract.NEO.Id);
            Assert.AreEqual(-6, NativeContract.GAS.Id);
            Assert.AreEqual(-7, NativeContract.Policy.Id);
            Assert.AreEqual(-8, NativeContract.RoleManagement.Id);
            Assert.AreEqual(-9, NativeContract.Oracle.Id);
            Assert.AreEqual(-10, NativeContract.Notary.Id);
            Assert.AreEqual(-11, NativeContract.Treasury.Id);
```


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
