### PR TITLE
Native: properly activate native methods/events

### DIFF
--- a/src/Neo/SmartContract/Native/NativeContract.cs
+++ b/src/Neo/SmartContract/Native/NativeContract.cs
@@ -225,12 +225,8 @@ namespace Neo.SmartContract.Native
 
         internal static bool IsActive(IHardforkActivable u, IsHardforkEnabledDelegate hfChecker, uint blockHeight)
         {
-            return  // no hardfork is involved
-                    u.ActiveIn is null && u.DeprecatedIn is null ||
-                    // deprecated method hardfork is involved
-                    u.DeprecatedIn is not null && hfChecker(u.DeprecatedIn.Value, blockHeight) == false ||
-                    // active method hardfork is involved
-                    (u.DeprecatedIn is null && u.ActiveIn is not null && hfChecker(u.ActiveIn.Value, blockHeight));
+            // Method/event is active iff ActiveIn hardfork IS active AND DeprecatedIn hardfork IS NOT active.
+            return (u.ActiveIn is null || hfChecker(u.ActiveIn.Value, blockHeight)) && (u.DeprecatedIn is null || !hfChecker(u.DeprecatedIn.Value, blockHeight));
         }
 
         /// <summary>

--- a/tests/Neo.UnitTests/SmartContract/Native/UT_NativeContract.cs
+++ b/tests/Neo.UnitTests/SmartContract/Native/UT_NativeContract.cs
@@ -76,6 +76,8 @@ namespace Neo.UnitTests.SmartContract.Native
             Assert.IsTrue(NativeContract.IsActive(new active() { ActiveIn = null, DeprecatedIn = Hardfork.HF_Cockatrice }, settings.IsHardforkEnabled, 1));
             Assert.IsFalse(NativeContract.IsActive(new active() { ActiveIn = null, DeprecatedIn = Hardfork.HF_Cockatrice }, settings.IsHardforkEnabled, 20));
 
+            Assert.IsFalse(NativeContract.IsActive(new active() { ActiveIn = Hardfork.HF_Basilisk, DeprecatedIn = Hardfork.HF_Cockatrice }, settings.IsHardforkEnabled, 9));
+            Assert.IsTrue(NativeContract.IsActive(new active() { ActiveIn = Hardfork.HF_Basilisk, DeprecatedIn = Hardfork.HF_Cockatrice }, settings.IsHardforkEnabled, 10));
             Assert.IsTrue(NativeContract.IsActive(new active() { ActiveIn = Hardfork.HF_Basilisk, DeprecatedIn = Hardfork.HF_Cockatrice }, settings.IsHardforkEnabled, 19));
             Assert.IsFalse(NativeContract.IsActive(new active() { ActiveIn = Hardfork.HF_Basilisk, DeprecatedIn = Hardfork.HF_Cockatrice }, settings.IsHardforkEnabled, 20));
         }


### PR DESCRIPTION
# Description

https://github.com/neo-project/neo/pull/4520 fixes false-positive activation in case if DeprecatedIn hardfork is passed. However, it's not enough for proper ActiveIn work because there's a case of false-positive activation in case if both DeprecatedIn and ActiveIn hardforks are not yet passed.

This commit rewrites ActiveIn condition: the method/event IS active if and only if ActiveIn hardfork IS active AND DeprecatedIn hardfork IS NOT active. ActiveIn hardfork IS active if it's null OR it's already passed. DeprecatedIn hardfork IS NOT active if it's null OR it's not yet passed.

For reference, here's the same condition (but in reversed form) in NeoGo:
https://github.com/nspcc-dev/neo-go/blob/60b8cd32a74d033e77b0fa9034f0fa3a999a34c1/pkg/core/interop/context.go#L332-L335

# Change Log

- Rewrite ActiveIn to cover all combinations of ActiveIn/DeprecatedIn

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [X] Unit Testing
- [ ] Run Application
- [ ] Local Computer Tests
- [ ] No Testing


# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
