### PR TITLE
Native: mark execFeeFactor entry as Changed on Faun Policy update

### DIFF
--- a/src/Neo/SmartContract/Native/PolicyContract.cs
+++ b/src/Neo/SmartContract/Native/PolicyContract.cs
@@ -154,7 +154,7 @@ namespace Neo.SmartContract.Native
             if (hardfork == Hardfork.HF_Faun)
             {
                 // Add decimals to exec fee factor
-                var item = engine.SnapshotCache.TryGet(_execFeeFactor) ??
+                var item = engine.SnapshotCache.GetAndChange(_execFeeFactor) ??
                     throw new InvalidOperationException("Policy was not initialized");
                 item.Set((uint)(BigInteger)item * ApplicationEngine.FeeFactor);
             }


### PR DESCRIPTION
# Description

Close #4435.

`TryGet` doesn't mark the entry as Changed which leads to the fact that item changes are ignored during cache persist:
https://github.com/neo-project/neo/blob/309353a66b521a9640e6ec7a600f4a2d647eb84a/src/Neo/SmartContract/Native/PolicyContract.cs#L157

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Unit Testing
- [ ] Run Application
- [ ] Local Computer Tests
- [X] No Testing (needs manual check)


# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
