### PR TITLE
Fix ECDSA sign method for Android

### DIFF
--- a/src/Neo/Cryptography/Crypto.cs
+++ b/src/Neo/Cryptography/Crypto.cs
@@ -10,6 +10,7 @@
 // modifications are permitted.
 
 using Neo.IO.Caching;
+using Neo.Wallets;
 using Org.BouncyCastle.Asn1.X9;
 using Org.BouncyCastle.Crypto.Parameters;
 using Org.BouncyCastle.Crypto.Signers;
@@ -56,18 +57,16 @@ public static class Crypto
     /// Signs the specified message using the ECDSA algorithm and specified hash algorithm.
     /// </summary>
     /// <param name="message">The message to be signed.</param>
-    /// <param name="priKey">The private key to be used.</param>
-    /// <param name="ecCurve">The <see cref="ECC.ECCurve"/> curve of the signature, default is <see cref="ECC.ECCurve.Secp256r1"/>.</param>
+    /// <param name="key">The private key to be used.</param>
     /// <param name="hashAlgorithm">The hash algorithm to hash the message, default is SHA256.</param>
     /// <returns>The ECDSA signature for the specified message.</returns>
-    public static byte[] Sign(byte[] message, byte[] priKey, ECC.ECCurve? ecCurve = null, HashAlgorithm hashAlgorithm = HashAlgorithm.SHA256)
+    public static byte[] Sign(byte[] message, KeyPair key, HashAlgorithm hashAlgorithm = HashAlgorithm.SHA256)
     {
-        ecCurve ??= ECC.ECCurve.Secp256r1;
-        if (s_isOSX && ecCurve == ECC.ECCurve.Secp256k1)
+        if (s_isOSX && key.PublicKey.Curve == ECC.ECCurve.Secp256k1)
         {
             var signer = new ECDsaSigner();
-            var privateKey = new BigInteger(1, priKey);
-            var priKeyParameters = new ECPrivateKeyParameters(privateKey, ecCurve.BouncyCastleDomainParams);
+            var privateKey = new BigInteger(1, key.PrivateKey);
+            var priKeyParameters = new ECPrivateKeyParameters(privateKey, key.PublicKey.Curve.BouncyCastleDomainParams);
             signer.Init(true, priKeyParameters);
             var messageHash = GetMessageHash(message, hashAlgorithm);
             var signature = signer.GenerateSignature(messageHash);
@@ -81,14 +80,20 @@ public static class Crypto
         }
 
         var curve =
-            ecCurve == ECC.ECCurve.Secp256r1 ? ECCurve.NamedCurves.nistP256 :
-            ecCurve == ECC.ECCurve.Secp256k1 ? s_secP256k1 :
-            throw new NotSupportedException($"The elliptic curve {ecCurve} is not supported. Only Secp256r1 and Secp256k1 curves are supported for ECDSA signing operations.");
+            key.PublicKey.Curve == ECC.ECCurve.Secp256r1 ? ECCurve.NamedCurves.nistP256 :
+            key.PublicKey.Curve == ECC.ECCurve.Secp256k1 ? s_secP256k1 :
+            throw new NotSupportedException($"The elliptic curve {key.PublicKey.Curve} is not supported. Only Secp256r1 and Secp256k1 curves are supported for ECDSA signing operations.");
 
+        byte[] pubkey = key.PublicKey.EncodePoint(false);
         using var ecdsa = ECDsa.Create(new ECParameters
         {
             Curve = curve,
-            D = priKey,
+            D = key.PrivateKey,
+            Q = new System.Security.Cryptography.ECPoint
+            {
+                X = pubkey[1..33],
+                Y = pubkey[33..]
+            }
         });
 
         if (hashAlgorithm == HashAlgorithm.Keccak256)
@@ -103,6 +108,19 @@ public static class Crypto
                 throw new NotSupportedException($"The hash algorithm {nameof(hashAlgorithm)} is not supported.");
             return ecdsa.SignData(message, hashAlg);
         }
+    }
+
+    /// <summary>
+    /// Verifies the digital signature of a message using the specified public key and hash algorithm.
+    /// </summary>
+    /// <param name="message">The message data to verify, provided as a read-only span of bytes.</param>
+    /// <param name="signature">The digital signature to verify, provided as a read-only span of bytes.</param>
+    /// <param name="key">The key pair containing the public key used for signature verification.</param>
+    /// <param name="hashAlgorithm">The hash algorithm to use when verifying the signature. The default is SHA256.</param>
+    /// <returns>true if the signature is valid for the specified message and public key; otherwise, false.</returns>
+    public static bool VerifySignature(ReadOnlySpan<byte> message, ReadOnlySpan<byte> signature, KeyPair key, HashAlgorithm hashAlgorithm = HashAlgorithm.SHA256)
+    {
+        return VerifySignature(message, signature, key.PublicKey, hashAlgorithm);
     }
 
     /// <summary>

--- a/src/Neo/Network/P2P/Payloads/VersionPayload.cs
+++ b/src/Neo/Network/P2P/Payloads/VersionPayload.cs
@@ -114,7 +114,7 @@ public class VersionPayload : ISerializable
         using var ms = new MemoryStream();
         using var writer = new BinaryWriter(ms);
         ret.Serialize(writer, false);
