### PR TITLE
Use header cache for `GetBlockByIndexPayload`

### DIFF
--- a/src/Neo/Network/P2P/RemoteNode.ProtocolHandler.cs
+++ b/src/Neo/Network/P2P/RemoteNode.ProtocolHandler.cs
@@ -291,12 +291,17 @@ namespace Neo.Network.P2P
         {
             var snapshot = _system.StoreView;
             if (payload.IndexStart > NativeContract.Ledger.CurrentIndex(snapshot)) return;
-            List<Header> headers = new();
+            var headers = new List<Header>();
             uint count = payload.Count == -1 ? HeadersPayload.MaxHeadersCount : (uint)payload.Count;
             for (uint i = 0; i < count; i++)
             {
-                var header = NativeContract.Ledger.GetHeader(snapshot, payload.IndexStart + i);
-                if (header == null) break;
+                uint index = payload.IndexStart + i;
+                Header? header = _system.HeaderCache[index];
+                if (header == null)
+                {
+                    header = NativeContract.Ledger.GetHeader(snapshot, index);
+                    if (header == null) break;
+                }
                 headers.Add(header);
             }
             if (headers.Count == 0) return;


### PR DESCRIPTION
# Description

This pull request optimizes how block headers are retrieved in the `OnGetHeadersMessageReceived` method by leveraging a local cache before accessing the ledger. This change helps improve performance by reducing unnecessary database lookups.

**Performance improvements:**

* Modified `OnGetHeadersMessageReceived` in `RemoteNode.ProtocolHandler.cs` to first check the `_system.HeaderCache` for a header before querying `NativeContract.Ledger`. This reduces redundant ledger accesses and improves efficiency.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Unit Testing
- [ ] Run Application
- [ ] Local Computer Tests
- [ ] No Testing


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
