### PR TITLE
Allow larger MaxValidUntilBlockIncrement for high priority transactions

### DIFF
--- a/src/Neo/Network/P2P/Payloads/Transaction.cs
+++ b/src/Neo/Network/P2P/Payloads/Transaction.cs
@@ -321,7 +321,10 @@ public class Transaction : IEquatable<Transaction>, IInventory, IInteroperable
     public virtual VerifyResult VerifyStateDependent(ProtocolSettings settings, DataCache snapshot, TransactionVerificationContext context, IEnumerable<Transaction> conflictsList)
     {
         uint height = NativeContract.Ledger.CurrentIndex(snapshot);
-        if (ValidUntilBlock <= height || ValidUntilBlock > height + settings.MaxValidUntilBlockIncrement)
+        uint maxValidUntilBlockIncrement = GetAttribute<HighPriorityAttribute>() is null
+            ? settings.MaxValidUntilBlockIncrement
+            : settings.MaxValidUntilBlockIncrementForHighPriority;
+        if (ValidUntilBlock <= height || ValidUntilBlock > height + maxValidUntilBlockIncrement)
             return VerifyResult.Expired;
         UInt160[] hashes = GetScriptHashesForVerifying(snapshot);
         foreach (UInt160 hash in hashes)

--- a/src/Neo/ProtocolSettings.cs
+++ b/src/Neo/ProtocolSettings.cs
@@ -67,6 +67,11 @@ public record ProtocolSettings
     public uint MaxValidUntilBlockIncrement { get; init; }
 
     /// <summary>
+    /// The maximum increment of the <see cref="Transaction.ValidUntilBlock"/> field for high priority transactions.
+    /// </summary>
+    public uint MaxValidUntilBlockIncrementForHighPriority { get; init; }
+
+    /// <summary>
     /// Indicates the maximum number of transactions that can be contained in a block.
     /// </summary>
     public uint MaxTransactionsPerBlock { get; init; }
@@ -109,7 +114,8 @@ public record ProtocolSettings
         SeedList = Array.Empty<string>(),
         MillisecondsPerBlock = 15000,
         MaxTransactionsPerBlock = 512,
-        MaxValidUntilBlockIncrement = 86400000 / 15000,
+        MaxValidUntilBlockIncrement = 86400000 / 15000,                     // 1 day
+        MaxValidUntilBlockIncrementForHighPriority = 2592000000 / 15000,    // 30 days
         MemoryPoolMaxTransactions = 50_000,
         MaxTraceableBlocks = 2_102_400,
         InitialGasDistribution = 52_000_000_00000000,
@@ -206,6 +212,7 @@ public record ProtocolSettings
             MemoryPoolMaxTransactions = section.GetValue("MemoryPoolMaxTransactions", Default.MemoryPoolMaxTransactions),
             MaxTraceableBlocks = section.GetValue("MaxTraceableBlocks", Default.MaxTraceableBlocks),
             MaxValidUntilBlockIncrement = section.GetValue("MaxValidUntilBlockIncrement", Default.MaxValidUntilBlockIncrement),
+            MaxValidUntilBlockIncrementForHighPriority = section.GetValue("MaxValidUntilBlockIncrementForHighPriority", Default.MaxValidUntilBlockIncrementForHighPriority),
             InitialGasDistribution = section.GetValue("InitialGasDistribution", Default.InitialGasDistribution),
             Hardforks = section.GetSection("Hardforks").Exists()
                 ? EnsureOmmitedHardforks(section.GetSection("Hardforks").GetChildren().ToDictionary(p => Enum.Parse<Hardfork>(p.Key, true), p => uint.Parse(p.Value!))).ToImmutableDictionary()


### PR DESCRIPTION
It is unlikely that we can gather 11 signatures from the committee's 21 members within a single day, which significantly increases the difficulty of modifying the network parameters. The validity period of committee proposal transactions needs to be extended.