### PR TITLE
Load plugins from the current AssemblyLoadContext

### DIFF
--- a/src/Neo/Plugins/Plugin.cs
+++ b/src/Neo/Plugins/Plugin.cs
@@ -213,7 +213,7 @@ public abstract class Plugin : IDisposable
     {
         if (!Directory.Exists(PluginsDirectory)) return;
         List<Assembly> assemblies = AssemblyLoadContext.Default.Assemblies
-            .Where(p => p.FullName?.StartsWith("Neo") == true)
+            .Where(p => p.FullName?.StartsWith("Neo", StringComparison.InvariantCultureIgnoreCase) == true)
             .ToList();
         foreach (var rootPath in Directory.GetDirectories(PluginsDirectory))
         {


### PR DESCRIPTION
# Description

Load plugins from the current AppDomain. This is useful for plugins that are referenced via NuGet.

# Change Log

- Update File 'Plugin.cs'

# Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [ ] Unit Testing
- [ ] Run Application
- [ ] Local Computer Tests
- [x] No Testing


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
