### PR TITLE
ci: cleanup MyGet CI history for 3.x and 4.x

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -123,16 +123,19 @@ jobs:
             continue
           fi
 
-          keep_v3=$(echo "$versions_json" | jq -r '[.versions[]? | select(test("^3\\..*-CI[0-9]+$"))] | last // empty')
-          keep_v4=$(echo "$versions_json" | jq -r '[.versions[]? | select(test("^4\\..*-CI[0-9]+$"))] | last // empty')
+          keep_v3=$(
+            {
+              echo "$versions_json" | jq -r '.versions[]? | select(test("^3\\..*-CI[0-9]+$"))'
+              [[ "$current_version" =~ ^3\..*-CI[0-9]+$ ]] && echo "$current_version"
+            } | awk 'NF' | sort -V | tail -n 1
+          )
 
-          if [[ "$current_version" =~ ^3\..*-CI[0-9]+$ ]]; then
-            keep_v3="$current_version"
-          fi
-
-          if [[ "$current_version" =~ ^4\..*-CI[0-9]+$ ]]; then
-            keep_v4="$current_version"
-          fi
+          keep_v4=$(
+            {
+              echo "$versions_json" | jq -r '.versions[]? | select(test("^4\\..*-CI[0-9]+$"))'
+              [[ "$current_version" =~ ^4\..*-CI[0-9]+$ ]] && echo "$current_version"
+            } | awk 'NF' | sort -V | tail -n 1
+          )
 
           declare -A keep_ci_versions=()
           [[ -n "$keep_v3" ]] && keep_ci_versions["$keep_v3"]=1


### PR DESCRIPTION
## Summary
- add MyGet cleanup step before publish in `PublishMyGet`
- keep latest CI package for both `3.x` and `4.x` tracks per package
- delete older CI history to avoid MyGet pending upload size (413) failures

## Test Plan
- parsed workflow YAML successfully with `python3` + `yaml.safe_load`
- reviewed workflow diff for `PublishMyGet` job logic
