### PR TITLE
Native: properly deactivate native mathods/events

### DIFF
--- a/src/Neo/SmartContract/Native/NativeContract.cs
+++ b/src/Neo/SmartContract/Native/NativeContract.cs
@@ -230,7 +230,7 @@ namespace Neo.SmartContract.Native
                     // deprecated method hardfork is involved
                     u.DeprecatedIn is not null && hfChecker(u.DeprecatedIn.Value, blockHeight) == false ||
                     // active method hardfork is involved
-                    u.ActiveIn is not null && hfChecker(u.ActiveIn.Value, blockHeight);
+                    (u.DeprecatedIn is null && u.ActiveIn is not null && hfChecker(u.ActiveIn.Value, blockHeight));
         }
 
         /// <summary>

--- a/tests/Neo.UnitTests/SmartContract/Native/UT_NativeContract.cs
+++ b/tests/Neo.UnitTests/SmartContract/Native/UT_NativeContract.cs
@@ -64,7 +64,7 @@ namespace Neo.UnitTests.SmartContract.Native
         [TestMethod]
         public void TestActiveDeprecatedIn()
         {
-            string json = UT_ProtocolSettings.CreateHFSettings("\"HF_Cockatrice\": 20");
+            string json = UT_ProtocolSettings.CreateHFSettings("\"HF_Basilisk\": 10,\n\"HF_Cockatrice\": 20");
             var file = Path.GetTempFileName();
             File.WriteAllText(file, json);
             ProtocolSettings settings = ProtocolSettings.Load(file);
@@ -75,6 +75,9 @@ namespace Neo.UnitTests.SmartContract.Native
 
             Assert.IsTrue(NativeContract.IsActive(new active() { ActiveIn = null, DeprecatedIn = Hardfork.HF_Cockatrice }, settings.IsHardforkEnabled, 1));
             Assert.IsFalse(NativeContract.IsActive(new active() { ActiveIn = null, DeprecatedIn = Hardfork.HF_Cockatrice }, settings.IsHardforkEnabled, 20));
+
+            Assert.IsTrue(NativeContract.IsActive(new active() { ActiveIn = Hardfork.HF_Basilisk, DeprecatedIn = Hardfork.HF_Cockatrice }, settings.IsHardforkEnabled, 19));
+            Assert.IsFalse(NativeContract.IsActive(new active() { ActiveIn = Hardfork.HF_Basilisk, DeprecatedIn = Hardfork.HF_Cockatrice }, settings.IsHardforkEnabled, 20));
         }
 
         [TestMethod]


### PR DESCRIPTION
# Description

Required for https://github.com/neo-project/neo/pull/4449. If DeprecatedIn hardfork is specified and is already passed, then this method should never be considered as active, even if ActiveIn hardfork check is passed.

Should fix the exception described in https://github.com/neo-project/neo/pull/4449/changes#r2900766541.

# Change Log

- Fix the behaviour of `NativeContract.IsActive`.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [X] Unit Testing
- [ ] Run Application
- [ ] Local Computer Tests
- [ ] No Testing


# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
