### PR TITLE
Fix: avoid always creating logger for Plugin

### DIFF
--- a/src/Neo/Plugins/Plugin.cs
+++ b/src/Neo/Plugins/Plugin.cs
@@ -10,7 +10,6 @@
 // modifications are permitted.
 
 using Microsoft.Extensions.Configuration;
-using Serilog;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -76,8 +75,6 @@ namespace Neo.Plugins
         /// </summary>
         protected internal virtual UnhandledExceptionPolicy ExceptionPolicy { get; init; } = UnhandledExceptionPolicy.StopNode;
 
-        protected ILogger Logger { get; private set; }
-
         /// <summary>
         /// The plugin will be stopped if an exception is thrown.
         /// But it also depends on <see cref="UnhandledExceptionPolicy"/>.
@@ -107,7 +104,6 @@ namespace Neo.Plugins
         protected Plugin()
         {
             Plugins.Add(this);
-            Logger = Logs.GetLogger($"{nameof(Plugin)}_{Name}");
             Configure();
         }
 
@@ -230,17 +226,6 @@ namespace Neo.Plugins
             {
                 LoadPlugin(assembly);
             }
-        }
-
-        /// <summary>
-        /// Write a log for the plugin.
-        /// </summary>
-        /// <param name="message">The message of the log.</param>
-        /// <param name="level">The level of the log.</param>
-        [Obsolete("Use Logs.GetLogger(source) instead.")]
-        protected void Log(object message, LogLevel level = LogLevel.Info)
-        {
-            Logger.Write((Serilog.Events.LogEventLevel)level, "{Message}", message);
         }
 
         /// <summary>


### PR DESCRIPTION

Avoid  always creating `Logger` for Plugin, even if a plugin doesn't have any log operation.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
