### PR TITLE
P2P: QUIC/TCP auto-switch + multiplexing (compat)

### DIFF
--- a/benchmarks/Neo.Benchmarks/Network/P2P/Benchmarks.P2PTransport.cs
+++ b/benchmarks/Neo.Benchmarks/Network/P2P/Benchmarks.P2PTransport.cs
@@ -1,0 +1,307 @@
+// Copyright (C) 2015-2025 The Neo Project.
+//
+// Benchmarks.P2PTransport.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using BenchmarkDotNet.Attributes;
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Quic;
+using System.Net.Security;
+using System.Net.Sockets;
+using System.Runtime.Versioning;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Neo.Benchmark.Network.P2P
+{
+    [MemoryDiagnoser]
+    public class Benchmarks_P2PTransport
+    {
+        [SupportedOSPlatformGuard("linux")]
+        [SupportedOSPlatformGuard("macos")]
+        [SupportedOSPlatformGuard("windows")]
+        private static bool IsQuicPlatformSupported =>
+            OperatingSystem.IsWindows() || OperatingSystem.IsLinux() || OperatingSystem.IsMacOS();
+
+        [Params(256, 1024, 8192, 65536)]
+        public int MessageSize;
+
+        [Params(256)]
+        public int MessagesPerIteration;
+
+        private byte[] _payload = Array.Empty<byte>();
+
+        private CancellationTokenSource _cts;
+
+        private TcpListener _tcpListener;
+        private TcpClient _tcpClient;
+        private TcpClient _tcpServerClient;
+        private NetworkStream _tcpClientStream;
+        private NetworkStream _tcpServerStream;
+        private Task _tcpReadLoop;
+        private long _tcpReadTargetBytes;
+        private long _tcpReadSoFar;
+        private readonly ManualResetEventSlim _tcpReadDone = new(false);
+
+        private QuicListener _quicListener;
+        private QuicConnection _quicClient;
+        private QuicConnection _quicServer;
+        private X509Certificate2 _quicCert;
+        private Task _quicAcceptLoop;
+        private int _quicExpectedMessages;
+        private int _quicMessagesReceived;
+        private readonly ManualResetEventSlim _quicReadDone = new(false);
+
+        [GlobalSetup]
+        public async Task SetupAsync()
+        {
+            _payload = new byte[MessageSize];
+            RandomNumberGenerator.Fill(_payload);
+
+            _cts = new CancellationTokenSource();
+
+            SetupTcp();
+            if (IsQuicPlatformSupported)
+                await SetupQuicAsync().ConfigureAwait(false);
+        }
+
+        [GlobalCleanup]
+        public async Task CleanupAsync()
+        {
+            _cts.Cancel();
+
+            _tcpReadDone.Set();
+            _quicReadDone.Set();
+
+            try { _tcpClientStream.Dispose(); } catch { }
+            try { _tcpServerStream.Dispose(); } catch { }
+            try { _tcpClient.Dispose(); } catch { }
+            try { _tcpServerClient.Dispose(); } catch { }
+            try { _tcpListener.Stop(); } catch { }
+
+            if (IsQuicPlatformSupported && QuicListener.IsSupported)
+            {
+                try { await _quicClient.DisposeAsync().ConfigureAwait(false); } catch { }
+                try { await _quicServer.DisposeAsync().ConfigureAwait(false); } catch { }
+                try { await _quicListener.DisposeAsync().ConfigureAwait(false); } catch { }
+                try { _quicCert.Dispose(); } catch { }
+            }
+
+            _cts.Dispose();
+        }
+
+        private void SetupTcp()
+        {
+            _tcpListener = new TcpListener(IPAddress.Loopback, 0);
+            _tcpListener.Start();
+
+            _tcpClient = new TcpClient { NoDelay = true };
+            _tcpClient.Connect((IPEndPoint)_tcpListener.LocalEndpoint);
+            _tcpClientStream = _tcpClient.GetStream();
+
+            _tcpServerClient = _tcpListener.AcceptTcpClient();
+            _tcpServerClient.NoDelay = true;
+            _tcpServerStream = _tcpServerClient.GetStream();
+
+            _tcpReadLoop = Task.Run(() => TcpReadLoopAsync(_tcpServerStream, _cts!.Token));
+        }
+
+        [SupportedOSPlatform("linux")]
+        [SupportedOSPlatform("macos")]
+        [SupportedOSPlatform("windows")]
+        private async Task SetupQuicAsync()
+        {
+            if (!IsQuicPlatformSupported || !QuicListener.IsSupported)
+                return;
+
+            _quicCert = CreateSelfSignedCertificate("neo-p2p");
+
+            var listenerOptions = new QuicListenerOptions
+            {
+                ListenEndPoint = new IPEndPoint(IPAddress.Loopback, 0),
+                ApplicationProtocols = new List<SslApplicationProtocol> { new("neo-p2p") },
+                ConnectionOptionsCallback = (_, _, _) => ValueTask.FromResult(new QuicServerConnectionOptions
+                {
+                    DefaultCloseErrorCode = 0,
+                    DefaultStreamErrorCode = 0,
+                    MaxInboundBidirectionalStreams = 2048,
+                    ServerAuthenticationOptions = new SslServerAuthenticationOptions
+                    {
+                        ApplicationProtocols = new List<SslApplicationProtocol> { new("neo-p2p") },
+                        ServerCertificate = _quicCert,
+                    },
+                })
+            };
+
+            _quicListener = await QuicListener.ListenAsync(listenerOptions, _cts!.Token).ConfigureAwait(false);
+
+            var serverAcceptTask = _quicListener.AcceptConnectionAsync(_cts.Token).AsTask();
+
+            var clientOptions = new QuicClientConnectionOptions
+            {
+                RemoteEndPoint = (IPEndPoint)_quicListener.LocalEndPoint,
+                DefaultCloseErrorCode = 0,
+                DefaultStreamErrorCode = 0,
+                MaxInboundBidirectionalStreams = 2048,
+                ClientAuthenticationOptions = new SslClientAuthenticationOptions
+                {
+                    ApplicationProtocols = new List<SslApplicationProtocol> { new("neo-p2p") },
+                    TargetHost = "neo-p2p",
+                    CertificateRevocationCheckMode = X509RevocationMode.NoCheck,
+                    RemoteCertificateValidationCallback = (_, _, _, _) => true,
+                }
+            };
+
+            _quicClient = await QuicConnection.ConnectAsync(clientOptions, _cts.Token).ConfigureAwait(false);
+            _quicServer = await serverAcceptTask.ConfigureAwait(false);
+
+            _quicAcceptLoop = Task.Run(() => QuicAcceptLoopAsync(_quicServer, _cts.Token), _cts.Token);
+        }
+
+        private async Task TcpReadLoopAsync(NetworkStream stream, CancellationToken cancellationToken)
+        {
+            var buffer = new byte[64 * 1024];
+            try
+            {
+                while (!cancellationToken.IsCancellationRequested)
+                {
+                    var read = await stream.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
+                    if (read == 0) break;
+
+                    var total = Interlocked.Add(ref _tcpReadSoFar, read);
+                    if (total >= Volatile.Read(ref _tcpReadTargetBytes))
+                        _tcpReadDone.Set();
+                }
+            }
+            catch
+            {
+            }
+        }
+
+        [Benchmark(Description = "TCP: single stream, N fixed-size messages")]
+        public void Tcp_SendFixedSizeMessages()
+        {
+            var stream = _tcpClientStream;
+            _tcpReadDone.Reset();
+            Interlocked.Exchange(ref _tcpReadSoFar, 0);
+            Volatile.Write(ref _tcpReadTargetBytes, (long)_payload.Length * MessagesPerIteration);
+
+            for (int i = 0; i < MessagesPerIteration; i++)
+                stream.Write(_payload);
+
+            stream.Flush();
+            _tcpReadDone.Wait();
+        }
+
+        [Benchmark(Description = "QUIC: one stream per message, N fixed-size messages")]
+        [SupportedOSPlatform("linux")]
+        [SupportedOSPlatform("macos")]
+        [SupportedOSPlatform("windows")]
+        public async Task Quic_SendFixedSizeMessages_StreamPerMessage()
+        {
+            if (!IsQuicPlatformSupported || !QuicListener.IsSupported)
+                return;
+
+            _quicReadDone.Reset();
+            Interlocked.Exchange(ref _quicMessagesReceived, 0);
+            Volatile.Write(ref _quicExpectedMessages, MessagesPerIteration);
+
+            for (int i = 0; i < MessagesPerIteration; i++)
+            {
+                await using var stream = await _quicClient.OpenOutboundStreamAsync(QuicStreamType.Bidirectional, _cts.Token).ConfigureAwait(false);
+                await stream.WriteAsync(_payload, _cts.Token).ConfigureAwait(false);
+                stream.CompleteWrites();
+            }
+
+            _quicReadDone.Wait();
+        }
+
+        [SupportedOSPlatform("linux")]
+        [SupportedOSPlatform("macos")]
+        [SupportedOSPlatform("windows")]
+        private async Task QuicAcceptLoopAsync(QuicConnection connection, CancellationToken cancellationToken)
+        {
+            try
+            {
+                while (!cancellationToken.IsCancellationRequested)
+                {
+                    var stream = await connection.AcceptInboundStreamAsync(cancellationToken).ConfigureAwait(false);
+                    _ = Task.Run(() => QuicDrainStreamAsync(stream, cancellationToken), cancellationToken);
+                }
+            }
+            catch
+            {
+            }
+        }
+
+        [SupportedOSPlatform("linux")]
+        [SupportedOSPlatform("macos")]
+        [SupportedOSPlatform("windows")]
+        private async Task QuicDrainStreamAsync(QuicStream stream, CancellationToken cancellationToken)
+        {
+            var buffer = new byte[64 * 1024];
+            try
+            {
+                while (true)
+                {
+                    var read = await stream.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
+                    if (read == 0) break;
+                }
+
+                var received = Interlocked.Increment(ref _quicMessagesReceived);
+                if (received >= Volatile.Read(ref _quicExpectedMessages))
+                    _quicReadDone.Set();
+            }
+            catch
+            {
+            }
+            finally
+            {
+                try { await stream.DisposeAsync().ConfigureAwait(false); } catch { }
+            }
+        }
+
+        private static X509Certificate2 CreateSelfSignedCertificate(string host)
+        {
+            using var rsa = RSA.Create(2048);
+            var request = new CertificateRequest($"CN={host}", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+            request.CertificateExtensions.Add(new X509BasicConstraintsExtension(false, false, 0, false));
+            request.CertificateExtensions.Add(new X509KeyUsageExtension(X509KeyUsageFlags.DigitalSignature | X509KeyUsageFlags.KeyEncipherment, false));
+            request.CertificateExtensions.Add(new X509SubjectKeyIdentifierExtension(request.PublicKey, false));
+            request.CertificateExtensions.Add(new X509EnhancedKeyUsageExtension(new OidCollection { new("1.3.6.1.5.5.7.3.1") }, false));
+
+            var sanBuilder = new SubjectAlternativeNameBuilder();
+            sanBuilder.AddDnsName(host);
+            request.CertificateExtensions.Add(sanBuilder.Build());
+
+            using var cert = request.CreateSelfSigned(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddYears(1));
+            var pfx = cert.Export(X509ContentType.Pfx);
+            var keyStorageFlags =
+                OperatingSystem.IsWindows()
+                    ? X509KeyStorageFlags.Exportable | X509KeyStorageFlags.MachineKeySet | X509KeyStorageFlags.PersistKeySet
+                    : X509KeyStorageFlags.Exportable | X509KeyStorageFlags.EphemeralKeySet;
+
+            try
+            {
+                return X509CertificateLoader.LoadPkcs12(pfx, password: null, keyStorageFlags: keyStorageFlags);
+            }
+            catch (CryptographicException) when (OperatingSystem.IsWindows())
+            {
+                return X509CertificateLoader.LoadPkcs12(
+                    pfx,
+                    password: null,
+                    keyStorageFlags: X509KeyStorageFlags.Exportable | X509KeyStorageFlags.UserKeySet | X509KeyStorageFlags.PersistKeySet);
+            }
+        }
+    }
+}

--- a/benchmarks/Neo.Benchmarks/Program.cs
+++ b/benchmarks/Neo.Benchmarks/Program.cs
@@ -10,6 +10,7 @@
 // modifications are permitted.
 
 using BenchmarkDotNet.Running;
+using BenchmarkDotNet.Configs;
 
 // List all benchmarks:
 //  dotnet run -c Release --framework [for example: net9.0] -- --list flat(or tree)
@@ -20,4 +21,5 @@ using BenchmarkDotNet.Running;
 // Run all benchmarks of a class:
 //  dotnet run -c Release --framework [for example: net9.0] -- -f '*Class*'
 // More options: https://benchmarkdotnet.org/articles/guides/console-args.html
-BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+var config = DefaultConfig.Instance.WithOptions(ConfigOptions.DisableOptimizationsValidator);
+BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args, config);

