### PR TITLE
Fix routing table closest-node selection

### DIFF
--- a/src/Neo/Network/P2P/RoutingTable.cs
+++ b/src/Neo/Network/P2P/RoutingTable.cs
@@ -122,9 +122,7 @@ public sealed class RoutingTable
         ArgumentOutOfRangeException.ThrowIfNegative(count);
         if (count == 0) return Array.Empty<NodeContact>();
 
-        var candidates = new List<NodeContact>();
-        foreach (var contact in EnumerateAllContacts())
-            candidates.Add(contact);
+        var candidates = EnumerateAllContacts().ToList();
 
         // Sort by XOR distance to target.
         candidates.Sort((a, b) => CompareDistance(a.NodeId, b.NodeId, targetId));

--- a/src/Neo/Network/P2P/RoutingTable.cs
+++ b/src/Neo/Network/P2P/RoutingTable.cs
@@ -122,12 +122,9 @@ public sealed class RoutingTable
         ArgumentOutOfRangeException.ThrowIfNegative(count);
         if (count == 0) return Array.Empty<NodeContact>();
 
-        // Start from the bucket corresponding to target distance, then expand outward.
-        int start = GetBucketIndex(targetId);
-        if (start < 0) start = 0;
-
-        var candidates = new List<NodeContact>(Math.Min(count * 3, BucketSize * 8));
-        CollectFromBuckets(start, candidates, hardLimit: Math.Max(count * 8, BucketSize * 8));
+        var candidates = new List<NodeContact>();
+        foreach (var contact in EnumerateAllContacts())
+            candidates.Add(contact);
 
         // Sort by XOR distance to target.
         candidates.Sort((a, b) => CompareDistance(a.NodeId, b.NodeId, targetId));
@@ -174,34 +171,6 @@ public sealed class RoutingTable
             }
         }
         return list;
-    }
-
-    void CollectFromBuckets(int start, List<NodeContact> output, int hardLimit)
-    {
-        void AddRange(int bucketIndex)
-        {
-            lock (_buckets[bucketIndex])
-                foreach (var c in _buckets[bucketIndex].Contacts)
-                {
-                    output.Add(c);
-                    if (output.Count >= hardLimit) return;
-                }
-        }
-
-        AddRange(start);
-        if (output.Count >= hardLimit) return;
-
-        for (int step = 1; step < IdBits; step++)
-        {
-            int left = start - step;
-            int right = start + step;
-
-            if (left >= 0) AddRange(left);
-            if (output.Count >= hardLimit) break;
-            if (right < IdBits) AddRange(right);
-            if (output.Count >= hardLimit) break;
-            if (left < 0 && right >= IdBits) break;
-        }
     }
 
     IEnumerable<NodeContact> EnumerateAllContacts()

--- a/tests/Neo.UnitTests/Network/P2P/UT_RoutingTable.cs
+++ b/tests/Neo.UnitTests/Network/P2P/UT_RoutingTable.cs
@@ -1,0 +1,72 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// UT_RoutingTable.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Neo.Network.P2P;
+using System.Net;
+
+namespace Neo.UnitTests.Network.P2P;
+
+[TestClass]
+public class UT_RoutingTable
+{
+    [TestMethod]
+    public void FindClosest_ReturnsContactsOrderedByXorDistance()
+    {
+        var table = new RoutingTable(UInt256.Zero, bucketSize: 2, replacementSize: 0, badThreshold: 1);
+        UInt256 target = UInt256.Zero;
+
+        Add(table, WithBit(3), 10003);
+        Add(table, WithBit(1), 10001);
+        Add(table, WithBit(2), 10002);
+        Add(table, WithBit(0), 10000);
+
+        IReadOnlyList<NodeContact> result = table.FindClosest(target, 3);
+
+        Assert.HasCount(3, result);
+        Assert.AreEqual(WithBit(0), result[0].NodeId);
+        Assert.AreEqual(WithBit(1), result[1].NodeId);
+        Assert.AreEqual(WithBit(2), result[2].NodeId);
+    }
+
+    [TestMethod]
+    public void FindClosest_ConsidersAllBucketsWhenLowerBucketIsCloser()
+    {
+        var table = new RoutingTable(UInt256.Zero, bucketSize: 1, replacementSize: 0, badThreshold: 1);
+        UInt256 target = WithBit(128);
+        UInt256 closest = WithBit(0);
+
+        for (int bit = 127; bit >= 124; bit--)
+            Add(table, WithBit(bit), 10000 + bit);
+        for (int bit = 129; bit <= 132; bit++)
+            Add(table, WithBit(bit), 10000 + bit);
+        Add(table, closest, 10000);
+
+        IReadOnlyList<NodeContact> result = table.FindClosest(target, 1);
+
+        Assert.HasCount(1, result);
+        Assert.AreEqual(closest, result[0].NodeId);
+    }
+
+    private static void Add(RoutingTable table, UInt256 nodeId, int port)
+    {
+        table.Update(nodeId, new OverlayEndpoint(
+            TransportProtocol.Tcp,
+            new IPEndPoint(IPAddress.Loopback, port),
+            EndpointKind.Observed));
+    }
+
+    private static UInt256 WithBit(int bit)
+    {
+        var bytes = new byte[UInt256.Length];
+        bytes[bit / 8] = (byte)(1 << (bit % 8));
+        return new UInt256(bytes);
+    }
+}


### PR DESCRIPTION
## Summary
- Correct DHT routing table closest-node selection to sort all known contacts by XOR distance before applying the requested count.
- Add routing table coverage for XOR-distance ordering across buckets.

## Testing
- dotnet test tests/Neo.UnitTests/Neo.UnitTests.csproj --configuration Release --no-restore --filter "FullyQualifiedName~UT_RoutingTable" --verbosity minimal --disable-build-servers
- dotnet test tests/Neo.UnitTests/Neo.UnitTests.csproj --configuration Release --no-restore --filter "FullyQualifiedName~Network.P2P" --verbosity minimal --disable-build-servers
- dotnet test tests/Neo.UnitTests/Neo.UnitTests.csproj --configuration Release --no-restore --verbosity minimal --disable-build-servers
- dotnet format src/Neo/Neo.csproj --verify-no-changes --no-restore --verbosity minimal
- dotnet format tests/Neo.UnitTests/Neo.UnitTests.csproj --verify-no-changes --no-restore --verbosity minimal
- git diff --check