### PR TITLE
Fix workflow and add manual release mode

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches: [master-n3]
   pull_request:
+  release:
+    types: [created]
 
 env:
   DOTNET_VERSION: 10.0.x
@@ -90,9 +92,12 @@ jobs:
         MYGET_TOKEN: ${{ secrets.MYGET_TOKEN }}
         
   Release:
-    if: github.ref == 'refs/heads/master-n3' && startsWith(github.repository, 'neo-project/')
-    needs: Test
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master-n3' && startsWith(github.repository, 'neo-project/')
+    needs: [Test]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
     steps:
     - name: Checkout
       uses: actions/checkout@v5
@@ -100,21 +105,23 @@ jobs:
       id: get_version
       run: |
         sudo apt install xmlstarlet
-        find src -name Directory.Build.props | xargs xmlstarlet sel -N i=http://schemas.microsoft.com/developer/msbuild/2003 -t -v "concat('version=v',//i:Version/text())" | xargs echo >> $GITHUB_OUTPUT
+        find src -name Directory.Build.props | xargs xmlstarlet sel -N i=http://schemas.microsoft.com/developer/msbuild/2003 -t -v "concat('version=v',//i:VersionPrefix/text())" | xargs echo >> $GITHUB_OUTPUT
     - name: Check tag
       if: steps.get_version.outputs.version != 'v' && startsWith(steps.get_version.outputs.version, 'v')
       id: check_tag
-      run: curl -s -I ${{ format('https://github.com/{0}/releases/tag/{1}', github.repository, steps.get_version.outputs.version) }} | head -n 1 | cut -d$' ' -f2 | xargs printf "statusCode=%s" | xargs echo >> $GITHUB_OUTPUT
+      run: |
+        STATUS=$(curl -s -I ${{ format('https://github.com/{0}/releases/tag/{1}', github.repository, steps.get_version.outputs.version) }} | head -n 1 | cut -d' ' -f2)
+        echo "statusCode=$STATUS" >> $GITHUB_OUTPUT
     - name: Create release
       if: steps.check_tag.outputs.statusCode == '404'
       id: create_release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      uses: softprops/action-gh-release@v1
       with:
         tag_name: ${{ steps.get_version.outputs.version }}
-        release_name: ${{ steps.get_version.outputs.version }}
+        name: ${{ steps.get_version.outputs.version }}
         prerelease: ${{ contains(steps.get_version.outputs.version, '-') }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Setup .NET Core
       if: steps.check_tag.outputs.statusCode == '404'
       uses: actions/setup-dotnet@v5
@@ -124,6 +131,60 @@ jobs:
       if: steps.check_tag.outputs.statusCode == '404'
       run: |
         dotnet pack -o out -c Release
-        dotnet nuget push out/*.nupkg -s https://api.nuget.org/v3/index.json -k ${NUGET_TOKEN}
+        dotnet nuget push out/*.nupkg -s https://api.nuget.org/v3/index.json -k ${NUGET_TOKEN} --skip-duplicate
+      env:
+        NUGET_TOKEN: ${{ secrets.NUGET_TOKEN }}
+
+  ReleaseFromManual:
+    if: github.event_name == 'release' && github.event.action == 'created' && startsWith(github.repository, 'neo-project/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v5
+      with:
+        ref: ${{ github.event.release.tag_name }}
+    - name: Extract version from tag
+      id: get_version
+      run: |
+        TAG_NAME="${{ github.event.release.tag_name }}"
+        # Remove 'v' prefix if present (e.g., v3.9.1 -> 3.9.1)
+        VERSION=${TAG_NAME#v}
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
+        echo "Extracted version: $VERSION from tag: $TAG_NAME"
+    - name: Get VersionPrefix from Directory.Build.props
+      id: get_versionprefix
+      run: |
+        sudo apt install xmlstarlet
+        VERSION_PREFIX=$(find src -name Directory.Build.props | xargs xmlstarlet sel -N i=http://schemas.microsoft.com/developer/msbuild/2003 -t -v "//i:VersionPrefix/text()")
+        echo "versionPrefix=$VERSION_PREFIX" >> $GITHUB_OUTPUT
+        echo "VersionPrefix from Directory.Build.props: $VERSION_PREFIX"
+    - name: Validate version consistency
+      run: |
+        TAG_VERSION="${{ steps.get_version.outputs.version }}"
+        VERSION_PREFIX="${{ steps.get_versionprefix.outputs.versionPrefix }}"
+        
+        echo "Tag version (without 'v'): $TAG_VERSION"
+        echo "VersionPrefix: $VERSION_PREFIX"
+        
+        if [ "$TAG_VERSION" != "$VERSION_PREFIX" ]; then
+          echo "::error::Version mismatch detected!"
+          echo "::error::Release tag version ($TAG_VERSION) does not match VersionPrefix ($VERSION_PREFIX) in Directory.Build.props"
+          echo "::error::Please ensure the release tag matches the VersionPrefix before creating a release."
+          echo "::error::Expected tag: v$VERSION_PREFIX, but got: ${{ github.event.release.tag_name }}"
+          exit 1
+        fi
+        
+        echo "✅ Version consistency check passed: tag version ($TAG_VERSION) matches VersionPrefix ($VERSION_PREFIX)"
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v5
+      with:
+        dotnet-version: ${{ env.DOTNET_VERSION }}
+    - name: Publish to NuGet
+      run: |
+        dotnet pack -o out -c Release -p:Version=${{ steps.get_version.outputs.version }}
+        dotnet nuget push out/*.nupkg -s https://api.nuget.org/v3/index.json -k ${NUGET_TOKEN} --skip-duplicate
       env:
         NUGET_TOKEN: ${{ secrets.NUGET_TOKEN }}


### PR DESCRIPTION
# Description

I notice now Neo is using `Directory.Build.props` to control version. However it's using `VersionPerfix` but workflow is checking `Version` when trigger for new version release. That's why when we merge `VersionPerfix = 3.9.0`, there's no release on Neo. But now since it's already `3.9.0`, we also need a manual mode for current release.

So in summary:
1. Fixed version extraction: Changed XML query from //i:Version/text() to //i:VersionPrefix/text() to correctly read the version from Directory.Build.props.
2. Updated release action: Replaced deprecated actions/create-release@v1 with softprops/action-gh-release@v1 for better maintenance and compatibility.
3. Added permissions: Added explicit permissions: contents: write, packages: write to Release job to ensure proper access rights.
4. Added duplicate handling: Added --skip-duplicate flag to dotnet nuget push command to gracefully handle duplicate package versions.
5. Added version extraction from tag: Manual release workflow now extracts version from release tag name and uses it for NuGet package version via -p:Version parameter.
6. Added version validation: Manual release workflow now validates that tag version (without 'v' prefix) matches VersionPrefix before publishing, failing with clear error messages if mismatch is detected.


## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Unit Testing
- [x] Run Application
- [ ] Local Computer Tests
- [ ] No Testing


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
