### PR TITLE
Port Fix: the bits argument of Mnemonic.Create must be multiple of 32

### DIFF
--- a/src/Neo/Wallets/Mnemonic.cs
+++ b/src/Neo/Wallets/Mnemonic.cs
@@ -146,7 +146,7 @@ public class Mnemonic : IReadOnlyList<string>
     {
         if (bits < 128 || bits > 256)
             throw new ArgumentException("The length of entropy should be between 128 and 256 bits.", nameof(bits));
-        if (bits % 4 != 0)
+        if (bits % 32 != 0)
             throw new ArgumentException("The length of entropy should be a multiple of 32 bits.", nameof(bits));
         byte[] entropy = RandomNumberGenerator.GetBytes(bits / 8);
         return Create(entropy);


### PR DESCRIPTION
Port of Fix: the bits argument of Mnemonic.Create must be multiple of 32

Credits to: @red4sec, issue N39-02 closed