### PR TITLE
The `IReadOnlyStore.FindRange` should have the same TKey/TValue with the `Find`

### DIFF
--- a/src/Neo/Persistence/DataCache.cs
+++ b/src/Neo/Persistence/DataCache.cs
@@ -246,6 +246,12 @@ public abstract class DataCache : IReadOnlyStore
         return Find(key, direction);
     }
 
+    /// <inheritdoc/>
+    public IEnumerable<(StorageKey Key, StorageItem Value)> FindRange(StorageKey start, StorageKey end, SeekDirection direction = SeekDirection.Forward)
+    {
+        return FindRange(start.ToArray(), end.ToArray(), direction);
+    }
+
     /// <summary>
     /// Finds the entries starting with the specified prefix.
     /// </summary>

--- a/src/Neo/Persistence/IReadOnlyStore.cs
+++ b/src/Neo/Persistence/IReadOnlyStore.cs
@@ -75,12 +75,12 @@ public interface IReadOnlyStore<TKey, TValue> where TKey : class?
     /// Returns an enumerable collection of key/value pairs within the specified key range, ordered according to the
     /// specified seek direction.
     /// </summary>
-    /// <param name="start">The inclusive lower bound of the key range to search, represented as a byte array. Cannot be null.</param>
-    /// <param name="end">The exclusive upper bound of the key range to search, represented as a byte array. Cannot be null.</param>
+    /// <param name="start">The inclusive lower bound of the key range to search. Cannot be null.</param>
+    /// <param name="end">The exclusive upper bound of the key range to search. Cannot be null.</param>
     /// <param name="direction">The direction in which to enumerate the results. Use SeekDirection.Forward to enumerate in ascending key order,
     /// or SeekDirection.Backward for descending order. The default is SeekDirection.Forward.</param>
     /// <returns>An enumerable collection of key/value pairs whose keys are greater than or equal to <paramref name="start"/> and
     /// less than <paramref name="end"/>, ordered according to <paramref name="direction"/>. The collection is empty if
     /// no keys are found in the specified range.</returns>
-    public IEnumerable<(TKey Key, TValue Value)> FindRange(byte[] start, byte[] end, SeekDirection direction = SeekDirection.Forward);
+    public IEnumerable<(TKey Key, TValue Value)> FindRange(TKey start, TKey end, SeekDirection direction = SeekDirection.Forward);
 }

--- a/src/Neo/SmartContract/Native/Governance.cs
+++ b/src/Neo/SmartContract/Native/Governance.cs
@@ -531,8 +531,8 @@ public sealed class Governance : NativeContract
 
     IEnumerable<(uint Index, BigInteger GasPerBlock)> GetSortedGasRecords(IReadOnlyStore snapshot, uint end)
     {
-        var key = CreateStorageKey(Prefix_GasPerBlock, end).ToArray();
-        var boundary = CreateStorageKey(Prefix_GasPerBlock).ToArray();
+        var key = CreateStorageKey(Prefix_GasPerBlock, end);
+        var boundary = CreateStorageKey(Prefix_GasPerBlock);
         return snapshot.FindRange(key, boundary, SeekDirection.Backward)
             .Select(u => (BinaryPrimitives.ReadUInt32BigEndian(u.Key.Key.Span[^sizeof(uint)..]), (BigInteger)u.Value));
     }

--- a/src/Neo/SmartContract/Native/RoleManagement.cs
+++ b/src/Neo/SmartContract/Native/RoleManagement.cs
@@ -46,8 +46,8 @@ public sealed class RoleManagement : NativeContract
         var currentIndex = Ledger.CurrentIndex(snapshot);
         if (currentIndex + 1 < index)
             throw new ArgumentOutOfRangeException(nameof(index), $"Index {index} exceeds current index + 1 ({currentIndex + 1})");
-        var key = CreateStorageKey((byte)role, index).ToArray();
-        var boundary = CreateStorageKey((byte)role).ToArray();
+        var key = CreateStorageKey((byte)role, index);
+        var boundary = CreateStorageKey((byte)role);
         return snapshot.FindRange(key, boundary, SeekDirection.Backward)
             .Select(u => u.Value.GetInteroperable<NodeList>().ToArray())
             .FirstOrDefault() ?? [];


### PR DESCRIPTION



The `IReadOnlyStore.FindRange` should have the same TKey/TValue with the `Find`

The start key of `Find` is TKey, but start key of `FindRange` is byte[]:

https://github.com/neo-project/neo/blob/0f8f05f08391ebca8ac566b3781a3e74976fd1d5/src/Neo/Persistence/IReadOnlyStore.cs#L72-L85

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Optimization (the change is only an optimization)
- [x] Style (the change is only a code style for better maintenance or standard purpose)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update



# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