--- a/src/Neo/Network/P2P/Capabilities/NeoP2PExtensionsCapability.cs
+++ b/src/Neo/Network/P2P/Capabilities/NeoP2PExtensionsCapability.cs
@@ -1,0 +1,87 @@
+// Copyright (C) 2015-2025 The Neo Project.
+//
+// NeoP2PExtensionsCapability.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using System;
+using System.Buffers.Binary;
+
+namespace Neo.Network.P2P.Capabilities
+{
+    [Flags]
+    internal enum NeoP2PExtensions : byte
+    {
+        None = 0,
+        Quic = 1 << 0,
+    }
+
+    internal readonly record struct NeoP2PExtensionsData(NeoP2PExtensions Extensions, ushort QuicPort);
+
+    internal static class NeoP2PExtensionsCapability
+    {
+        private const byte CapabilityVersion = 1;
+        private static ReadOnlySpan<byte> Magic => "NEOQ"u8;
+
+        // 4 bytes magic + 1 version + 1 flags + 2 quicPort
+        private const int PayloadLengthV1 = 8;
+
+        public static UnknownCapability Create(NeoP2PExtensionsData data)
+        {
+            Span<byte> payload = stackalloc byte[PayloadLengthV1];
+            Magic.CopyTo(payload);
+            payload[4] = CapabilityVersion;
+            payload[5] = (byte)data.Extensions;
+            BinaryPrimitives.WriteUInt16LittleEndian(payload[6..8], data.QuicPort);
+
+            return new UnknownCapability(NodeCapabilityType.Extension0) { Data = payload.ToArray() };
+        }
+
+        public static bool TryParse(NodeCapability[] capabilities, out NeoP2PExtensionsData data)
+        {
+            foreach (var capability in capabilities)
+            {
+                if (capability is not UnknownCapability unknown) continue;
+                if (unknown.Type != NodeCapabilityType.Extension0) continue;
+
+                if (TryParse(unknown.Data.Span, out data))
+                    return true;
+            }
+
+            data = default;
+            return false;
+        }
+
+        public static bool TryParse(ReadOnlySpan<byte> payload, out NeoP2PExtensionsData data)
+        {
+            if (payload.Length < PayloadLengthV1)
+            {
+                data = default;
+                return false;
+            }
+
+            if (!payload[..4].SequenceEqual(Magic))
+            {
+                data = default;
+                return false;
+            }
+
+            if (payload[4] != CapabilityVersion)
+            {
+                data = default;
+                return false;
+            }
+
+            var extensions = (NeoP2PExtensions)payload[5];
+            ushort quicPort = BinaryPrimitives.ReadUInt16LittleEndian(payload[6..8]);
+
+            data = new NeoP2PExtensionsData(extensions, quicPort);
+            return true;
+        }
+    }
+}

