### PR TITLE
[N3] - Update github actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
     continue-on-error: true
     steps:
     - name: Checkout
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
     - name: Setup .NET
       uses: actions/setup-dotnet@v5
       with:
@@ -36,13 +36,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
     - name: Setup .NET
       uses: actions/setup-dotnet@v5
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
     - name: Cache NuGet packages
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.nuget/packages
         key         : ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
@@ -61,7 +61,7 @@ jobs:
         dotnet test /p:GITHUB_ACTIONS=true /p:CollectCoverage=true /p:CoverletOutput='${{ github.workspace }}/TestResults/coverage/' /p:MergeWith='${{ github.workspace }}/TestResults/coverage/coverage.json' /p:CoverletOutputFormat=\"lcov,json\" -m:1
     - name: Codecov
       if: matrix.os == 'ubuntu-latest'
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v6
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: ${{ github.workspace }}/TestResults/coverage/coverage.info
@@ -73,7 +73,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
     - name: Setup .NET Core
@@ -95,7 +95,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
     - name: Get version
       id: get_version
       run: |

--- a/.github/workflows/pkgs-delete.yml
+++ b/.github/workflows/pkgs-delete.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
     - name: Delete Neo Package (docker)
-      uses: actions/delete-package-versions@v4
+      uses: actions/delete-package-versions@v5
       continue-on-error: true
       with:
         package-name: Neo
@@ -47,7 +47,7 @@ jobs:
 
     steps:
     - name: Delete ${{ matrix.pkgs }} Package
-      uses: actions/delete-package-versions@v4
+      uses: actions/delete-package-versions@v5
       continue-on-error: true
       with:
         package-name: ${{ matrix.pkgs }}


### PR DESCRIPTION
## Summary

Updates GitHub Actions

## Changes

- Updated `actions/checkout` from `v5` to `v6`.
- Updated `actions/cache` from `v4` to `v5`.
- Updated `codecov/codecov-action` from `v5` to `v6`.
- Updated `actions/delete-package-versions` from `v4` to `v5`.

