### PR TITLE
[Telemetry 1/4] Add telemetry hooks to Neo core

### DIFF
--- a/src/Neo/Neo.csproj
+++ b/src/Neo/Neo.csproj
@@ -30,8 +30,6 @@
     <InternalsVisibleTo Include="Neo.Plugins.RpcServer.Tests" />
     <InternalsVisibleTo Include="Neo.Plugins.OracleService.Tests" />
     <InternalsVisibleTo Include="Neo.Plugins.DBFTPlugin.Tests" />
-    <InternalsVisibleTo Include="Telemetry" />
-    <InternalsVisibleTo Include="Neo.Plugins.Telemetry.Tests" />
     <InternalsVisibleTo Include="neodebug-3-adapter" />
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
   </ItemGroup>

--- a/src/Neo/Network/P2P/RemoteNode.cs
+++ b/src/Neo/Network/P2P/RemoteNode.cs
@@ -30,8 +30,21 @@ namespace Neo.Network.P2P
     /// </summary>
     public partial class RemoteNode : Connection
     {
+        public enum ConnectionDirection
+        {
+            Inbound,
+            Outbound
+        }
+
+        public enum ConnectionChangeReason
+        {
+            Connected,
+            Closed,
+            Stopped
+        }
+
         public delegate void MessageSentHandler(NeoSystem system, Message message);
-        public delegate void ConnectionChangedHandler(NeoSystem system, IPEndPoint remote, string direction, bool connected, string reason);
+        public delegate void ConnectionChangedHandler(NeoSystem system, IPEndPoint remote, ConnectionDirection direction, bool connected, ConnectionChangeReason reason);
 
         public static event MessageSentHandler? MessageSent;
         public static event ConnectionChangedHandler? ConnectionChanged;
@@ -48,7 +61,8 @@ namespace Neo.Network.P2P
         private ByteString _messageBuffer = ByteString.Empty;
         private bool _ack = true;
         private uint _lastHeightSent = 0;
-        private readonly string _connectionDirection;
+        private readonly ConnectionDirection _connectionDirection;
+        private bool _disconnectNotified;
 
         /// <summary>
         /// The address of the remote Tcp server.
@@ -93,8 +107,8 @@ namespace Neo.Network.P2P
             _sentHashes = new HashSetCache<UInt256>(Math.Max(1, config.MaxKnownHashes));
             localNode.RemoteNodes.TryAdd(Self, this);
             var listenPort = config.Tcp?.Port;
-            _connectionDirection = listenPort.HasValue && local.Port == listenPort.Value ? "inbound" : "outbound";
-            ConnectionChanged?.Invoke(system, remote, _connectionDirection, true, "connected");
+            _connectionDirection = listenPort.HasValue && local.Port == listenPort.Value ? ConnectionDirection.Inbound : ConnectionDirection.Outbound;
+            NotifyConnectionChanged(true, ConnectionChangeReason.Connected);
         }
 
         /// <summary>
@@ -163,8 +177,8 @@ namespace Neo.Network.P2P
             base.OnReceive(message);
             switch (message)
             {
-                case Close close:
-                    ConnectionChanged?.Invoke(_system, Remote, _connectionDirection, false, "closed");
+                case Close:
+                    NotifyConnectionChanged(false, ConnectionChangeReason.Closed);
                     break;
                 case Timer _:
                     OnTimer();
@@ -225,7 +239,7 @@ namespace Neo.Network.P2P
             {
                 _knownHashes.Clear();
                 _sentHashes.Clear();
-                ConnectionChanged?.Invoke(_system, Remote, _connectionDirection, false, "stopped");
+                NotifyConnectionChanged(false, ConnectionChangeReason.Stopped);
             }
             base.PostStop();
         }
@@ -240,9 +254,31 @@ namespace Neo.Network.P2P
             _ack = false;
             // Here it is possible that we dont have the Version message yet,
             // so we need to send the message uncompressed
-            MessageSent?.Invoke(_system, message);
+            SafeInvoke(() => MessageSent?.Invoke(_system, message));
             SendData(ByteString.FromBytes(message.ToArray(Version?.AllowCompression ?? false)));
             _sentCommands[(byte)message.Command] = true;
+        }
+
+        private void NotifyConnectionChanged(bool connected, ConnectionChangeReason reason)
+        {
+            if (!connected)
+            {
+                if (_disconnectNotified) return;
+                _disconnectNotified = true;
+            }
+
+            SafeInvoke(() => ConnectionChanged?.Invoke(_system, Remote, _connectionDirection, connected, reason));
+        }
+
+        private static void SafeInvoke(Action action)
+        {
+            try
+            {
+                action();
+            }
+            catch
+            {
+            }
         }
 
         private Message? TryParseMessage()


### PR DESCRIPTION
## Summary

This PR adds static event hooks to the Neo core P2P layer to enable telemetry collection without modifying the core behavior.

### Changes
- Add `MessageSent` event to `RemoteNode` for tracking outgoing messages
- Add `ConnectionChanged` event for monitoring peer connection lifecycle
- Wrap event invocations in try-catch to prevent telemetry failures from crashing the node

### Files Changed
- `src/Neo/Network/P2P/RemoteNode.cs`

## Test Plan
- [x] Build passes
- [x] Existing unit tests pass
- [x] Event handlers with exceptions don't crash the node

## Part of Telemetry Feature

This is PR 1 of 4 for adding comprehensive telemetry support to Neo nodes:
1. **[This PR]** Core hooks - Add event hooks to Neo core
2. Plugin + Collectors - Main telemetry plugin and metric collectors
3. Health endpoints - Kubernetes-compatible health check endpoints
4. Documentation - README and monitoring configurations

Related to #4376