### PR TITLE
Native: fix sanity check for Notary's MaxNVBDelta setter

### DIFF
--- a/src/Neo/SmartContract/Native/Notary.cs
+++ b/src/Neo/SmartContract/Native/Notary.cs
@@ -253,10 +253,10 @@ public sealed class Notary : NativeContract
     private void SetMaxNotValidBeforeDelta(ApplicationEngine engine, uint value)
     {
         var maxVUBIncrement = engine.ProtocolSettings.MaxValidUntilBlockIncrement;
-        if (value > maxVUBIncrement / 2 || value < ProtocolSettings.Default.ValidatorsCount)
+        if (value > maxVUBIncrement / 2 || value < engine.ProtocolSettings.ValidatorsCount)
         {
             throw new FormatException(string.Format("MaxNotValidBeforeDelta cannot be more than {0} or less than {1}",
-               maxVUBIncrement / 2, ProtocolSettings.Default.ValidatorsCount));
+               maxVUBIncrement / 2, engine.ProtocolSettings.ValidatorsCount));
         }
         AssertCommittee(engine);
 


### PR DESCRIPTION
# Description

A port of #4495. Ref. #4494.

# Change Log

- Fix native Notary's setMaxNotValidBeforeDelta verification.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [ ] Unit Testing
- [ ] Run Application
- [ ] Local Computer Tests
- [X] No Testing

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