--- a/src/Neo/Network/P2P/ChannelsConfig.cs
+++ b/src/Neo/Network/P2P/ChannelsConfig.cs
@@ -49,6 +49,16 @@ namespace Neo.Network.P2P
         public IPEndPoint? Tcp { get; set; }
 
         /// <summary>
+        /// Quic configuration (UDP endpoint).
+        /// </summary>
+        public IPEndPoint? Quic { get; set; }
+
+        /// <summary>
+        /// Prefer QUIC when the remote peer supports it.
+        /// </summary>
+        public bool PreferQuic { get; set; } = false;
+
+        /// <summary>
         /// Enable compression.
         /// </summary>
         public bool EnableCompression { get; set; } = DefaultEnableCompression;

--- a/src/Neo/Network/P2P/LocalNode.cs
+++ b/src/Neo/Network/P2P/LocalNode.cs
@@ -271,6 +271,13 @@ namespace Neo.Network.P2P
 
             if (ListenerTcpPort > 0) capabilities.Add(new ServerCapability(NodeCapabilityType.TcpServer, (ushort)ListenerTcpPort));
 
+            if (ListenerQuicPort is > 0 and <= ushort.MaxValue)
+            {
+                capabilities.Add(NeoP2PExtensionsCapability.Create(new NeoP2PExtensionsData(
+                    NeoP2PExtensions.Quic,
+                    (ushort)ListenerQuicPort)));
+            }
+
             return [.. capabilities];
         }
 

--- a/src/Neo/Network/P2P/RemoteNode.ProtocolHandler.cs
+++ b/src/Neo/Network/P2P/RemoteNode.ProtocolHandler.cs
@@ -139,11 +139,7 @@ namespace Neo.Network.P2P
             ref bool sent = ref _sentCommands[(byte)MessageCommand.GetAddr];
             if (!sent) return;
             sent = false;
-            var endPoints = payload.AddressList
-                .Select(p => p.EndPoint)
-                .Where(p => p.Port > 0)
-                .ToArray();
-            _system.LocalNode.Tell(new Peer.Peers(endPoints));
+            _system.LocalNode.Tell(new Peer.AdvertisedPeers(payload.AddressList));
         }
 
         private void OnFilterAddMessageReceived(FilterAddPayload payload)

--- a/src/Neo/Network/P2P/Transports/ITransportConnection.cs
+++ b/src/Neo/Network/P2P/Transports/ITransportConnection.cs
@@ -1,0 +1,31 @@
+// Copyright (C) 2015-2025 The Neo Project.
+//
+// ITransportConnection.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Akka.Actor;
+using System;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Neo.Network.P2P.Transports
+{
+    internal interface ITransportConnection : IAsyncDisposable
+    {
+        IPEndPoint RemoteEndPoint { get; }
+        IPEndPoint LocalEndPoint { get; }
+
+        void Start(IActorRef receiver);
+
+        Task SendAsync(ReadOnlyMemory<byte> data, CancellationToken cancellationToken);
+
+        Task CloseAsync(bool abort, CancellationToken cancellationToken);
+    }
+}

