### PR TITLE
SmartContract: move `Crypto.VerifySignature[V0]` switch under `Gorgon`

### DIFF
--- a/src/Neo/SmartContract/ApplicationEngine.Crypto.cs
+++ b/src/Neo/SmartContract/ApplicationEngine.Crypto.cs
@@ -45,7 +45,9 @@ namespace Neo.SmartContract
         /// <returns><see langword="true"/> if the signature is valid; otherwise, <see langword="false"/>.</returns>
         protected internal bool CheckSig(byte[] pubkey, byte[] signature)
         {
-            return Crypto.VerifySignature(ScriptContainer!.GetSignData(ProtocolSettings.Network), signature, pubkey, ECCurve.Secp256r1);
+            if (IsHardforkEnabled(Hardfork.HF_Gorgon))
+                return Crypto.VerifySignature(ScriptContainer!.GetSignData(ProtocolSettings.Network), signature, pubkey, ECCurve.Secp256r1);
+            return Crypto.VerifySignatureV0(ScriptContainer!.GetSignData(ProtocolSettings.Network), signature, pubkey, ECCurve.Secp256r1);
         }
 
         /// <summary>
@@ -63,9 +65,11 @@ namespace Neo.SmartContract
             if (m == 0) throw new ArgumentException("signatures array cannot be empty.");
             if (m > n) throw new ArgumentException($"signatures count ({m}) cannot be greater than pubkeys count ({n}).");
             AddFee(CheckSigPrice * n * _execFeeFactor);
+            var isGorgon = IsHardforkEnabled(Hardfork.HF_Gorgon);
             for (int i = 0, j = 0; i < m && j < n;)
             {
-                if (Crypto.VerifySignature(message, signatures[i], pubkeys[j], ECCurve.Secp256r1))
+                var ok = isGorgon ? Crypto.VerifySignature(message, signatures[i], pubkeys[j], ECCurve.Secp256r1) : Crypto.VerifySignatureV0(message, signatures[i], pubkeys[j], ECCurve.Secp256r1);
+                if (ok)
                     i++;
                 j++;
                 if (m - i > n - j)


### PR DESCRIPTION
# Description

https://github.com/neo-project/neo/pull/4449 changed the behaviour of Crypto.VerifySignature method to throw an exception in case of invalid signature length. The users of Crypto.VerifySignature are:
1. Transaction's VerifyStateIndependent method: https://github.com/neo-project/neo/blob/43e66b82751bbc7f84689a68f4991b274174ddb5/src/Neo/Network/P2P/Payloads/Transaction.cs#L392 https://github.com/neo-project/neo/blob/43e66b82751bbc7f84689a68f4991b274174ddb5/src/Neo/Network/P2P/Payloads/Transaction.cs#L409 It wraps the call into try-catch block, so not affected by this change.
2. ContractGroup's IsValid method: https://github.com/neo-project/neo/blob/43e66b82751bbc7f84689a68f4991b274174ddb5/src/Neo/SmartContract/Manifest/ContractGroup.cs#L75 which is only called by native ContractManagement's on deploy/update. Hence contract groups are marshalled from JSON manifest, signature is always guaranteed to have valid length by this check: https://github.com/neo-project/neo/blob/43e66b82751bbc7f84689a68f4991b274174ddb5/src/Neo/SmartContract/Manifest/ContractGroup.cs#L63
3. Native Notary's `verify` method: https://github.com/neo-project/neo/blob/43e66b82751bbc7f84689a68f4991b274174ddb5/src/Neo/SmartContract/Native/Notary.cs#L134 which is only called in transaction verification context, in which there's no difference if verification returns false or fails.
4. CryptoLib's `verifyWithECDsa` method which was already moved under Gorgon hardfork to switch between two implementations of Crypto.VerifySignature.
5. System.Crypto.CheckSig and System.Crypto.CheckMultisig interops: https://github.com/neo-project/neo/blob/43e66b82751bbc7f84689a68f4991b274174ddb5/src/Neo/SmartContract/ApplicationEngine.Crypto.cs#L48 https://github.com/neo-project/neo/blob/43e66b82751bbc7f84689a68f4991b274174ddb5/src/Neo/SmartContract/ApplicationEngine.Crypto.cs#L68 which may be used by smart contracts in their scripts.

From this list, only case 5 has a potential to introduce state difference if used in raw transaction script. Despite the fact that Owen checked the node states after #4449 and found no diff, it's extremely easy to trigger such execution and introduce this diff. That's why case 5 is moved under Gorgon.

Discovered during porting https://github.com/nspcc-dev/neo-go/pull/4236.

# Change Log

- Move switch between `Crypto.VerifySignature` and `Crypto.VerifySignatureV0` under Gorgon fork.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Unit Testing
- [ ] Run Application
- [ ] Local Computer Tests
- [X] No Testing


# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
