### PR TITLE
Add DeepWiki badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@
   <a href='https://coveralls.io/github/neo-project/neo'>
     <img src='https://coveralls.io/repos/github/neo-project/neo/badge.svg' alt='Coverage Status' />
   </a>
+  <a href="https://deepwiki.com/neo-project/neo">
+    <img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki.">
+  </a>
   <a href="https://github.com/neo-project/neo/blob/master/LICENSE">
     <img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License.">
   </a>


### PR DESCRIPTION
Adds the DeepWiki badge to the README badge block.

Well, not a necessary change, just depends on if @shargon wants deepwiki to automatically refresh the index of this project. 