### PR TITLE
Native: block contract account prior to its removal from snapshot

### DIFF
--- a/src/Neo/SmartContract/Native/ContractManagement.cs
+++ b/src/Neo/SmartContract/Native/ContractManagement.cs
@@ -376,25 +376,63 @@ namespace Neo.SmartContract.Native
         }
 
         /// <summary>
-        /// Destroys a contract.
+        /// Destroys a contract. Pre-Gorgon version of `destroy` that blocks the contract's account
+        /// *after* removing the contract state and contract storage items from the snapshot.
         /// </summary>
         /// <param name="engine">The engine used to write data.</param>
-        [ContractMethod(CpuFee = 1 << 15, RequiredCallFlags = CallFlags.States | CallFlags.AllowNotify)]
-        private async ContractTask Destroy(ApplicationEngine engine)
+        [ContractMethod(true, Hardfork.HF_Gorgon, CpuFee = 1 << 15, RequiredCallFlags = CallFlags.States | CallFlags.AllowNotify, Name = "destroy")]
+        private async ContractTask DestroyV0(ApplicationEngine engine)
+        {
+            await DestroyInternal(engine, false);
+        }
+
+        /// <summary>
+        /// Destroys a contract. Post-Gorgon version of `destroy` that blocks the contract's account
+        /// *prior to* removing the contract state and contract storage items from the snapshot.
+        /// </summary>
+        /// <param name="engine">The engine used to write data.</param>
+        [ContractMethod(Hardfork.HF_Gorgon, CpuFee = 1 << 15, RequiredCallFlags = CallFlags.States | CallFlags.AllowNotify, Name = "destroy")]
+        private async ContractTask DestroyV1(ApplicationEngine engine)
+        {
+            await DestroyInternal(engine, true);
+        }
+
+        /// <summary>
+        /// An internal representation of `destroy` method that destroys a contract.
+        /// </summary>
+        /// <param name="engine">The engine used to write data.</param>
+        /// <param name="blockBeforeErase">Denotes whether the contract account blocking should happen before the contract state and storage items removal from the storage.</param>
+        private async ContractTask DestroyInternal(ApplicationEngine engine, bool blockBeforeErase)
         {
             UInt160 hash = engine.CallingScriptHash!;
             StorageKey ckey = CreateStorageKey(Prefix_Contract, hash);
             ContractState? contract = engine.SnapshotCache.TryGet(ckey)?.GetInteroperable<ContractState>(false);
             if (contract is null) return;
+
+            if (blockBeforeErase)
+            {
+                // Lock contract (and allow to receive an unclaimed GAS after votes revoke, if so,
+                // because the contract is not yet removed from the snapshot).
+                await Policy.BlockAccountInternal(engine, hash);
+                // Clean whitelist (emit event if exists with the old manifest information).
+                Policy.CleanWhitelist(engine, contract);
+            }
+
             engine.SnapshotCache.Delete(ckey);
             engine.SnapshotCache.Delete(CreateStorageKey(Prefix_ContractHash, contract.Id));
             foreach (var (key, _) in engine.SnapshotCache.Find(StorageKey.CreateSearchPrefix(contract.Id, ReadOnlySpan<byte>.Empty)))
                 engine.SnapshotCache.Delete(key);
-            // lock contract
-            await Policy.BlockAccountInternal(engine, hash);
-            // Clean whitelist (emit event if exists with the old manifest information)
-            Policy.CleanWhitelist(engine, contract);
-            // emit event
+
+            if (!blockBeforeErase)
+            {
+                // Lock contract (and skip any side calls like onNEP17Payment on votes revoke
+                // because the contract is already removed from the snapshot).
+                await Policy.BlockAccountInternal(engine, hash);
+                // Clean whitelist (emit event if exists with the old manifest information).
+                Policy.CleanWhitelist(engine, contract);
+            }
+
+            // Emit event.
             engine.SendNotification(Hash, "Destroy", new Array(engine.ReferenceCounter) { hash.ToArray() });
         }
     }


### PR DESCRIPTION
# Description

During contract destruction we call Policy.BlockAccountInternal. Policy.BlockAccountInternal performs votes revoking starting from #4347, which may trigger an unclaimed GAS distribution to the contract account. If a contract is removed from the snapshot by this moment, then no onNEP17Payment call may happen, although technically the contract should be considered as "still living" for proper GAS distribution processing.

So it's more correct to remove contract and its storage items from the snapshot *after* its account is blocked by Policy. Ref. https://github.com/nspcc-dev/neo-go/pull/4233.

# Change Log

- `destroy` method of native `ContractManagement` is updated starting from Gorgon hardfork.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Unit Testing
- [ ] Run Application
- [ ] Local Computer Tests
- [X] No Testing (tested via unit-test in https://github.com/nspcc-dev/neo-go/pull/4233, it's easier to deploy such contract in `neotest` and check the behaviour).


# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
