### PR TITLE
[N4] - Update github actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
     - name: Cache NuGet packages
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.nuget/packages
         key         : ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
@@ -61,7 +61,7 @@ jobs:
         dotnet test /p:GITHUB_ACTIONS=true /p:CollectCoverage=true /p:CoverletOutput='${{ github.workspace }}/TestResults/coverage/' /p:MergeWith='${{ github.workspace }}/TestResults/coverage/coverage.json' /p:CoverletOutputFormat=\"lcov,json\" -m:1
     - name: Codecov
       if: matrix.os == 'ubuntu-latest'
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v6
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: ${{ github.workspace }}/TestResults/coverage/coverage.info

--- a/.github/workflows/pkgs-delete.yml
+++ b/.github/workflows/pkgs-delete.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
     - name: Delete Neo Package (docker)
-      uses: actions/delete-package-versions@v4
+      uses: actions/delete-package-versions@v5
       continue-on-error: true
       with:
         package-name: Neo


### PR DESCRIPTION
## Summary

Updates GitHub Actions

## Changes

- Updated `actions/cache` from `v4` to `v5`.
- Updated `codecov/codecov-action` from `v5` to `v6`.
- Updated `actions/delete-package-versions` from `v4` to `v5`.