### PR TITLE
fix: the CallFlags for ContractManagement.Deploy and ContractManagement.Update.

### DIFF
--- a/src/Neo/SmartContract/Native/ContractManagement.cs
+++ b/src/Neo/SmartContract/Native/ContractManagement.cs
@@ -235,7 +235,7 @@ public sealed class ContractManagement : NativeContract
     /// <param name="nefFile">The NEF file of the contract.</param>
     /// <param name="manifest">The manifest of the contract.</param>
     /// <returns>The deployed contract.</returns>
-    [ContractMethod(RequiredCallFlags = CallFlags.States | CallFlags.AllowNotify)]
+    [ContractMethod(RequiredCallFlags = CallFlags.All)]
     private ContractTask<ContractState> Deploy(ApplicationEngine engine, byte[] nefFile, byte[] manifest)
     {
         return Deploy(engine, nefFile, manifest, StackItem.Null);
@@ -301,7 +301,7 @@ public sealed class ContractManagement : NativeContract
     /// <param name="nefFile">The NEF file of the contract.</param>
     /// <param name="manifest">The manifest of the contract.</param>
     /// <returns>The updated contract.</returns>
-    [ContractMethod(RequiredCallFlags = CallFlags.States | CallFlags.AllowNotify)]
+    [ContractMethod(RequiredCallFlags = CallFlags.All)]
     private ContractTask Update(ApplicationEngine engine, byte[]? nefFile, byte[]? manifest)
     {
         return Update(engine, nefFile, manifest, StackItem.Null);


### PR DESCRIPTION

The #4326 only changes the CallFlags of 
`ContractTask<ContractState> Deploy(ApplicationEngine engine, byte[] nefFile, byte[] manifest, StackItem data)` 
and 
`ContractTask Update(ApplicationEngine engine, byte[]? nefFile, byte[]? manifest, StackItem data)`.

But not including 
`ContractTask<ContractState> Deploy(ApplicationEngine engine, byte[] nefFile, byte[] manifest)`
and 
`ContractTask Update(ApplicationEngine engine, byte[]? nefFile, byte[]? manifest)`.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