-        ret.Signature = Crypto.Sign(ms.ToArray(), nodeKey.PrivateKey);
+        ret.Signature = Crypto.Sign(ms.ToArray(), nodeKey);
 
         return ret;
     }

--- a/src/Neo/Wallets/Helper.cs
+++ b/src/Neo/Wallets/Helper.cs
@@ -39,7 +39,7 @@ public static class Helper
     /// <returns>The signature for the <see cref="IVerifiable"/>.</returns>
     public static byte[] Sign(this IVerifiable verifiable, KeyPair key, uint network)
     {
-        return Crypto.Sign(verifiable.GetSignData(network), key.PrivateKey);
+        return Crypto.Sign(verifiable.GetSignData(network), key);
     }
 
     /// <summary>

--- a/src/Neo/Wallets/KeyPair.cs
+++ b/src/Neo/Wallets/KeyPair.cs
@@ -52,21 +52,36 @@ public class KeyPair : IEquatable<KeyPair>
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="KeyPair"/> class.
+    /// Initializes a new instance of the KeyPair class using the specified private key.
     /// </summary>
-    /// <param name="privateKey">The private key in the <see cref="KeyPair"/>.</param>
-    public KeyPair(byte[] privateKey)
+    /// <remarks>This constructor defaults to using the Secp256r1 (NIST P-256) elliptic curve. Use the other
+    /// constructor to specify a different curve if needed.</remarks>
+    /// <param name="privateKey">A byte array containing the private key to use for generating the key pair.</param>
+    public KeyPair(byte[] privateKey) : this(privateKey, ECCurve.Secp256r1)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the KeyPair class using the specified private key and elliptic curve.
+    /// </summary>
+    /// <remarks>If privateKey is 32 bytes, the public key is derived from the curve's generator point and the
+    /// private key. For longer privateKey values, the public key is extracted from the provided bytes. The format of
+    /// privateKey must match the expected format for the specified curve.</remarks>
+    /// <param name="privateKey">A byte array containing the private key. Must be 32, 96, or 104 bytes in length, depending on the key format.</param>
+    /// <param name="curve">The elliptic curve to use for key generation and public key derivation.</param>
+    /// <exception cref="ArgumentException">Thrown if privateKey is not 32, 96, or 104 bytes in length.</exception>
+    public KeyPair(byte[] privateKey, ECCurve curve)
     {
         if (privateKey.Length != 32 && privateKey.Length != 96 && privateKey.Length != 104)
             throw new ArgumentException($"Invalid private key length: {privateKey.Length}", nameof(privateKey));
         PrivateKey = privateKey[^32..];
         if (privateKey.Length == 32)
         {
-            PublicKey = ECCurve.Secp256r1.G * privateKey;
+            PublicKey = curve.G * privateKey;
         }
         else
         {
-            PublicKey = ECPoint.FromBytes(privateKey, ECCurve.Secp256r1);
+            PublicKey = ECPoint.FromBytes(privateKey, curve);
         }
     }
 

--- a/src/Neo/Wallets/Wallet.cs
+++ b/src/Neo/Wallets/Wallet.cs
@@ -775,14 +775,15 @@ public abstract class Wallet : ISigner
         var account = GetAccount(publicKey)
             ?? throw new SignException("No such account found");
 
-        var privateKey = account.GetKey()?.PrivateKey
-            ?? throw new SignException("No private key found for the given public key");
+        var key = account.GetKey();
+        if (key?.PrivateKey is null)
+            throw new SignException("No private key found for the given public key");
 
         if (account.Lock)
             throw new SignException("Account is locked");
 
         var signData = block.GetSignData(network);
-        return Crypto.Sign(signData, privateKey);
+        return Crypto.Sign(signData, key);
     }
 
     /// <summary>

--- a/tests/Neo.UnitTests/Cryptography/UT_Crypto.cs
+++ b/tests/Neo.UnitTests/Cryptography/UT_Crypto.cs
@@ -29,8 +29,8 @@ public class UT_Crypto
         "aabbccdd11223344556677889900112233445566778899001122334455667788".HexToBytes();
     private static readonly byte[] s_secp256k1Priv =
         "7177f0d04c79fa0b8c91fe90c1cf1d44772d1fba6e5eb9b281a22cd3aafb51fe".HexToBytes();
