### PR TITLE
Fix: the bits argument of Mnemonic.Create must be multiple of 32

### DIFF
--- a/src/Neo/Wallets/Mnemonic.cs
+++ b/src/Neo/Wallets/Mnemonic.cs
@@ -149,7 +149,7 @@ namespace Neo.Wallets
         {
             if (bits < 128 || bits > 256)
                 throw new ArgumentException("The length of entropy should be between 128 and 256 bits.", nameof(bits));
-            if (bits % 4 != 0)
+            if (bits % 32 != 0)
                 throw new ArgumentException("The length of entropy should be a multiple of 32 bits.", nameof(bits));
             byte[] entropy = RandomNumberGenerator.GetBytes(bits / 8);
             return Create(entropy);

--- a/tests/Neo.UnitTests/Wallets/UT_Mnemonic.cs
+++ b/tests/Neo.UnitTests/Wallets/UT_Mnemonic.cs
@@ -34,6 +34,20 @@ namespace Neo.UnitTests.Wallets
         }
 
         [TestMethod]
+        public void CreateWithBits()
+        {
+            Assert.ThrowsExactly<ArgumentException>(() => Mnemonic.Create(127));
+            Assert.ThrowsExactly<ArgumentException>(() => Mnemonic.Create(257));
+            Assert.ThrowsExactly<ArgumentException>(() => Mnemonic.Create(132));
+
+            Mnemonic mnemonic = Mnemonic.Create(128);
+            Assert.AreEqual(12, mnemonic.Count);
+
+            mnemonic = Mnemonic.Create(256);
+            Assert.AreEqual(24, mnemonic.Count);
+        }
+
+        [TestMethod]
         public void InvariantCulture_EqualsEnglish()
         {
             byte[] entropy = new byte[16];


### PR DESCRIPTION
# Description

A simple fix:
The bits argument of Mnemonic.Create must be multiple of 32

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Unit Testing
- [ ] Run Application
- [ ] Local Computer Tests
- [ ] No Testing


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