--- a/src/Neo/Network/P2P/Transports/QuicTransport.cs
+++ b/src/Neo/Network/P2P/Transports/QuicTransport.cs
@@ -1,0 +1,157 @@
+// Copyright (C) 2015-2025 The Neo Project.
+//
+// QuicTransport.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Quic;
+using System.Net.Security;
+using System.Runtime.Versioning;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
+
+namespace Neo.Network.P2P.Transports
+{
+    [SupportedOSPlatform("linux")]
+    [SupportedOSPlatform("macos")]
+    [SupportedOSPlatform("windows")]
+    internal static class QuicTransport
+    {
+        internal const string TargetHost = "neo-p2p";
+        internal static readonly SslApplicationProtocol ApplicationProtocol = new(TargetHost);
+
+        [SupportedOSPlatformGuard("linux")]
+        [SupportedOSPlatformGuard("macos")]
+        [SupportedOSPlatformGuard("windows")]
+        public static bool IsSupported => QuicListener.IsSupported;
+
+        public static X509Certificate2 CreateSelfSignedCertificate()
+        {
+            // Prefer RSA here for broad compatibility across TLS providers (including Windows Schannel / MsQuic).
+            using var rsa = RSA.Create(2048);
+            var request = new CertificateRequest($"CN={TargetHost}", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+            request.CertificateExtensions.Add(new X509BasicConstraintsExtension(false, false, 0, false));
+            request.CertificateExtensions.Add(new X509KeyUsageExtension(X509KeyUsageFlags.DigitalSignature | X509KeyUsageFlags.KeyEncipherment, false));
+            request.CertificateExtensions.Add(new X509SubjectKeyIdentifierExtension(request.PublicKey, false));
+            request.CertificateExtensions.Add(new X509EnhancedKeyUsageExtension(
+                new OidCollection { new Oid("1.3.6.1.5.5.7.3.1") }, // Server Authentication
+                false));
+
+            var sanBuilder = new SubjectAlternativeNameBuilder();
+            sanBuilder.AddDnsName(TargetHost);
+            request.CertificateExtensions.Add(sanBuilder.Build());
+
+            var notBefore = DateTimeOffset.UtcNow.AddDays(-1);
+            var notAfter = notBefore.AddYears(1);
+            using var cert = request.CreateSelfSigned(notBefore, notAfter);
+
+            // Re-import as PFX so the private key is available to the OS TLS stack (notably on Windows).
+            var pfx = cert.Export(X509ContentType.Pfx);
+            if (OperatingSystem.IsWindows())
+            {
+                // MsQuic/Schannel can be picky about how the private key is loaded. Prefer machine key storage,
+                // with a fallback to the user key store when machine storage isn't available.
+                var machineFlags = X509KeyStorageFlags.Exportable | X509KeyStorageFlags.MachineKeySet | X509KeyStorageFlags.PersistKeySet;
+                var userFlags = X509KeyStorageFlags.Exportable | X509KeyStorageFlags.UserKeySet | X509KeyStorageFlags.PersistKeySet;
+
+                try
+                {
+                    var loaded = X509CertificateLoader.LoadPkcs12(pfx, password: null, keyStorageFlags: machineFlags);
+                    if (loaded.HasPrivateKey)
+                        return loaded;
+                    loaded.Dispose();
+                }
+                catch (CryptographicException)
+                {
+                }
+
+                var fallback = X509CertificateLoader.LoadPkcs12(pfx, password: null, keyStorageFlags: userFlags);
+                if (!fallback.HasPrivateKey)
+                    throw new CryptographicException("Failed to create a QUIC server certificate with a usable private key.");
+                return fallback;
+            }
+
+            return X509CertificateLoader.LoadPkcs12(
+                pfx,
+                password: null,
+                keyStorageFlags: X509KeyStorageFlags.Exportable | X509KeyStorageFlags.EphemeralKeySet);
+        }
+
+        public static QuicListenerOptions CreateListenerOptions(IPEndPoint listenEndPoint, X509Certificate2 certificate)
+        {
+            return new QuicListenerOptions
+            {
+                ListenEndPoint = listenEndPoint,
+                ApplicationProtocols = new List<SslApplicationProtocol> { ApplicationProtocol },
+                ConnectionOptionsCallback = (_, _, _) => ValueTask.FromResult(new QuicServerConnectionOptions
+                {
+                    DefaultCloseErrorCode = 0,
+                    DefaultStreamErrorCode = 0,
+                    MaxInboundBidirectionalStreams = 256,
+                    ServerAuthenticationOptions = CreateServerAuthenticationOptions(certificate),
+                })
+            };
+        }
+
+        public static QuicClientConnectionOptions CreateClientOptions(IPEndPoint remoteEndPoint)
+        {
+            return new QuicClientConnectionOptions
+            {
+                RemoteEndPoint = remoteEndPoint,
+                DefaultCloseErrorCode = 0,
+                DefaultStreamErrorCode = 0,
+                MaxInboundBidirectionalStreams = 256,
+                ClientAuthenticationOptions = CreateClientAuthenticationOptions(),
+            };
+        }
+
+        private static SslServerAuthenticationOptions CreateServerAuthenticationOptions(X509Certificate2 certificate)
+        {
+            return new SslServerAuthenticationOptions
+            {
+                ApplicationProtocols = new List<SslApplicationProtocol> { ApplicationProtocol },
+                ServerCertificate = certificate,
+            };
+        }
+
+        private static SslClientAuthenticationOptions CreateClientAuthenticationOptions()
+        {
+            return new SslClientAuthenticationOptions
+            {
+                ApplicationProtocols = new List<SslApplicationProtocol> { ApplicationProtocol },
+                CertificateRevocationCheckMode = X509RevocationMode.NoCheck,
+                TargetHost = TargetHost,
+                RemoteCertificateValidationCallback = ValidateServerCertificate,
+            };
+        }
+
+        private static bool ValidateServerCertificate(object _, X509Certificate? certificate, X509Chain? __, SslPolicyErrors sslPolicyErrors)
+        {
+            if (certificate is not X509Certificate2 cert)
+                return false;
+
+            // Expect a self-signed cert for now (encrypts transport, but does not provide strong peer authentication).
+            // Keep at least basic checks so we don't fully disable validation.
+            if (sslPolicyErrors is not (SslPolicyErrors.None or SslPolicyErrors.RemoteCertificateChainErrors))
+                return false;
+
+            var now = DateTimeOffset.UtcNow;
+            if (now < cert.NotBefore || now > cert.NotAfter)
+                return false;
+
+            if (!cert.Subject.Contains($"CN={TargetHost}", StringComparison.OrdinalIgnoreCase))
+                return false;
+
+            return true;
+        }
+    }
+}

--- a/src/Neo/Network/P2P/Transports/QuicTransportConnection.cs
+++ b/src/Neo/Network/P2P/Transports/QuicTransportConnection.cs
@@ -1,0 +1,192 @@
+// Copyright (C) 2015-2025 The Neo Project.
+//
+// QuicTransportConnection.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Akka.Actor;
+using Akka.IO;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Quic;
+using System.Runtime.Versioning;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Neo.Network.P2P.Transports
+{
+    [SupportedOSPlatform("linux")]
+    [SupportedOSPlatform("macos")]
+    [SupportedOSPlatform("windows")]
+    internal sealed class QuicTransportConnection : ITransportConnection
+    {
+        private const int ReceiveBufferSize = 64 * 1024;
+        private const int MaxMessageSize = Neo.Network.P2P.Message.PayloadMaxSize + 64;
+
+        private readonly QuicConnection _connection;
+
+        private CancellationTokenSource? _cts;
+        private Task? _acceptLoop;
+        private int _closed = 0;
+
+        private long _nextInboundSeq = 0;
+        private long _nextDeliverSeq = 0;
+        private readonly object _deliverLock = new();
+        private readonly Dictionary<long, byte[]> _pendingBySeq = new();
+
+        private QuicTransportConnection(QuicConnection connection)
+        {
+            _connection = connection;
+
+            RemoteEndPoint = (IPEndPoint)_connection.RemoteEndPoint;
+            LocalEndPoint = (IPEndPoint)_connection.LocalEndPoint;
+        }
+
+        public IPEndPoint RemoteEndPoint { get; }
+
+        public IPEndPoint LocalEndPoint { get; }
+
+        public static async Task<QuicTransportConnection> ConnectAsync(IPEndPoint remoteEndPoint, CancellationToken cancellationToken)
+        {
+            var options = QuicTransport.CreateClientOptions(remoteEndPoint);
+            var connection = await QuicConnection.ConnectAsync(options, cancellationToken).ConfigureAwait(false);
+            return new QuicTransportConnection(connection);
+        }
+
+        public static QuicTransportConnection FromAcceptedConnection(QuicConnection connection) => new(connection);
+
+        public void Start(IActorRef receiver)
+        {
+            if (_acceptLoop != null) return;
+
+            _cts = new CancellationTokenSource();
+            _acceptLoop = Task.Run(() => AcceptLoopAsync(receiver, _cts.Token));
+        }
+
+        public async Task SendAsync(ReadOnlyMemory<byte> data, CancellationToken cancellationToken)
+        {
+            QuicStream? stream = null;
+            try
+            {
+                stream = await _connection.OpenOutboundStreamAsync(QuicStreamType.Bidirectional, cancellationToken).ConfigureAwait(false);
+                await stream.WriteAsync(data, cancellationToken).ConfigureAwait(false);
+                stream.CompleteWrites();
+            }
+            finally
+            {
+                if (stream != null)
+                    await stream.DisposeAsync().ConfigureAwait(false);
+            }
+        }
+
+        public async Task CloseAsync(bool abort, CancellationToken cancellationToken)
+        {
+            if (cancellationToken.IsCancellationRequested)
+                abort = true;
+
+            _cts?.Cancel();
+
+            try
+            {
+                await _connection.CloseAsync(abort ? 1 : 0, cancellationToken).ConfigureAwait(false);
+            }
+            finally
+            {
+                await DisposeAsync().ConfigureAwait(false);
+            }
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            try { await _connection.DisposeAsync().ConfigureAwait(false); } catch { }
+            _cts?.Dispose();
+        }
+
+        private async Task AcceptLoopAsync(IActorRef receiver, CancellationToken cancellationToken)
+        {
+            try
+            {
+                while (!cancellationToken.IsCancellationRequested)
+                {
+                    QuicStream stream = await _connection.AcceptInboundStreamAsync(cancellationToken).ConfigureAwait(false);
+                    var seq = Interlocked.Increment(ref _nextInboundSeq) - 1;
+                    _ = Task.Run(() => ReadStreamToEndAsync(receiver, stream, seq, cancellationToken), cancellationToken);
+                }
+                NotifyClosed(receiver, abort: false);
+            }
+            catch (OperationCanceledException)
+            {
+                NotifyClosed(receiver, abort: false);
+            }
+            catch
+            {
+                NotifyClosed(receiver, abort: true);
+            }
+        }
+
+        private async Task ReadStreamToEndAsync(IActorRef receiver, QuicStream stream, long seq, CancellationToken cancellationToken)
+        {
+            var buffer = new byte[ReceiveBufferSize];
+            try
+            {
+                using var ms = new MemoryStream();
+                while (true)
+                {
+                    var read = await stream.ReadAsync(buffer.AsMemory(), cancellationToken).ConfigureAwait(false);
+                    if (read == 0) break;
+
+                    if (ms.Length + read > MaxMessageSize)
+                    {
+                        NotifyClosed(receiver, abort: true);
+                        return;
+                    }
+
+                    ms.Write(buffer, 0, read);
+                }
+
+                var data = ms.ToArray();
+                if (data.Length > 0)
+                    EnqueueOrdered(receiver, seq, data);
+            }
+            catch (OperationCanceledException)
+            {
+            }
+            catch
+            {
+                NotifyClosed(receiver, abort: true);
+            }
+            finally
+            {
+                try { await stream.DisposeAsync().ConfigureAwait(false); } catch { }
+            }
+        }
+
+        private void EnqueueOrdered(IActorRef receiver, long seq, byte[] data)
+        {
+            lock (_deliverLock)
+            {
+                _pendingBySeq[seq] = data;
+
+                while (_pendingBySeq.TryGetValue(_nextDeliverSeq, out var next))
+                {
+                    _pendingBySeq.Remove(_nextDeliverSeq);
+                    _nextDeliverSeq++;
+                    receiver.Tell(new TransportMessages.Received(ByteString.FromBytes(next)));
+                }
+            }
+        }
+
+        private void NotifyClosed(IActorRef receiver, bool abort)
+        {
+            if (Interlocked.Exchange(ref _closed, 1) != 0) return;
+            receiver.Tell(new TransportMessages.ConnectionClosed(Abort: abort));
+        }
+    }
+}

--- a/src/Neo/Network/P2P/Transports/QuicTransportListener.cs
+++ b/src/Neo/Network/P2P/Transports/QuicTransportListener.cs
@@ -1,0 +1,60 @@
+// Copyright (C) 2015-2025 The Neo Project.
+//
+// QuicTransportListener.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using System;
+using System.Net;
+using System.Net.Quic;
+using System.Runtime.Versioning;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Neo.Network.P2P.Transports
+{
+    [SupportedOSPlatform("linux")]
+    [SupportedOSPlatform("macos")]
+    [SupportedOSPlatform("windows")]
+    internal sealed class QuicTransportListener : IAsyncDisposable
+    {
+        private readonly QuicListener _listener;
+        private readonly X509Certificate2 _certificate;
+
+        private QuicTransportListener(QuicListener listener, X509Certificate2 certificate)
+        {
+            _listener = listener;
+            _certificate = certificate;
+        }
+
+        public IPEndPoint ListenEndPoint => (IPEndPoint)_listener.LocalEndPoint;
+
+        public static async Task<QuicTransportListener> ListenAsync(IPEndPoint listenEndPoint, CancellationToken cancellationToken)
+        {
+            var cert = QuicTransport.CreateSelfSignedCertificate();
+            var listener = await QuicListener.ListenAsync(
+                QuicTransport.CreateListenerOptions(listenEndPoint, cert),
+                cancellationToken).ConfigureAwait(false);
+
+            return new QuicTransportListener(listener, cert);
+        }
+
+        public async Task<QuicTransportConnection> AcceptAsync(CancellationToken cancellationToken)
+        {
+            var connection = await _listener.AcceptConnectionAsync(cancellationToken).ConfigureAwait(false);
+            return QuicTransportConnection.FromAcceptedConnection(connection);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await _listener.DisposeAsync().ConfigureAwait(false);
+            _certificate.Dispose();
+        }
+    }
+}

--- a/src/Neo/Network/P2P/Transports/TransportMessages.cs
+++ b/src/Neo/Network/P2P/Transports/TransportMessages.cs
@@ -1,0 +1,22 @@
+// Copyright (C) 2015-2025 The Neo Project.
+//
+// TransportMessages.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Akka.IO;
+
+namespace Neo.Network.P2P.Transports
+{
+    internal static class TransportMessages
+    {
+        internal sealed record Received(ByteString Data);
+
+        internal sealed record ConnectionClosed(bool Abort);
+    }
+}

--- a/tests/Neo.Extensions.Tests/Network/P2P/UT_QuicTransport.cs
+++ b/tests/Neo.Extensions.Tests/Network/P2P/UT_QuicTransport.cs
@@ -1,0 +1,369 @@
+// Copyright (C) 2015-2025 The Neo Project.
+//
+// UT_QuicTransport.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Akka.Actor;
+using Akka.IO;
+using Neo.Network.P2P;
+using Neo.Network.P2P.Capabilities;
+using System;
+using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Quic;
+using System.Net.Security;
+using System.Reflection;
+using System.Runtime.Versioning;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Neo.Extensions.Tests.Network.P2P
+{
+    [TestClass]
+    public class UT_QuicTransport
+    {
+        private sealed class ByteCollectorActor : ReceiveActor
+        {
+            private readonly int _expected;
+            private readonly TaskCompletionSource<IReadOnlyList<byte[]>> _tcs;
+            private readonly List<byte[]> _received = new();
+
+            public ByteCollectorActor(int expected, TaskCompletionSource<IReadOnlyList<byte[]>> tcs)
+            {
+                _expected = expected;
+                _tcs = tcs;
+
+                Receive<object>(msg =>
+                {
+                    var msgType = msg.GetType();
+                    if (msgType.FullName != "Neo.Network.P2P.Transports.TransportMessages+Received")
+                        return;
+
+                    var data = msgType.GetProperty("Data", BindingFlags.Instance | BindingFlags.Public)?.GetValue(msg);
+                    if (data is not ByteString bs)
+                        return;
+
+                    _received.Add(bs.ToArray());
+                    if (_received.Count == _expected)
+                        _tcs.TrySetResult(_received.ToArray());
+                });
+            }
+        }
+
+        [SupportedOSPlatform("linux")]
+        [SupportedOSPlatform("macos")]
+        [SupportedOSPlatform("windows")]
+        private static QuicClientConnectionOptions CreateInsecureTestClientOptions(IPEndPoint remoteEndPoint)
+        {
+            return new QuicClientConnectionOptions
+            {
+                RemoteEndPoint = remoteEndPoint,
+                DefaultCloseErrorCode = 0,
+                DefaultStreamErrorCode = 0,
+                MaxInboundBidirectionalStreams = 32,
+                ClientAuthenticationOptions = new SslClientAuthenticationOptions
+                {
+                    ApplicationProtocols = new List<SslApplicationProtocol> { new("neo-p2p") },
+                    TargetHost = "neo-p2p",
+                    CertificateRevocationCheckMode = X509RevocationMode.NoCheck,
+                    RemoteCertificateValidationCallback = (_, _, _, _) => true,
+                }
+            };
+        }
+
+        private static async Task<object> CreateQuicTransportListenerAsync(IPEndPoint listenEndPoint, CancellationToken cancellationToken)
+        {
+            var neoAssembly = typeof(ChannelsConfig).Assembly;
+            var listenerType = neoAssembly.GetType("Neo.Network.P2P.Transports.QuicTransportListener", throwOnError: true)!;
+            var listenAsync = listenerType.GetMethod("ListenAsync", BindingFlags.Public | BindingFlags.Static)!;
+            var taskObj = listenAsync.Invoke(null, new object[] { listenEndPoint, cancellationToken })!;
+
+            await (Task)taskObj;
+            return taskObj.GetType().GetProperty("Result", BindingFlags.Public | BindingFlags.Instance)!.GetValue(taskObj)!;
+        }
+
+        private static async Task<object> AcceptQuicTransportConnectionAsync(object listener, CancellationToken cancellationToken)
+        {
+            var acceptAsync = listener.GetType().GetMethod("AcceptAsync", BindingFlags.Public | BindingFlags.Instance)!;
+            var taskObj = acceptAsync.Invoke(listener, new object[] { cancellationToken })!;
+
+            await (Task)taskObj;
+            return taskObj.GetType().GetProperty("Result", BindingFlags.Public | BindingFlags.Instance)!.GetValue(taskObj)!;
+        }
+
+        private static IPEndPoint GetListenEndPoint(object listener)
+        {
+            return (IPEndPoint)listener.GetType().GetProperty("ListenEndPoint", BindingFlags.Public | BindingFlags.Instance)!.GetValue(listener)!;
+        }
+
+        private static void StartTransportConnection(object connection, IActorRef receiver)
+        {
+            connection.GetType().GetMethod("Start", BindingFlags.Public | BindingFlags.Instance)!.Invoke(connection, new object[] { receiver });
+        }
+
+        private static async Task<object> ConnectQuicTransportConnectionAsync(IPEndPoint remoteEndPoint, CancellationToken cancellationToken)
+        {
+            var neoAssembly = typeof(ChannelsConfig).Assembly;
+            var connectionType = neoAssembly.GetType("Neo.Network.P2P.Transports.QuicTransportConnection", throwOnError: true)!;
+            var connectAsync = connectionType.GetMethod("ConnectAsync", BindingFlags.Public | BindingFlags.Static)!;
+            var taskObj = connectAsync.Invoke(null, new object[] { remoteEndPoint, cancellationToken })!;
+
+            await (Task)taskObj;
+            return taskObj.GetType().GetProperty("Result", BindingFlags.Public | BindingFlags.Instance)!.GetValue(taskObj)!;
+        }
+
+        private static async Task SendQuicTransportAsync(object connection, ReadOnlyMemory<byte> data, CancellationToken cancellationToken)
+        {
+            var sendAsync = connection.GetType().GetMethod("SendAsync", BindingFlags.Public | BindingFlags.Instance)!;
+            var taskObj = sendAsync.Invoke(connection, new object[] { data, cancellationToken })!;
+            await (Task)taskObj;
+        }
+
+        [TestMethod]
+        public void QuicCapability_Encoding_IsStable()
+        {
+            var neoAssembly = typeof(ChannelsConfig).Assembly;
+            var capabilityType = neoAssembly.GetType("Neo.Network.P2P.Capabilities.NeoP2PExtensionsCapability", throwOnError: true)!;
+            var dataType = neoAssembly.GetType("Neo.Network.P2P.Capabilities.NeoP2PExtensionsData", throwOnError: true)!;
+            var extensionsEnum = neoAssembly.GetType("Neo.Network.P2P.Capabilities.NeoP2PExtensions", throwOnError: true)!;
+
+            object quicFlag = Enum.Parse(extensionsEnum, "Quic");
+            object data = Activator.CreateInstance(
+                dataType,
+                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+                binder: null,
+                args: new object[] { quicFlag, (ushort)12345 },
+                culture: null)!;
+            var create = capabilityType.GetMethod("Create", BindingFlags.Public | BindingFlags.Static)!;
+
+            var unknown = (UnknownCapability)create.Invoke(null, new[] { data })!;
+
+            Assert.AreEqual(NodeCapabilityType.Extension0, unknown.Type);
+            Assert.AreEqual(8, unknown.Data.Length);
+
+            Assert.AreEqual((byte)'N', unknown.Data.Span[0]);
+            Assert.AreEqual((byte)'E', unknown.Data.Span[1]);
+            Assert.AreEqual((byte)'O', unknown.Data.Span[2]);
+            Assert.AreEqual((byte)'Q', unknown.Data.Span[3]);
+            Assert.AreEqual(1, unknown.Data.Span[4]); // capability version
+            Assert.AreEqual(1, unknown.Data.Span[5]); // quic flag
+            Assert.AreEqual((ushort)12345, BinaryPrimitives.ReadUInt16LittleEndian(unknown.Data.Span[6..8]));
+        }
+
+        [TestMethod]
+        public void QuicCapability_TryParse_ReturnsExpectedData()
+        {
+            var neoAssembly = typeof(ChannelsConfig).Assembly;
+            var capabilityType = neoAssembly.GetType("Neo.Network.P2P.Capabilities.NeoP2PExtensionsCapability", throwOnError: true)!;
+            var dataType = neoAssembly.GetType("Neo.Network.P2P.Capabilities.NeoP2PExtensionsData", throwOnError: true)!;
+            var extensionsEnum = neoAssembly.GetType("Neo.Network.P2P.Capabilities.NeoP2PExtensions", throwOnError: true)!;
+
+            object quicFlag = Enum.Parse(extensionsEnum, "Quic");
+            object data = Activator.CreateInstance(
+                dataType,
+                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+                binder: null,
+                args: new object[] { quicFlag, (ushort)23456 },
+                culture: null)!;
+
+            var create = capabilityType.GetMethod("Create", BindingFlags.Public | BindingFlags.Static)!;
+            var unknown = (UnknownCapability)create.Invoke(null, new[] { data })!;
+
+            var tryParse = capabilityType.GetMethod("TryParse", BindingFlags.Public | BindingFlags.Static, binder: null, types: new[] { typeof(NodeCapability[]), dataType.MakeByRefType() }, modifiers: null)!;
+            object? parsed = null;
+            var args = new object?[] { new NodeCapability[] { unknown }, parsed };
+
+            var ok = (bool)tryParse.Invoke(null, args)!;
+            Assert.IsTrue(ok);
+
+            var parsedData = args[1]!;
+            var parsedExtensions = parsedData.GetType().GetProperty("Extensions", BindingFlags.Public | BindingFlags.Instance)!.GetValue(parsedData)!;
+            var parsedPort = (ushort)parsedData.GetType().GetProperty("QuicPort", BindingFlags.Public | BindingFlags.Instance)!.GetValue(parsedData)!;
+
+            Assert.AreEqual(quicFlag, parsedExtensions);
+            Assert.AreEqual((ushort)23456, parsedPort);
+        }
+
+        [TestMethod]
+        public void QuicTransport_CreateSelfSignedCertificate_HasPrivateKeyAndEku()
+        {
+            var neoAssembly = typeof(ChannelsConfig).Assembly;
+            var transportType = neoAssembly.GetType("Neo.Network.P2P.Transports.QuicTransport", throwOnError: true)!;
+            var create = transportType.GetMethod("CreateSelfSignedCertificate", BindingFlags.Public | BindingFlags.Static)!;
+
+            using var cert = (X509Certificate2)create.Invoke(null, Array.Empty<object>())!;
+            Assert.IsTrue(cert.HasPrivateKey);
+            Assert.IsTrue(cert.Subject.Contains("CN=neo-p2p", StringComparison.OrdinalIgnoreCase));
+
+            bool hasServerAuthEku = false;
+            foreach (var ext in cert.Extensions)
+            {
+                if (ext is not X509EnhancedKeyUsageExtension eku)
+                    continue;
+
+                foreach (var oid in eku.EnhancedKeyUsages)
+                {
+                    if (oid.Value == "1.3.6.1.5.5.7.3.1")
+                        hasServerAuthEku = true;
+                }
+            }
+
+            Assert.IsTrue(hasServerAuthEku);
+        }
+
+        [TestMethod]
+        [SupportedOSPlatform("linux")]
+        [SupportedOSPlatform("macos")]
+        [SupportedOSPlatform("windows")]
+        public async Task QuicTransport_ReceivesStreamsInAcceptOrder()
+        {
+            if (!QuicListener.IsSupported)
+                return;
+
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+            using var system = ActorSystem.Create("quic-order-tests");
+            try
+            {
+                await using var listener = (IAsyncDisposable)await CreateQuicTransportListenerAsync(
+                    new IPEndPoint(IPAddress.Loopback, 0),
+                    cts.Token);
+                var listenEndPoint = GetListenEndPoint(listener);
+
+                var acceptTask = AcceptQuicTransportConnectionAsync(listener, cts.Token);
+                await using var client = await QuicConnection.ConnectAsync(CreateInsecureTestClientOptions(listenEndPoint), cts.Token);
+                await using var serverConnection = (IAsyncDisposable)await acceptTask;
+
+                var receivedTcs = new TaskCompletionSource<IReadOnlyList<byte[]>>(TaskCreationOptions.RunContinuationsAsynchronously);
+                var receiver = system.ActorOf(Props.Create(() => new ByteCollectorActor(2, receivedTcs)));
+                StartTransportConnection(serverConnection, receiver);
+
+                await using var s1 = await client.OpenOutboundStreamAsync(QuicStreamType.Bidirectional, cts.Token);
+                await using var s2 = await client.OpenOutboundStreamAsync(QuicStreamType.Bidirectional, cts.Token);
+
+                var msg1 = new byte[] { 1, 1, 1 };
+                var msg2 = new byte[] { 2, 2, 2 };
+
+                await s2.WriteAsync(msg2, cts.Token);
+                s2.CompleteWrites();
+
+                await Task.Delay(100, cts.Token);
+
+                await s1.WriteAsync(msg1, cts.Token);
+                s1.CompleteWrites();
+
+                var received = await receivedTcs.Task.WaitAsync(TimeSpan.FromSeconds(3), cts.Token);
+                Assert.AreEqual(2, received.Count);
+                CollectionAssert.AreEqual(msg1, received[0]);
+                CollectionAssert.AreEqual(msg2, received[1]);
+            }
+            finally
+            {
+                await system.Terminate();
+            }
+        }
+
+        [TestMethod]
+        [SupportedOSPlatform("linux")]
+        [SupportedOSPlatform("macos")]
+        [SupportedOSPlatform("windows")]
+        public async Task QuicTransportConnection_SendAsync_Roundtrip()
+        {
+            if (!QuicListener.IsSupported)
+                return;
+
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            using var system = ActorSystem.Create("quic-send-tests");
+
+            try
+            {
+                await using var listener = (IAsyncDisposable)await CreateQuicTransportListenerAsync(
+                    new IPEndPoint(IPAddress.Loopback, 0),
+                    cts.Token);
+                var listenEndPoint = GetListenEndPoint(listener);
+
+                var acceptTask = AcceptQuicTransportConnectionAsync(listener, cts.Token);
+                await using var clientConnection = (IAsyncDisposable)await ConnectQuicTransportConnectionAsync(listenEndPoint, cts.Token);
+                await using var serverConnection = (IAsyncDisposable)await acceptTask;
+
+                var receivedTcs = new TaskCompletionSource<IReadOnlyList<byte[]>>(TaskCreationOptions.RunContinuationsAsynchronously);
+                var receiver = system.ActorOf(Props.Create(() => new ByteCollectorActor(3, receivedTcs)));
+                StartTransportConnection(serverConnection, receiver);
+
+                var msg1 = new byte[] { 10, 11, 12 };
+                var msg2 = new byte[] { 20, 21, 22 };
+                var msg3 = new byte[] { 30, 31, 32 };
+
+                await SendQuicTransportAsync(clientConnection, msg1, cts.Token);
+                await SendQuicTransportAsync(clientConnection, msg2, cts.Token);
+                await SendQuicTransportAsync(clientConnection, msg3, cts.Token);
+
+                var received = await receivedTcs.Task.WaitAsync(TimeSpan.FromSeconds(3), cts.Token);
+                Assert.AreEqual(3, received.Count);
+                CollectionAssert.AreEqual(msg1, received[0]);
+                CollectionAssert.AreEqual(msg2, received[1]);
+                CollectionAssert.AreEqual(msg3, received[2]);
+            }
+            finally
+            {
+                await system.Terminate();
+            }
+        }
+
+        [TestMethod]
+        [SupportedOSPlatform("linux")]
+        [SupportedOSPlatform("macos")]
+        [SupportedOSPlatform("windows")]
+        public async Task QuicTransport_MultiplexesMultipleMessages()
+        {
+            if (!QuicListener.IsSupported)
+                return;
+
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+            using var system = ActorSystem.Create("quic-mux-tests");
+            try
+            {
+                await using var listener = (IAsyncDisposable)await CreateQuicTransportListenerAsync(
+                    new IPEndPoint(IPAddress.Loopback, 0),
+                    cts.Token);
+                var listenEndPoint = GetListenEndPoint(listener);
+
+                var acceptTask = AcceptQuicTransportConnectionAsync(listener, cts.Token);
+                await using var client = await QuicConnection.ConnectAsync(CreateInsecureTestClientOptions(listenEndPoint), cts.Token);
+                await using var serverConnection = (IAsyncDisposable)await acceptTask;
+
+                var receivedTcs = new TaskCompletionSource<IReadOnlyList<byte[]>>(TaskCreationOptions.RunContinuationsAsynchronously);
+                var receiver = system.ActorOf(Props.Create(() => new ByteCollectorActor(5, receivedTcs)));
+                StartTransportConnection(serverConnection, receiver);
+
+                var expected = new List<byte[]>();
+                for (int i = 0; i < 5; i++)
+                {
+                    var payload = new byte[] { (byte)i, (byte)(i + 1), (byte)(i + 2) };
+                    expected.Add(payload);
+                    await using var stream = await client.OpenOutboundStreamAsync(QuicStreamType.Bidirectional, cts.Token);
+                    await stream.WriteAsync(payload, cts.Token);
+                    stream.CompleteWrites();
+                }
+
+                var received = await receivedTcs.Task.WaitAsync(TimeSpan.FromSeconds(3), cts.Token);
+                Assert.AreEqual(5, received.Count);
+                for (int i = 0; i < 5; i++)
+                    CollectionAssert.AreEqual(expected[i], received[i]);
+            }
+            finally
+            {
+                await system.Terminate();
+            }
+        }
+    }
+}

--- a/tests/Neo.UnitTests/Network/P2P/UT_ChannelsConfig.cs
+++ b/tests/Neo.UnitTests/Network/P2P/UT_ChannelsConfig.cs
@@ -24,11 +24,15 @@ namespace Neo.UnitTests.Network.P2P
             var config = new ChannelsConfig();
 
             Assert.IsNull(config.Tcp);
+            Assert.IsNull(config.Quic);
+            Assert.IsFalse(config.PreferQuic);
             Assert.AreEqual(10, config.MinDesiredConnections);
             Assert.AreEqual(40, config.MaxConnections);
             Assert.AreEqual(3, config.MaxConnectionsPerAddress);
 
             config.Tcp = new IPEndPoint(IPAddress.Any, 21);
+            config.Quic = new IPEndPoint(IPAddress.Any, 42);
+            config.PreferQuic = true;
             config.MaxConnectionsPerAddress++;
             config.MaxConnections++;
             config.MinDesiredConnections++;
@@ -36,6 +40,10 @@ namespace Neo.UnitTests.Network.P2P
             Assert.AreSame(config.Tcp, config.Tcp);
             CollectionAssert.AreEqual(IPAddress.Any.GetAddressBytes(), config.Tcp.Address.GetAddressBytes());
             Assert.AreEqual(21, config.Tcp.Port);
+            Assert.AreSame(config.Quic, config.Quic);
+            CollectionAssert.AreEqual(IPAddress.Any.GetAddressBytes(), config.Quic.Address.GetAddressBytes());
+            Assert.AreEqual(42, config.Quic.Port);
+            Assert.IsTrue(config.PreferQuic);
             Assert.AreEqual(11, config.MinDesiredConnections);
             Assert.AreEqual(41, config.MaxConnections);
             Assert.AreEqual(4, config.MaxConnectionsPerAddress);


### PR DESCRIPTION
# Description

This PR adds a QUIC transport path for Neo N3 P2P with TCP fallback and stream-based multiplexing, while keeping the existing Neo message format unchanged. New nodes advertise QUIC support/port via an extension capability that older nodes ignore, so compatibility with existing TCP-only nodes is preserved.

# Change Log

- Add File `src/Neo/Network/P2P/Transports/QuicTransport.cs`
- Add File `src/Neo/Network/P2P/Transports/QuicTransportListener.cs`
- Add File `src/Neo/Network/P2P/Transports/QuicTransportConnection.cs`
- Add File `src/Neo/Network/P2P/Transports/ITransportConnection.cs`
- Add File `src/Neo/Network/P2P/Transports/TransportMessages.cs`
- Add File `src/Neo/Network/P2P/Capabilities/NeoP2PExtensionsCapability.cs`
- Add Class `Benchmarks_P2PTransport` (QUIC vs TCP, local-only)
- Add Tests `UT_QuicTransport`
- Update QUIC certificate handling for Windows (MsQuic/Schannel)

Fixes #N/A

## Type of change

- [ ] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Unit Testing
- [ ] Run Application
- [x] Local Computer Tests
- [ ] No Testing

Commands:
- `dotnet test -p:GITHUB_ACTIONS=true`
- Bench (local-only): `dotnet run -c Release -p:NuGetAudit=false --project benchmarks/Neo.Benchmarks/Neo.Benchmarks.csproj --framework net10.0 -- -f "*P2PTransport*"`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