-    private static ECPoint Secp256r1Pub => ECCurve.Secp256r1.G * s_secp256r1Priv;
-    private static ECPoint Secp256k1Pub => ECCurve.Secp256k1.G * s_secp256k1Priv;
+    private static readonly KeyPair Secp256r1Key = new(s_secp256r1Priv, ECCurve.Secp256r1);
+    private static readonly KeyPair Secp256k1Key = new(s_secp256k1Priv, ECCurve.Secp256k1);
 
     private static byte[] GetFormatValidButInvalidSecp256r1PubKey()
     {
@@ -84,7 +84,7 @@ public class UT_Crypto
     public void TestVerifySignature()
     {
         var message = Encoding.Default.GetBytes("HelloWorld");
-        var signature = Crypto.Sign(message, _key.PrivateKey);
+        var signature = Crypto.Sign(message, _key);
         Assert.IsTrue(Crypto.VerifySignature(message, signature, _key.PublicKey));
 
         var wrongKey2 = new byte[36];
@@ -103,15 +103,16 @@ public class UT_Crypto
     public void TestSecp256k1()
     {
         byte[] privkey = "7177f0d04c79fa0b8c91fe90c1cf1d44772d1fba6e5eb9b281a22cd3aafb51fe".HexToBytes();
+        KeyPair key = new(privkey, ECCurve.Secp256k1);
         byte[] message = "2d46a712699bae19a634563d74d04cc2da497b841456da270dccb75ac2f7c4e7".HexToBytes();
-        var signature = Crypto.Sign(message, privkey, ECCurve.Secp256k1);
+        var signature = Crypto.Sign(message, key);
 
         byte[] pubKey = ("04" + "fd0a8c1ce5ae5570fdd46e7599c16b175bf0ebdfe9c178f1ab848fb16dac74a5" +
             "d301b0534c7bcf1b3760881f0c420d17084907edd771e1c9c8e941bbf6ff9108").HexToBytes();
         Assert.IsTrue(Crypto.VerifySignature(message, signature, pubKey, ECCurve.Secp256k1));
 
         message = Encoding.Default.GetBytes("world");
-        signature = Crypto.Sign(message, privkey, ECCurve.Secp256k1);
+        signature = Crypto.Sign(message, key);
 
         Assert.IsTrue(Crypto.VerifySignature(message, signature, pubKey, ECCurve.Secp256k1));
 
@@ -300,63 +301,63 @@ public class UT_Crypto
     public void TestSignWithKeccak256()
     {
         var r1Message = Encoding.UTF8.GetBytes("round-trip-keccak-r1");
-        var r1Signature = Crypto.Sign(r1Message, s_secp256r1Priv, ECCurve.Secp256r1, HashAlgorithm.Keccak256);
+        var r1Signature = Crypto.Sign(r1Message, Secp256r1Key, HashAlgorithm.Keccak256);
         Assert.AreEqual(64, r1Signature.Length);
-        Assert.IsTrue(Crypto.VerifySignature(r1Message, r1Signature, Secp256r1Pub, HashAlgorithm.Keccak256));
+        Assert.IsTrue(Crypto.VerifySignature(r1Message, r1Signature, Secp256r1Key.PublicKey, HashAlgorithm.Keccak256));
 
         var k1Message = Encoding.UTF8.GetBytes("round-trip-keccak-k1");
-        var k1Signature = Crypto.Sign(k1Message, s_secp256k1Priv, ECCurve.Secp256k1, HashAlgorithm.Keccak256);
+        var k1Signature = Crypto.Sign(k1Message, Secp256k1Key, HashAlgorithm.Keccak256);
         Assert.AreEqual(64, k1Signature.Length);
-        Assert.IsTrue(Crypto.VerifySignature(k1Message, k1Signature, Secp256k1Pub, HashAlgorithm.Keccak256));
+        Assert.IsTrue(Crypto.VerifySignature(k1Message, k1Signature, Secp256k1Key.PublicKey, HashAlgorithm.Keccak256));
     }
 
     [TestMethod]
     public void TestSignSecp256k1CrossPlatformPath()
     {
         var sha256Message = Encoding.UTF8.GetBytes("k1-sha256-sign-path");
-        var sha256Signature = Crypto.Sign(sha256Message, s_secp256k1Priv, ECCurve.Secp256k1, HashAlgorithm.SHA256);
+        var sha256Signature = Crypto.Sign(sha256Message, Secp256k1Key, HashAlgorithm.SHA256);
         Assert.AreEqual(64, sha256Signature.Length);
-        Assert.IsTrue(Crypto.VerifySignature(sha256Message, sha256Signature, Secp256k1Pub, HashAlgorithm.SHA256));
+        Assert.IsTrue(Crypto.VerifySignature(sha256Message, sha256Signature, Secp256k1Key.PublicKey, HashAlgorithm.SHA256));
 
         var keccakMessage = Encoding.UTF8.GetBytes("k1-keccak-sign-path");
-        var keccakSignature = Crypto.Sign(keccakMessage, s_secp256k1Priv, ECCurve.Secp256k1, HashAlgorithm.Keccak256);
+        var keccakSignature = Crypto.Sign(keccakMessage, Secp256k1Key, HashAlgorithm.Keccak256);
         Assert.AreEqual(64, keccakSignature.Length);
-        Assert.IsTrue(Crypto.VerifySignature(keccakMessage, keccakSignature, Secp256k1Pub, HashAlgorithm.Keccak256));
+        Assert.IsTrue(Crypto.VerifySignature(keccakMessage, keccakSignature, Secp256k1Key.PublicKey, HashAlgorithm.Keccak256));
     }
 
     [TestMethod]
     public void TestSignUnsupportedHashAlgorithm()
     {
         Assert.ThrowsExactly<NotSupportedException>(() =>
-            Crypto.Sign(Array.Empty<byte>(), s_secp256r1Priv, ECCurve.Secp256r1, HashAlgorithm.SHA512));
+            Crypto.Sign(Array.Empty<byte>(), Secp256r1Key, HashAlgorithm.SHA512));
     }
 
     [TestMethod]
     public void TestVerifySignatureAdditionalCases()
     {
         var message = Encoding.UTF8.GetBytes("message-a");
-        var signature = Crypto.Sign(message, s_secp256r1Priv, ECCurve.Secp256r1, HashAlgorithm.SHA256);
+        var signature = Crypto.Sign(message, Secp256r1Key, HashAlgorithm.SHA256);
 
         Assert.ThrowsExactly<NotSupportedException>(() =>
-            Crypto.VerifySignature(message, new byte[64], Secp256r1Pub, (HashAlgorithm)0xFD));
+            Crypto.VerifySignature(message, new byte[64], Secp256r1Key.PublicKey, (HashAlgorithm)0xFD));
         Assert.ThrowsExactly<NotSupportedException>(() =>
-            Crypto.VerifySignature(message, new byte[64], Secp256r1Pub, HashAlgorithm.SHA512));
+            Crypto.VerifySignature(message, new byte[64], Secp256r1Key.PublicKey, HashAlgorithm.SHA512));
 
         signature[0] ^= 0x01;
-        Assert.IsFalse(Crypto.VerifySignature(message, signature, Secp256r1Pub, HashAlgorithm.SHA256));
+        Assert.IsFalse(Crypto.VerifySignature(message, signature, Secp256r1Key.PublicKey, HashAlgorithm.SHA256));
 
-        var validSignature = Crypto.Sign(message, s_secp256r1Priv, ECCurve.Secp256r1, HashAlgorithm.SHA256);
-        Assert.IsFalse(Crypto.VerifySignature(Encoding.UTF8.GetBytes("message-b"), validSignature, Secp256r1Pub, HashAlgorithm.SHA256));
+        var validSignature = Crypto.Sign(message, Secp256r1Key, HashAlgorithm.SHA256);
+        Assert.IsFalse(Crypto.VerifySignature(Encoding.UTF8.GetBytes("message-b"), validSignature, Secp256r1Key.PublicKey, HashAlgorithm.SHA256));
     }
 
     [TestMethod]
     public void TestVerifySignatureAdditionalVectors()
     {
         var message = Encoding.UTF8.GetBytes("span-overload");
-        var signature = Crypto.Sign(message, s_secp256r1Priv);
-        var pubBytes = Secp256r1Pub.EncodePoint(true);
+        var signature = Crypto.Sign(message, Secp256r1Key);
+        var pubBytes = Secp256r1Key.PublicKey.EncodePoint(true);
         Assert.IsTrue(Crypto.VerifySignature(message, signature, pubBytes, ECCurve.Secp256r1, HashAlgorithm.SHA256));
-        Assert.IsTrue(Crypto.VerifySignature(message, signature, Secp256r1Pub, HashAlgorithm.SHA256));
+        Assert.IsTrue(Crypto.VerifySignature(message, signature, Secp256r1Key.PublicKey, HashAlgorithm.SHA256));
 
         var fixedMessage = Encoding.Default.GetBytes("中文");
         var fixedSignature = ("b8cba1ff42304d74d083e87706058f59cdd4f755b995926d2cd80a734c5a3c37" +
@@ -369,8 +370,8 @@ public class UT_Crypto
     [TestMethod]
     public void TestCreateECDsa()
     {
-        var ecdsaR1First = Crypto.CreateECDsa(Secp256r1Pub);
-        var ecdsaR1Second = Crypto.CreateECDsa(Secp256r1Pub);
+        var ecdsaR1First = Crypto.CreateECDsa(Secp256r1Key.PublicKey);
+        var ecdsaR1Second = Crypto.CreateECDsa(Secp256r1Key.PublicKey);
         Assert.AreSame(ecdsaR1First, ecdsaR1Second);
 
         var infinity = new ECPoint();
@@ -382,7 +383,7 @@ public class UT_Crypto
     public void TestVerifySignatureInvalidButFormatValidPubkey()
     {
         var message = Encoding.UTF8.GetBytes("neo-crypto-signverify-sha256");
-        var signature = Crypto.Sign(message, s_secp256r1Priv, ECCurve.Secp256r1, HashAlgorithm.SHA256);
+        var signature = Crypto.Sign(message, Secp256r1Key, HashAlgorithm.SHA256);
         var invalidPubKey = GetFormatValidButInvalidSecp256r1PubKey();
 
         var ex = Assert.ThrowsExactly<ArgumentException>(() =>
@@ -397,7 +398,7 @@ public class UT_Crypto
     public void TestVerifyWithECDsaInvalidButFormatValidPubkey()
     {
         var message = Encoding.UTF8.GetBytes("neo-crypto-signverify-sha256");
-        var signature = Crypto.Sign(message, s_secp256r1Priv, ECCurve.Secp256r1, HashAlgorithm.SHA256);
+        var signature = Crypto.Sign(message, Secp256r1Key, HashAlgorithm.SHA256);
         var invalidPubKey = GetFormatValidButInvalidSecp256r1PubKey();
 
         var ex = Assert.ThrowsExactly<ArgumentException>(() =>

--- a/tests/Neo.UnitTests/SmartContract/Manifest/UT_ContractGroup.cs
+++ b/tests/Neo.UnitTests/SmartContract/Manifest/UT_ContractGroup.cs
@@ -54,7 +54,7 @@ public class UT_ContractGroup
                                        0x01,0x01,0x01,0x01,0x01,
                                        0x01,0x01,0x01,0x01,0x01,
                                        0x01,0x01,0x01,0x01,0x01 };
-        var signature = Crypto.Sign(message, keyPair.PrivateKey);
+        var signature = Crypto.Sign(message, keyPair);
         contractGroup = new ContractGroup
         {
             PubKey = keyPair.PublicKey,

--- a/tests/Neo.UnitTests/SmartContract/Native/UT_CryptoLib.cs
+++ b/tests/Neo.UnitTests/SmartContract/Native/UT_CryptoLib.cs
@@ -19,6 +19,7 @@ using Neo.Network.P2P.Payloads;
 using Neo.SmartContract;
 using Neo.SmartContract.Native;
 using Neo.VM;
+using Neo.Wallets;
 using Org.BouncyCastle.Utilities.Encoders;
 using System.Numerics;
 using System.Text;
@@ -620,15 +621,13 @@ public class UT_CryptoLib
     public async Task TestVerifyWithECDsa_CustomTxWitness_SingleSig()
     {
         byte[] privkey = "7177f0d04c79fa0b8c91fe90c1cf1d44772d1fba6e5eb9b281a22cd3aafb51fe".HexToBytes();
-        var pubHex = "04" + "fd0a8c1ce5ae5570fdd46e7599c16b175bf0ebdfe9c178f1ab848fb16dac74a5" +
-            "d301b0534c7bcf1b3760881f0c420d17084907edd771e1c9c8e941bbf6ff9108";
-        ECPoint pubKey = ECPoint.Parse(pubHex, ECCurve.Secp256k1);
+        KeyPair key = new(privkey, ECCurve.Secp256k1);
 
         // vrf is a builder of witness verification script corresponding to the public key.
         using ScriptBuilder vrf = new();
         vrf.EmitPush((byte)NamedCurveHash.secp256k1Keccak256); // push Koblitz curve identifier and Keccak256 hasher.
         vrf.Emit(OpCode.SWAP); // swap curve identifier with the signature.
-        vrf.EmitPush(pubKey.EncodePoint(true)); // emit the caller's public key.
+        vrf.EmitPush(key.PublicKey.EncodePoint(true)); // emit the caller's public key.
 
         // Construct and push the signed message. The signed message is effectively the network-dependent transaction hash,
         // i.e. msg = [4-network-magic-bytes-LE, tx-hash-BE]
@@ -669,7 +668,7 @@ public class UT_CryptoLib
             Witnesses = []
         };
         var signData = tx.GetSignData(TestProtocolSettings.Default.Network);
-        var txSignature = Crypto.Sign(signData, privkey, ECCurve.Secp256k1, HashAlgorithm.Keccak256);
+        var txSignature = Crypto.Sign(signData, key, HashAlgorithm.Keccak256);
 
         // inv is a builder of witness invocation script corresponding to the public key.
         using ScriptBuilder inv = new();
@@ -759,33 +758,18 @@ public class UT_CryptoLib
     public async Task TestVerifyWithECDsa_CustomTxWitness_MultiSig()
     {
         var privkey1 = "b2dde592bfce654ef03f1ceea452d2b0112e90f9f52099bcd86697a2bd0a2b60".HexToBytes();
-        var pubKey1 = ECPoint.Parse("04" +
-            "0486468683c112125978ffe876245b2006bfe739aca8539b67335079262cb27a" +
-            "d0dedc9e5583f99b61c6f46bf80b97eaec3654b87add0e5bd7106c69922a229d", ECCurve.Secp256k1);
-
         var privkey2 = "b9879e26941872ee6c9e6f01045681496d8170ed2cc4a54ce617b39ae1891b3a".HexToBytes();
-        var pubKey2 = ECPoint.Parse("04" +
-            "0d26fc2ad3b1aae20f040b5f83380670f8ef5c2b2ac921ba3bdd79fd0af05251" +
-            "77715fd4370b1012ddd10579698d186ab342c223da3e884ece9cab9b6638c7bb", ECCurve.Secp256k1);
-
         var privkey3 = "4e1fe2561a6da01ee030589d504d62b23c26bfd56c5e07dfc9b8b74e4602832a".HexToBytes();
-        var pubKey3 = ECPoint.Parse("04" +
-            "7b4e72ae854b6a0955b3e02d92651ab7fa641a936066776ad438f95bb674a269" +
-            "a63ff98544691663d91a6cfcd215831f01bfb7a226363a6c5c67ef14541dba07", ECCurve.Secp256k1);
-
         var privkey4 = "6dfd066bb989d3786043aa5c1f0476215d6f5c44f5fc3392dd15e2599b67a728".HexToBytes();
-        var pubKey4 = ECPoint.Parse("04" +
-            "b62ac4c8a352a892feceb18d7e2e3a62c8c1ecbaae5523d89d747b0219276e22" +
-            "5be2556a137e0e806e4915762d816cdb43f572730d23bb1b1cba750011c4edc6", ECCurve.Secp256k1);
 
         // Public keys must be sorted, exactly like for standard CreateMultiSigRedeemScript.
-        var keys = new List<(byte[], ECPoint)>
+        var keys = new List<KeyPair>
         {
-            (privkey1, pubKey1),
-            (privkey2, pubKey2),
-            (privkey3, pubKey3),
-            (privkey4, pubKey4),
-        }.OrderBy(k => k.Item2).ToList();
+            new(privkey1,ECCurve.Secp256k1),
+            new(privkey2,ECCurve.Secp256k1),
+            new(privkey3,ECCurve.Secp256k1),
+            new(privkey4,ECCurve.Secp256k1)
+        }.OrderBy(k => k.PublicKey).ToList();
 
         // Consider 4 users willing to sign 3/4 multisignature transaction with their Secp256k1 private keys.
         var m = 3;
@@ -794,7 +778,7 @@ public class UT_CryptoLib
         // Must ensure the following conditions are met before verification script construction:
         Assert.IsGreaterThan(0, n);
         Assert.IsLessThanOrEqualTo(n, m);
-        Assert.AreEqual(n, keys.Select(k => k.Item2).Distinct().Count());
+        Assert.AreEqual(n, keys.Select(k => k.PublicKey).Distinct().Count());
 
         // In fact, the following algorithm is implemented via NeoVM instructions:
         //
@@ -820,7 +804,7 @@ public class UT_CryptoLib
         vrf.EmitPush(m); // push m.
         foreach (var tuple in keys)
         {
-            vrf.EmitPush(tuple.Item2.EncodePoint(true)); // push public keys in compressed form.
+            vrf.EmitPush(tuple.PublicKey.EncodePoint(true)); // push public keys in compressed form.
         }
         vrf.EmitPush(n); // push n.
 
@@ -944,7 +928,7 @@ public class UT_CryptoLib
             if (i == 1) // Skip one key since we need only 3 signatures.
                 continue;
             var signData = tx.GetSignData(TestProtocolSettings.Default.Network);
-            var sig = Crypto.Sign(signData, keys[i].Item1, ECCurve.Secp256k1, HashAlgorithm.Keccak256);
+            var sig = Crypto.Sign(signData, keys[i], HashAlgorithm.Keccak256);
             inv.EmitPush(sig);
         }
 
@@ -1095,36 +1079,32 @@ public class UT_CryptoLib
     public void TestVerifyWithECDsa()
     {
         byte[] privR1 = "6e63fda41e9e3aba9bb5696d58a75731f044a9bdc48fe546da571543b2fa460e".HexToBytes();
-        ECPoint pubR1 = ECPoint.Parse("04" +
-            "cae768e1cf58d50260cab808da8d6d83d5d3ab91eac41cdce577ce5862d73641" +
-            "3643bdecd6d21c3b66f122ab080f9219204b10aa8bbceb86c1896974768648f3", ECCurve.Secp256r1);
+        KeyPair keyR1 = new(privR1, ECCurve.Secp256r1);
 
         byte[] privK1 = "0b5fb3a050385196b327be7d86cbce6e40a04c8832445af83ad19c82103b3ed9".HexToBytes();
-        ECPoint pubK1 = ECPoint.Parse("04" +
-            "b6363b353c3ee1620c5af58594458aa00abf43a6d134d7c4cb2d901dc0f474fd" +
-            "74c94740bd7169aa0b1ef7bc657e824b1d7f4283c547e7ec18c8576acf84418a", ECCurve.Secp256k1);
+        KeyPair keyK1 = new(privK1, ECCurve.Secp256k1);
 
         byte[] message = Encoding.Default.GetBytes("HelloWorld");
 
         // secp256r1 + SHA256
-        byte[] signature = Crypto.Sign(message, privR1, ECCurve.Secp256r1, HashAlgorithm.SHA256);
-        Assert.IsTrue(Crypto.VerifySignature(message, signature, pubR1)); // SHA256 hash is used by default.
-        Assert.IsTrue(CallVerifyWithECDsa(message, pubR1, signature, NamedCurveHash.secp256r1SHA256));
+        byte[] signature = Crypto.Sign(message, keyR1, HashAlgorithm.SHA256);
+        Assert.IsTrue(Crypto.VerifySignature(message, signature, keyR1.PublicKey)); // SHA256 hash is used by default.
+        Assert.IsTrue(CallVerifyWithECDsa(message, keyR1.PublicKey, signature, NamedCurveHash.secp256r1SHA256));
 
         // secp256r1 + Keccak256
-        signature = Crypto.Sign(message, privR1, ECCurve.Secp256r1, HashAlgorithm.Keccak256);
-        Assert.IsTrue(Crypto.VerifySignature(message, signature, pubR1, HashAlgorithm.Keccak256));
-        Assert.IsTrue(CallVerifyWithECDsa(message, pubR1, signature, NamedCurveHash.secp256r1Keccak256));
+        signature = Crypto.Sign(message, keyR1, HashAlgorithm.Keccak256);
+        Assert.IsTrue(Crypto.VerifySignature(message, signature, keyR1.PublicKey, HashAlgorithm.Keccak256));
+        Assert.IsTrue(CallVerifyWithECDsa(message, keyR1.PublicKey, signature, NamedCurveHash.secp256r1Keccak256));
 
         // secp256k1 + SHA256
-        signature = Crypto.Sign(message, privK1, ECCurve.Secp256k1, HashAlgorithm.SHA256);
-        Assert.IsTrue(Crypto.VerifySignature(message, signature, pubK1)); // SHA256 hash is used by default.
-        Assert.IsTrue(CallVerifyWithECDsa(message, pubK1, signature, NamedCurveHash.secp256k1SHA256));
+        signature = Crypto.Sign(message, keyK1, HashAlgorithm.SHA256);
+        Assert.IsTrue(Crypto.VerifySignature(message, signature, keyK1.PublicKey)); // SHA256 hash is used by default.
+        Assert.IsTrue(CallVerifyWithECDsa(message, keyK1.PublicKey, signature, NamedCurveHash.secp256k1SHA256));
 
         // secp256k1 + Keccak256
-        signature = Crypto.Sign(message, privK1, ECCurve.Secp256k1, HashAlgorithm.Keccak256);
-        Assert.IsTrue(Crypto.VerifySignature(message, signature, pubK1, HashAlgorithm.Keccak256));
-        Assert.IsTrue(CallVerifyWithECDsa(message, pubK1, signature, NamedCurveHash.secp256k1Keccak256));
+        signature = Crypto.Sign(message, keyK1, HashAlgorithm.Keccak256);
+        Assert.IsTrue(Crypto.VerifySignature(message, signature, keyK1.PublicKey, HashAlgorithm.Keccak256));
+        Assert.IsTrue(CallVerifyWithECDsa(message, keyK1.PublicKey, signature, NamedCurveHash.secp256k1Keccak256));
     }
 
     [TestMethod]
@@ -1132,11 +1112,9 @@ public class UT_CryptoLib
     {
         var message = "hello world"u8.ToArray();
         var privateKey = "6e63fda41e9e3aba9bb5696d58a75731f044a9bdc48fe546da571543b2fa460e".HexToBytes();
-        var publicKey = ECPoint.Parse("04" +
-            "cae768e1cf58d50260cab808da8d6d83d5d3ab91eac41cdce577ce5862d73641" +
-            "3643bdecd6d21c3b66f122ab080f9219204b10aa8bbceb86c1896974768648f3", ECCurve.Secp256r1);
+        var key = new KeyPair(privateKey);
 
-        var sign = Crypto.Sign(message, privateKey, ECCurve.Secp256r1, HashAlgorithm.SHA256);
+        var sign = Crypto.Sign(message, key, HashAlgorithm.SHA256);
 
         // IndexOutOfRangeException, but should be FormatException
         Assert.ThrowsExactly<IndexOutOfRangeException>(() => CryptoLib.VerifyWithECDsa(message, null!, sign, NamedCurveHash.secp256r1SHA256));
@@ -1150,23 +1128,23 @@ public class UT_CryptoLib
         // FormatException if the signature is empty
         Assert.ThrowsExactly<FormatException>(() => CryptoLib.VerifyWithECDsa(message, [0x01], sign, NamedCurveHash.secp256r1SHA256));
 
-        Assert.ThrowsExactly<FormatException>(() => CryptoLib.VerifyWithECDsa(message, publicKey.EncodePoint(true), [], NamedCurveHash.secp256r1SHA256));
+        Assert.ThrowsExactly<FormatException>(() => CryptoLib.VerifyWithECDsa(message, key.PublicKey.EncodePoint(true), [], NamedCurveHash.secp256r1SHA256));
 
-        bool ok = CryptoLib.VerifyWithECDsa(message, publicKey.EncodePoint(true), sign, NamedCurveHash.secp256r1SHA256);
+        bool ok = CryptoLib.VerifyWithECDsa(message, key.PublicKey.EncodePoint(true), sign, NamedCurveHash.secp256r1SHA256);
         Assert.IsTrue(ok);
 
-        ok = CryptoLib.VerifyWithECDsa(message, publicKey.EncodePoint(false), sign, NamedCurveHash.secp256r1SHA256);
+        ok = CryptoLib.VerifyWithECDsa(message, key.PublicKey.EncodePoint(false), sign, NamedCurveHash.secp256r1SHA256);
         Assert.IsTrue(ok);
 
-        Assert.ThrowsExactly<ArgumentException>(() => CryptoLib.VerifyWithECDsa(message, publicKey.EncodePoint(false), sign, NamedCurveHash.secp256k1SHA256));
+        Assert.ThrowsExactly<ArgumentException>(() => CryptoLib.VerifyWithECDsa(message, key.PublicKey.EncodePoint(false), sign, NamedCurveHash.secp256k1SHA256));
 
         // ArithmeticException, but should be ArgumentException
         byte[] invalidPublicKey = [0x03, .. Enumerable.Repeat<byte>(0x03, 32)];
         Assert.ThrowsExactly<ArithmeticException>(() => CryptoLib.VerifyWithECDsa(message, invalidPublicKey, sign, NamedCurveHash.secp256k1SHA256));
 
         // null messsage and signature is valid, result is true
-        sign = Crypto.Sign([], privateKey, ECCurve.Secp256r1, HashAlgorithm.SHA256);
-        ok = CryptoLib.VerifyWithECDsa(null!, publicKey.EncodePoint(true), sign, NamedCurveHash.secp256r1SHA256);
+        sign = Crypto.Sign([], key, HashAlgorithm.SHA256);
+        ok = CryptoLib.VerifyWithECDsa(null!, key.PublicKey.EncodePoint(true), sign, NamedCurveHash.secp256r1SHA256);
         Assert.IsTrue(ok);
     }
 

--- a/tests/Neo.UnitTests/SmartContract/UT_InteropService.NEO.cs
+++ b/tests/Neo.UnitTests/SmartContract/UT_InteropService.NEO.cs
@@ -33,7 +33,7 @@ public partial class UT_InteropService
         var privateKey = Enumerable.Repeat((byte)0x01, 32).ToArray();
         var keyPair = new KeyPair(privateKey);
         var pubkey = keyPair.PublicKey;
-        var signature = Crypto.Sign(message, privateKey);
+        var signature = Crypto.Sign(message, keyPair);
         Assert.IsTrue(engine.CheckSig(pubkey.EncodePoint(false), signature));
         Assert.ThrowsExactly<FormatException>(() => engine.CheckSig(new byte[70], signature));
     }
@@ -48,12 +48,12 @@ public partial class UT_InteropService
         var privkey1 = Enumerable.Repeat((byte)0x01, 32).ToArray();
         var key1 = new KeyPair(privkey1);
         var pubkey1 = key1.PublicKey;
-        var signature1 = Crypto.Sign(message, privkey1);
+        var signature1 = Crypto.Sign(message, key1);
 
         var privkey2 = Enumerable.Repeat((byte)0x01, 32).ToArray();
         var key2 = new KeyPair(privkey2);
         var pubkey2 = key2.PublicKey;
-        var signature2 = Crypto.Sign(message, privkey2);
+        var signature2 = Crypto.Sign(message, key2);
 
         var pubkeys = new[] { pubkey1.EncodePoint(false), pubkey2.EncodePoint(false) };
         var signatures = new[] { signature1, signature2 };
@@ -140,7 +140,7 @@ public partial class UT_InteropService
 
         var pubkey = key.PublicKey;
         var state = TestUtils.GetContract();
-        var signature = Crypto.Sign(state.Hash.ToArray(), privkey);
+        var signature = Crypto.Sign(state.Hash.ToArray(), key);
         manifest.Groups = [new() { PubKey = pubkey, Signature = signature }];
 
         var storageItem = new StorageItem

--- a/tests/Neo.UnitTests/SmartContract/UT_InteropService.cs
+++ b/tests/Neo.UnitTests/SmartContract/UT_InteropService.cs
@@ -457,7 +457,7 @@ public partial class UT_InteropService : TestKit
             0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01};
         KeyPair keyPair = new(privateKey);
         var pubkey = keyPair.PublicKey;
-        var signature = Crypto.Sign(message, privateKey);
+        var signature = Crypto.Sign(message, keyPair);
         Assert.IsTrue(engine.CheckSig(pubkey.EncodePoint(false), signature));
 
         var wrongkey = pubkey.EncodePoint(false);
@@ -833,17 +833,17 @@ public partial class UT_InteropService : TestKit
         var privateKey = new byte[32];
         using var rng = RandomNumberGenerator.Create();
         rng.GetBytes(privateKey);
-        var publicKeyR1 = new KeyPair(privateKey).PublicKey.ToArray();
-        var publicKeyK1 = (ECCurve.Secp256k1.G * privateKey).ToArray();
+        var keyR1 = new KeyPair(privateKey, ECCurve.Secp256r1);
+        var keyK1 = new KeyPair(privateKey, ECCurve.Secp256k1);
         var hexMessage = "Hello, world!"u8.ToArray();
-        var signatureR1 = Crypto.Sign(hexMessage, privateKey, ECCurve.Secp256r1);
-        var signatureK1 = Crypto.Sign(hexMessage, privateKey, ECCurve.Secp256k1);
+        var signatureR1 = Crypto.Sign(hexMessage, keyR1);
+        var signatureK1 = Crypto.Sign(hexMessage, keyK1);
 
-        var result = CryptoLib.VerifyWithECDsa(hexMessage, publicKeyR1, signatureR1, NamedCurveHash.secp256r1SHA256);
+        var result = CryptoLib.VerifyWithECDsa(hexMessage, keyR1.PublicKey.EncodePoint(true), signatureR1, NamedCurveHash.secp256r1SHA256);
         Assert.IsTrue(result);
-        result = CryptoLib.VerifyWithECDsa(hexMessage, publicKeyK1, signatureK1, NamedCurveHash.secp256k1SHA256);
+        result = CryptoLib.VerifyWithECDsa(hexMessage, keyK1.PublicKey.EncodePoint(true), signatureK1, NamedCurveHash.secp256k1SHA256);
         Assert.IsTrue(result);
-        Assert.ThrowsExactly<FormatException>(() => CryptoLib.VerifyWithECDsa(hexMessage, publicKeyK1, [], NamedCurveHash.secp256k1SHA256));
+        Assert.ThrowsExactly<FormatException>(() => CryptoLib.VerifyWithECDsa(hexMessage, keyK1.PublicKey.EncodePoint(true), [], NamedCurveHash.secp256k1SHA256));
     }
 
     [TestMethod]


### PR DESCRIPTION
On Windows, only the `D` parameter needs to be set within `ECParameters` to perform a signature. However, in the Android environment, both `D` and `Q` must be set for it to function correctly. This PR resolves this issue.