### PR TITLE
Backport DHT routing support to master-n3

### DIFF
--- a/src/Neo/NeoSystem.cs
+++ b/src/Neo/NeoSystem.cs
@@ -21,6 +21,7 @@ using Neo.Plugins;
 using Neo.SmartContract;
 using Neo.SmartContract.Native;
 using Neo.VM;
+using Neo.Wallets;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -124,9 +125,10 @@ namespace Neo
         /// The path of the storage.
         /// If <paramref name="storageProvider"/> is the default in-memory storage engine, this parameter is ignored.
         /// </param>
-        public NeoSystem(ProtocolSettings settings, string? storageProvider = null, string? storagePath = null) :
+        /// <param name="nodeKey">The <see cref="KeyPair"/> of the node.</param>
+        public NeoSystem(ProtocolSettings settings, string? storageProvider = null, string? storagePath = null, KeyPair? nodeKey = null) :
             this(settings, StoreFactory.GetStoreProvider(storageProvider ?? nameof(MemoryStore))
-                ?? throw new ArgumentException($"Can't find the storage provider {storageProvider}", nameof(storageProvider)), storagePath)
+                ?? throw new ArgumentException($"Can't find the storage provider {storageProvider}", nameof(storageProvider)), storagePath, nodeKey)
         {
         }
 
@@ -139,7 +141,8 @@ namespace Neo
         /// The path of the storage.
         /// If <paramref name="storageProvider"/> is the default in-memory storage engine, this parameter is ignored.
         /// </param>
-        public NeoSystem(ProtocolSettings settings, IStoreProvider storageProvider, string? storagePath = null)
+        /// <param name="nodeKey">The <see cref="KeyPair"/> of the node.</param>
+        public NeoSystem(ProtocolSettings settings, IStoreProvider storageProvider, string? storagePath = null, KeyPair? nodeKey = null)
         {
             Settings = settings;
             GenesisBlock = CreateGenesisBlock(settings);
@@ -147,7 +150,7 @@ namespace Neo
             _store = storageProvider.GetStore(storagePath);
             MemPool = new MemoryPool(this);
             Blockchain = ActorSystem.ActorOf(Ledger.Blockchain.Props(this));
-            LocalNode = ActorSystem.ActorOf(Network.P2P.LocalNode.Props(this));
+            LocalNode = ActorSystem.ActorOf(Network.P2P.LocalNode.Props(this, nodeKey ?? new()));
             TaskManager = ActorSystem.ActorOf(Network.P2P.TaskManager.Props(this));
             TxRouter = ActorSystem.ActorOf(TransactionRouter.Props(this));
             foreach (var plugin in Plugin.Plugins)

--- a/src/Neo/Network/P2P/Connection.cs
+++ b/src/Neo/Network/P2P/Connection.cs
@@ -22,7 +22,7 @@ namespace Neo.Network.P2P
     /// </summary>
     public abstract class Connection : UntypedActor
     {
-        internal class Close { public bool Abort; }
+        internal class Close { public DisconnectReason Reason; }
         internal class Ack : Tcp.Event { public static Ack Instance = new(); }
 
         /// <summary>
@@ -59,7 +59,7 @@ namespace Neo.Network.P2P
         {
             Remote = remote;
             Local = local;
-            timer = Context.System.Scheduler.ScheduleTellOnceCancelable(TimeSpan.FromSeconds(connectionTimeoutLimitStart), Self, new Close { Abort = true }, ActorRefs.NoSender);
+            timer = Context.System.Scheduler.ScheduleTellOnceCancelable(TimeSpan.FromSeconds(connectionTimeoutLimitStart), Self, new Close { Reason = DisconnectReason.Timeout }, ActorRefs.NoSender);
             switch (connection)
             {
                 case IActorRef tcp:
@@ -71,14 +71,12 @@ namespace Neo.Network.P2P
         /// <summary>
         /// Disconnect from the remote node.
         /// </summary>
-        /// <param name="abort">Indicates whether the TCP ABORT command should be sent.</param>
-        public void Disconnect(bool abort = false)
+        /// <param name="reason">The reason for the disconnection.</param>
+        public void Disconnect(DisconnectReason reason = DisconnectReason.Close)
         {
             disconnected = true;
-            if (tcp != null)
-            {
-                tcp.Tell(abort ? Tcp.Abort.Instance : Tcp.Close.Instance);
-            }
+            tcp?.Tell(reason == DisconnectReason.Close ? Tcp.Close.Instance : Tcp.Abort.Instance);
+            OnDisconnect(reason);
             Context.Stop(Self);
         }
 
@@ -86,6 +84,16 @@ namespace Neo.Network.P2P
         /// Called when a TCP ACK message is received.
         /// </summary>
         protected virtual void OnAck()
+        {
+        }
+
+        /// <summary>
+        /// Invoked when a disconnect operation occurs, allowing derived classes to handle cleanup or custom logic.
+        /// </summary>
+        /// <remarks>Override this method in a derived class to implement custom behavior when a disconnect
+        /// occurs. This method is called regardless of whether the disconnect is graceful or due to an abort.</remarks>
+        /// <param name="reason">The reason for the disconnection.</param>
+        protected virtual void OnDisconnect(DisconnectReason reason)
         {
         }
 
@@ -100,7 +108,7 @@ namespace Neo.Network.P2P
             switch (message)
             {
                 case Close close:
-                    Disconnect(close.Abort);
+                    Disconnect(close.Reason);
                     break;
                 case Ack _:
                     OnAck();
@@ -117,8 +125,8 @@ namespace Neo.Network.P2P
         private void OnReceived(ByteString data)
         {
             timer.CancelIfNotNull();
-            timer = Context.System.Scheduler.ScheduleTellOnceCancelable(TimeSpan.FromSeconds(connectionTimeoutLimit), Self, new Close { Abort = true }, ActorRefs.NoSender);
-            data.TryCatch<ByteString, Exception>(OnData, (_, _) => Disconnect(true));
+            timer = Context.System.Scheduler.ScheduleTellOnceCancelable(TimeSpan.FromSeconds(connectionTimeoutLimit), Self, new Close { Reason = DisconnectReason.Timeout }, ActorRefs.NoSender);
+            data.TryCatch<ByteString, Exception>(OnData, (_, _) => Disconnect(DisconnectReason.ProtocolViolation));
         }
 
         protected override void PostStop()
@@ -135,10 +143,7 @@ namespace Neo.Network.P2P
         /// <param name="data"></param>
         protected void SendData(ByteString data)
         {
-            if (tcp != null)
-            {
-                tcp.Tell(Tcp.Write.Create(data, Ack.Instance));
-            }
+            tcp?.Tell(Tcp.Write.Create(data, Ack.Instance));
         }
     }
 }

--- a/src/Neo/Network/P2P/DisconnectReason.cs
+++ b/src/Neo/Network/P2P/DisconnectReason.cs
@@ -1,0 +1,40 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// DisconnectReason.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+namespace Neo.Network.P2P
+{
+    /// <summary>
+    /// Specifies the reason for a disconnection event in a network or communication context.
+    /// </summary>
+    /// <remarks>Use this enumeration to determine why a connection was terminated.</remarks>
+    public enum DisconnectReason
+    {
+        /// <summary>
+        /// No specific reason for disconnection.
+        /// </summary>
+        None,
+
+        /// <summary>
+        /// The connection was closed normally.
+        /// </summary>
+        Close,
+
+        /// <summary>
+        /// The connection was closed due to a timeout.
+        /// </summary>
+        Timeout,
+
+        /// <summary>
+        /// The connection was closed due to a protocol violation.
+        /// </summary>
+        ProtocolViolation
+    }
+}

--- a/src/Neo/Network/P2P/EndpointKind.cs
+++ b/src/Neo/Network/P2P/EndpointKind.cs
@@ -1,0 +1,59 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// EndpointKind.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using System;
+
+namespace Neo.Network.P2P
+{
+    /// <summary>
+    /// Describes how an overlay endpoint was learned and how it should be used.
+    /// </summary>
+    [Flags]
+    public enum EndpointKind : byte
+    {
+        /// <summary>
+        /// The endpoint was observed as the remote endpoint of an incoming or
+        /// outgoing connection.
+        /// This usually represents a NAT-mapped or ephemeral public endpoint and
+        /// should NOT be treated as a reliable dial target.
+        /// </summary>
+        Observed = 1,
+
+        /// <summary>
+        /// The endpoint was explicitly advertised by the peer itself, typically
+        /// via protocol handshake metadata (e.g., Version/Listener port).
+        ///
+        /// Advertised endpoints indicate that the peer claims to be listening
+        /// for incoming connections on this address and port.
+        ///
+        /// Actual reachability is still validated through success/failure tracking.
+        /// </summary>
+        Advertised = 2,
+
+        /// <summary>
+        /// The endpoint was derived indirectly rather than directly observed or
+        /// self-advertised.
+        ///
+        /// Derived endpoints usually require validation before being trusted for
+        /// active communication.
+        /// </summary>
+        Derived = 4,
+
+        /// <summary>
+        /// The endpoint represents a relay or intermediary rather than a direct
+        /// network address of the target node.
+        ///
+        /// Relay endpoints are never used for direct dialing and require
+        /// protocol-specific relay support.
+        /// </summary>
+        Relay = 8
+    }
+}

--- a/src/Neo/Network/P2P/Helper.cs
+++ b/src/Neo/Network/P2P/Helper.cs
@@ -10,6 +10,8 @@
 // modifications are permitted.
 
 using Neo.Cryptography;
+using Neo.Cryptography.ECC;
+using Neo.Extensions;
 using Neo.Network.P2P.Payloads;
 using System;
 using System.Buffers.Binary;
@@ -93,6 +95,26 @@ namespace Neo.Network.P2P
             messageHash.Serialize(buffer.AsSpan(sizeof(uint)));
 
             return buffer;
+        }
+
+        /// <summary>
+        /// Computes a unique node identifier based on the specified public key and protocol settings.
+        /// </summary>
+        /// <remarks>The returned node identifier is deterministic for a given public key and protocol settings.
+        /// This method is typically used to generate consistent node IDs for distributed hash table (DHT) operations in the
+        /// NEO network.</remarks>
+        /// <param name="pubkey">The public key of the node for which to generate the identifier.</param>
+        /// <param name="protocol">The protocol settings that provide network-specific information used in the identifier calculation.</param>
+        /// <returns>A 256-bit hash value that uniquely identifies the node within the specified network.</returns>
+        public static UInt256 GetNodeId(this ECPoint pubkey, ProtocolSettings protocol)
+        {
+            const string prefix = "NEO_DHT_NODEID";
+            using var ms = new MemoryStream();
+            using var writer = new BinaryWriter(ms);
+            writer.WriteFixedString(prefix, prefix.Length);
+            writer.Write(protocol.Network);
+            writer.Write(pubkey);
+            return Crypto.Hash256(ms.ToArray());
         }
     }
 }

--- a/src/Neo/Network/P2P/KBucket.cs
+++ b/src/Neo/Network/P2P/KBucket.cs
@@ -1,0 +1,196 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// KBucket.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Neo.Network.P2P
+{
+    /// <summary>
+    /// A Kademlia-style k-bucket: stores up to <see cref="Capacity"/> contacts in LRU order.
+    /// </summary>
+    sealed class KBucket
+    {
+        private readonly LinkedList<NodeContact> _lru = new();
+        private readonly Dictionary<UInt256, LinkedListNode<NodeContact>> _index = new();
+
+        // Replacement cache: best-effort candidates when the bucket is full.
+        private readonly LinkedList<NodeContact> _replacements = new();
+        private readonly Dictionary<UInt256, LinkedListNode<NodeContact>> _repIndex = new();
+
+        public int Capacity { get; }
+        public int ReplacementCapacity { get; }
+        public int BadThreshold { get; }
+        public int Count => _lru.Count;
+        public IReadOnlyCollection<NodeContact> Contacts => _lru;
+
+        public KBucket(int capacity, int replacementCapacity, int badThreshold)
+        {
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(capacity);
+            ArgumentOutOfRangeException.ThrowIfNegative(replacementCapacity);
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(badThreshold);
+            Capacity = capacity;
+            ReplacementCapacity = replacementCapacity;
+            BadThreshold = badThreshold;
+        }
+
+        public bool TryGet(UInt256 nodeId, [NotNullWhen(true)] out NodeContact? contact)
+        {
+            if (_index.TryGetValue(nodeId, out var node))
+            {
+                contact = node.Value;
+                return true;
+            }
+            contact = null;
+            return false;
+        }
+
+        /// <summary>
+        /// Updates LRU position and contact metadata. If bucket is full and the node is new,
+        /// the node is placed into replacement cache.
+        /// </summary>
+        /// <returns>
+        /// True if the contact ended up in the main bucket; false if it was cached as a replacement.
+        /// </returns>
+        public bool Update(NodeContact incoming)
+        {
+            if (_index.TryGetValue(incoming.NodeId, out var existingNode))
+            {
+                Merge(existingNode.Value, incoming);
+                Touch(existingNode);
+                return true;
+            }
+
+            if (_lru.Count < Capacity)
+            {
+                var node = _lru.AddLast(incoming);
+                _index[incoming.NodeId] = node;
+                return true;
+            }
+
+            // Bucket full: keep as replacement candidate.
+            AddOrUpdateReplacement(incoming);
+            return false;
+        }
+
+        public void MarkSuccess(UInt256 nodeId)
+        {
+            if (_index.TryGetValue(nodeId, out var node))
+            {
+                node.Value.FailCount = 0;
+                node.Value.LastSeen = TimeProvider.Current.UtcNow;
+                Touch(node);
+                return;
+            }
+
+            // If it was only a replacement, promote its freshness.
+            if (_repIndex.TryGetValue(nodeId, out var repNode))
+            {
+                repNode.Value.FailCount = 0;
+                repNode.Value.LastSeen = TimeProvider.Current.UtcNow;
+                Touch(repNode);
+            }
+        }
+
+        public void MarkFailure(UInt256 nodeId)
+        {
+            if (_index.TryGetValue(nodeId, out var node))
+            {
+                node.Value.FailCount++;
+                if (node.Value.FailCount < BadThreshold) return;
+
+                // Evict bad node and promote best replacement (if any).
+                RemoveFrom(node, _index);
+                PromoteReplacementIfAny();
+            }
+            else if (_repIndex.TryGetValue(nodeId, out var repNode))
+            {
+                // If it is a replacement, decay it and possibly drop.
+                repNode.Value.FailCount++;
+                if (repNode.Value.FailCount >= BadThreshold)
+                    RemoveFrom(repNode, _repIndex);
+            }
+        }
+
+        public void Remove(UInt256 nodeId)
+        {
+            if (_index.TryGetValue(nodeId, out var node))
+            {
+                RemoveFrom(node, _index);
+                PromoteReplacementIfAny();
+            }
+            else if (_repIndex.TryGetValue(nodeId, out var repNode))
+            {
+                RemoveFrom(repNode, _repIndex);
+            }
+        }
+
+        void AddOrUpdateReplacement(NodeContact incoming)
+        {
+            if (_repIndex.TryGetValue(incoming.NodeId, out var existing))
+            {
+                Merge(existing.Value, incoming);
+                Touch(existing);
+                return;
+            }
+
+            if (ReplacementCapacity == 0) return;
+
+            var node = _replacements.AddLast(incoming);
+            _repIndex[incoming.NodeId] = node;
+
+            if (_replacements.Count > ReplacementCapacity)
+            {
+                // Drop oldest replacement.
+                var first = _replacements.First;
+                if (first is not null)
+                    RemoveFrom(first, _repIndex);
+            }
+        }
+
+        void PromoteReplacementIfAny()
+        {
+            if (_lru.Count >= Capacity) return;
+            if (_replacements.Last is null) return;
+
+            // Promote the most recently seen replacement.
+            var rep = _replacements.Last;
+            RemoveFrom(rep, _repIndex);
+            var main = _lru.AddLast(rep.Value);
+            _index[main.Value.NodeId] = main;
+        }
+
+        static void Merge(NodeContact dst, NodeContact src)
+        {
+            // Merge overlay endpoints (preserve transport; merge endpoint kinds).
+            for (int i = 0; i < src.Endpoints.Count; i++)
+                dst.AddOrPromoteEndpoint(src.Endpoints[i]);
+
+            // Prefer latest seen & features.
+            if (src.LastSeen > dst.LastSeen) dst.LastSeen = src.LastSeen;
+            dst.Features |= src.Features;
+        }
+
+        static void Touch(LinkedListNode<NodeContact> node)
+        {
+            var list = node.List!;
+            list.Remove(node);
+            list.AddLast(node);
+        }
+
+        static void RemoveFrom(LinkedListNode<NodeContact> node, Dictionary<UInt256, LinkedListNode<NodeContact>> index)
+        {
+            index.Remove(node.Value.NodeId);
+            node.List!.Remove(node);
+        }
+    }
+}

--- a/src/Neo/Network/P2P/LocalNode.cs
+++ b/src/Neo/Network/P2P/LocalNode.cs
@@ -80,6 +80,11 @@ namespace Neo.Network.P2P
         public UInt256 NodeId { get; }
 
         /// <summary>
+        /// Gets the routing table for the local node.
+        /// </summary>
+        public RoutingTable RoutingTable { get; }
+
+        /// <summary>
         /// The identifier of the client software of the local node.
         /// </summary>
         public static string UserAgent { get; set; }
@@ -99,6 +104,7 @@ namespace Neo.Network.P2P
             this.system = system;
             NodeKey = nodeKey;
             NodeId = nodeKey.PublicKey.GetNodeId(system.Settings);
+            RoutingTable = new RoutingTable(NodeId);
             SeedList = new IPEndPoint[system.Settings.SeedList.Length];
 
             // Start dns resolution in parallel
@@ -159,21 +165,34 @@ namespace Neo.Network.P2P
 
         /// <summary>
         /// Checks the new connection.
-        /// If it is equal to the nonce of local or any remote node, it'll return false,
-        /// else we'll return true and update the Listener address of the connected remote node.
+        /// If it has the same identity as the local node or an existing remote node, it'll return false,
+        /// otherwise it'll return true and update the listener address of the connected remote node.
         /// </summary>
         /// <param name="actor">Remote node actor.</param>
         /// <param name="node">Remote node object.</param>
+        /// <param name="reason">The disconnect reason to use if the connection is not allowed.</param>
         /// <returns><see langword="true"/> if the new connection is allowed; otherwise, <see langword="false"/>.</returns>
-        public bool AllowNewConnection(IActorRef actor, RemoteNode node)
+        public bool AllowNewConnection(IActorRef actor, RemoteNode node, out DisconnectReason reason)
         {
-            if (node.Version!.Network != system.Settings.Network) return false;
-            if (node.Version.NodeId == NodeId) return false;
+            reason = DisconnectReason.None;
+            if (node.Version!.Network != system.Settings.Network)
+            {
+                reason = DisconnectReason.ProtocolViolation;
+                return false;
+            }
+            if (node.Version.NodeId == NodeId)
+            {
+                reason = DisconnectReason.Close;
+                return false;
+            }
 
             // filter duplicate connections
             foreach (var other in RemoteNodes.Values)
                 if (other != node && other.Remote.Address.Equals(node.Remote.Address) && other.Version?.NodeId == node.Version.NodeId)
+                {
+                    reason = DisconnectReason.Close;
                     return false;
+                }
 
             if (node.Remote.Port != node.ListenerTcpPort && node.ListenerTcpPort != 0)
                 ConnectedPeers.TryUpdate(actor, node.Listener, node.Remote);

--- a/src/Neo/Network/P2P/LocalNode.cs
+++ b/src/Neo/Network/P2P/LocalNode.cs
@@ -16,6 +16,7 @@ using Neo.IO;
 using Neo.Network.P2P.Capabilities;
 using Neo.Network.P2P.Payloads;
 using Neo.SmartContract.Native;
+using Neo.Wallets;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -69,9 +70,14 @@ namespace Neo.Network.P2P
         public int UnconnectedCount => UnconnectedPeers.Count;
 
         /// <summary>
-        /// The random number used to identify the local node.
+        /// Gets the cryptographic key pair associated with this node.
         /// </summary>
-        public static readonly uint Nonce;
+        public KeyPair NodeKey { get; }
+
+        /// <summary>
+        /// Gets the unique identifier for the node.
+        /// </summary>
+        public UInt256 NodeId { get; }
 
         /// <summary>
         /// The identifier of the client software of the local node.
@@ -80,7 +86,6 @@ namespace Neo.Network.P2P
 
         static LocalNode()
         {
-            Nonce = RandomNumberFactory.NextUInt32();
             UserAgent = $"/{Assembly.GetExecutingAssembly().GetName().Name}:{Assembly.GetExecutingAssembly().GetName().Version?.ToString(3)}/";
         }
 
@@ -88,9 +93,12 @@ namespace Neo.Network.P2P
         /// Initializes a new instance of the <see cref="LocalNode"/> class.
         /// </summary>
         /// <param name="system">The <see cref="NeoSystem"/> object that contains the <see cref="LocalNode"/>.</param>
-        public LocalNode(NeoSystem system)
+        /// <param name="nodeKey">The <see cref="KeyPair"/> used to identify the local node.</param>
+        public LocalNode(NeoSystem system, KeyPair nodeKey)
         {
             this.system = system;
+            NodeKey = nodeKey;
+            NodeId = nodeKey.PublicKey.GetNodeId(system.Settings);
             SeedList = new IPEndPoint[system.Settings.SeedList.Length];
 
             // Start dns resolution in parallel
@@ -160,11 +168,11 @@ namespace Neo.Network.P2P
         public bool AllowNewConnection(IActorRef actor, RemoteNode node)
         {
             if (node.Version!.Network != system.Settings.Network) return false;
-            if (node.Version.Nonce == Nonce) return false;
+            if (node.Version.NodeId == NodeId) return false;
 
             // filter duplicate connections
             foreach (var other in RemoteNodes.Values)
-                if (other != node && other.Remote.Address.Equals(node.Remote.Address) && other.Version?.Nonce == node.Version.Nonce)
+                if (other != node && other.Remote.Address.Equals(node.Remote.Address) && other.Version?.NodeId == node.Version.NodeId)
                     return false;
 
             if (node.Remote.Port != node.ListenerTcpPort && node.ListenerTcpPort != 0)
@@ -285,10 +293,11 @@ namespace Neo.Network.P2P
         /// Gets a <see cref="Akka.Actor.Props"/> object used for creating the <see cref="LocalNode"/> actor.
         /// </summary>
         /// <param name="system">The <see cref="NeoSystem"/> object that contains the <see cref="LocalNode"/>.</param>
+        /// <param name="nodeKey">The <see cref="KeyPair"/> used to identify the local node.</param>
         /// <returns>The <see cref="Akka.Actor.Props"/> object used for creating the <see cref="LocalNode"/> actor.</returns>
-        public static Props Props(NeoSystem system)
+        public static Props Props(NeoSystem system, KeyPair nodeKey)
         {
-            return Akka.Actor.Props.Create(() => new LocalNode(system));
+            return Akka.Actor.Props.Create(() => new LocalNode(system, nodeKey));
         }
 
         protected override Props ProtocolProps(object connection, IPEndPoint remote, IPEndPoint local)

--- a/src/Neo/Network/P2P/NodeContact.cs
+++ b/src/Neo/Network/P2P/NodeContact.cs
@@ -1,0 +1,121 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// NodeContact.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using System;
+using System.Collections.Generic;
+
+namespace Neo.Network.P2P
+{
+    /// <summary>
+    /// Represents a reachability hint for a DHT node (NOT a live connection).
+    /// </summary>
+    public sealed class NodeContact
+    {
+        const int MaxEndpoints = 4;
+
+        /// <summary>
+        /// The verified DHT node identifier.
+        /// </summary>
+        public UInt256 NodeId { get; }
+
+        /// <summary>
+        /// Known overlay endpoints for contacting the node. The first item is the preferred endpoint.
+        /// </summary>
+        public List<OverlayEndpoint> Endpoints { get; } = new();
+
+        /// <summary>
+        /// Last time we successfully communicated with this node (handshake or DHT message).
+        /// </summary>
+        public DateTime LastSeen { get; internal set; }
+
+        /// <summary>
+        /// Consecutive failures when trying to contact this node.
+        /// </summary>
+        public int FailCount { get; internal set; }
+
+        /// <summary>
+        /// Optional capability flags (reserved).
+        /// </summary>
+        public ulong Features { get; internal set; }
+
+        /// <summary>
+        /// Initializes a new instance of the NodeContact class with the specified node identifier, optional endpoints, and
+        /// feature flags.
+        /// </summary>
+        /// <param name="nodeId">The unique identifier for the node. This value is used to distinguish the node within the network.</param>
+        /// <param name="endpoints">A collection of overlay endpoints associated with the node. If not specified, the contact will have no initial endpoints.</param>
+        /// <param name="features">A bit field representing the features supported by the node. The default is 0, indicating no features.</param>
+        public NodeContact(UInt256 nodeId, IEnumerable<OverlayEndpoint>? endpoints = null, ulong features = 0)
+        {
+            NodeId = nodeId;
+            if (endpoints is not null)
+                foreach (var ep in endpoints)
+                    AddOrPromoteEndpoint(ep);
+            LastSeen = TimeProvider.Current.UtcNow;
+            Features = features;
+        }
+
+        internal void AddOrPromoteEndpoint(OverlayEndpoint endpoint)
+        {
+            // Keep unique endpoints by (Transport, IP, Port); merge kinds when we learn new semantics.
+            int index = Endpoints.IndexOf(endpoint);
+            if (index >= 0)
+            {
+                var merged = Endpoints[index].WithKind(Endpoints[index].Kind | endpoint.Kind);
+                if (index == 0)
+                {
+                    Endpoints[0] = merged;
+                    return;
+                }
+                Endpoints.RemoveAt(index);
+                Endpoints.Insert(0, merged);
+            }
+            else
+            {
+                Endpoints.Insert(0, endpoint);
+                TrimEndpoints();
+            }
+        }
+
+        public override string ToString()
+        {
+            return $"{NodeId} ({(Endpoints.Count > 0 ? Endpoints[0].ToString() : "no-endpoint")})";
+        }
+
+        void TrimEndpoints()
+        {
+            while (Endpoints.Count > MaxEndpoints)
+            {
+                int removeIndex = Endpoints.Count - 1;
+                int worstPriority = GetKindPriority(Endpoints[removeIndex].Kind);
+                for (int i = Endpoints.Count - 2; i >= 0; i--)
+                {
+                    int priority = GetKindPriority(Endpoints[i].Kind);
+                    if (priority < worstPriority)
+                    {
+                        worstPriority = priority;
+                        removeIndex = i;
+                        if (worstPriority == 0) break;
+                    }
+                }
+                Endpoints.RemoveAt(removeIndex);
+            }
+        }
+
+        static int GetKindPriority(EndpointKind kind)
+        {
+            if (kind.HasFlag(EndpointKind.Advertised)) return 3;
+            if (kind.HasFlag(EndpointKind.Observed)) return 2;
+            if (kind.HasFlag(EndpointKind.Derived)) return 1;
+            return 0;
+        }
+    }
+}

--- a/src/Neo/Network/P2P/OverlayEndpoint.cs
+++ b/src/Neo/Network/P2P/OverlayEndpoint.cs
@@ -1,0 +1,107 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// OverlayEndpoint.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using System;
+using System.Net;
+
+namespace Neo.Network.P2P
+{
+    /// <summary>
+    /// An overlay-network endpoint with transport and discovery semantics.
+    /// Equality intentionally ignores <see cref="Kind"/> so that the same transport+ip+port
+    /// can accumulate multiple kinds (e.g., Observed | Advertised).
+    /// </summary>
+    public readonly struct OverlayEndpoint : IEquatable<OverlayEndpoint>
+    {
+        /// <summary>
+        /// The transport protocol used to communicate with this endpoint.
+        /// </summary>
+        public TransportProtocol Transport { get; }
+
+        /// <summary>
+        /// The IP endpoint of this overlay endpoint.
+        /// </summary>
+        public IPEndPoint EndPoint { get; }
+
+        /// <summary>
+        /// The kind of this overlay endpoint.
+        /// </summary>
+        public EndpointKind Kind { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the OverlayEndpoint class with the specified transport protocol, network endpoint,
+        /// and endpoint kind.
+        /// </summary>
+        /// <param name="transport">The transport protocol to use for the overlay endpoint.</param>
+        /// <param name="endPoint">The network endpoint associated with this overlay endpoint.</param>
+        /// <param name="kind">The kind of endpoint represented by this instance.</param>
+        public OverlayEndpoint(TransportProtocol transport, IPEndPoint endPoint, EndpointKind kind)
+        {
+            Transport = transport;
+            EndPoint = endPoint;
+            Kind = kind;
+        }
+
+        /// <summary>
+        /// Returns a new OverlayEndpoint instance with the specified endpoint kind, preserving the existing transport and
+        /// endpoint values.
+        /// </summary>
+        /// <param name="kind">The endpoint kind to associate with the new OverlayEndpoint instance.</param>
+        /// <returns>A new OverlayEndpoint instance with the specified kind. The transport and endpoint values are copied from the
+        /// current instance.</returns>
+        public OverlayEndpoint WithKind(EndpointKind kind) => new(Transport, EndPoint, kind);
+
+        /// <summary>
+        /// Determines whether the current instance and the specified <see cref="OverlayEndpoint"/> are equal.
+        /// </summary>
+        /// <remarks>This method compares the Transport and EndPoint properties for equality. The Kind property is
+        /// not considered in the comparison.</remarks>
+        /// <param name="other">The <see cref="OverlayEndpoint"/> to compare with the current instance.</param>
+        /// <returns><see langword="true"/> if the current instance and <paramref name="other"/> represent the same transport and
+        /// endpoint; otherwise, <see langword="false"/>.</returns>
+        public bool Equals(OverlayEndpoint other)
+        {
+            // NOTE: ignore Kind on purpose
+            return Transport == other.Transport && EndPoint.Equals(other.EndPoint);
+        }
+
+        /// <summary>
+        /// Determines whether the specified object is equal to the current OverlayEndpoint instance.
+        /// </summary>
+        /// <param name="obj">The object to compare with the current OverlayEndpoint instance.</param>
+        /// <returns>true if the specified object is an OverlayEndpoint and is equal to the current instance; otherwise, false.</returns>
+        public override bool Equals(object? obj)
+        {
+            return obj is OverlayEndpoint other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            // NOTE: ignore Kind on purpose
+            return HashCode.Combine(Transport, EndPoint);
+        }
+
+        public override string ToString()
+        {
+            return $"{Transport.ToString().ToLowerInvariant()}:{EndPoint}";
+        }
+
+        public static bool operator ==(OverlayEndpoint left, OverlayEndpoint right)
+        {
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(OverlayEndpoint left, OverlayEndpoint right)
+        {
+            return !(left == right);
+        }
+    }
+}

--- a/src/Neo/Network/P2P/Payloads/VersionPayload.cs
+++ b/src/Neo/Network/P2P/Payloads/VersionPayload.cs
@@ -9,9 +9,9 @@
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
-using Neo.Extensions;
 using Neo.Cryptography;
 using Neo.Cryptography.ECC;
+using Neo.Extensions;
 using Neo.IO;
 using Neo.Network.P2P.Capabilities;
 using Neo.Wallets;

--- a/src/Neo/Network/P2P/Payloads/VersionPayload.cs
+++ b/src/Neo/Network/P2P/Payloads/VersionPayload.cs
@@ -10,8 +10,11 @@
 // modifications are permitted.
 
 using Neo.Extensions;
+using Neo.Cryptography;
+using Neo.Cryptography.ECC;
 using Neo.IO;
 using Neo.Network.P2P.Capabilities;
+using Neo.Wallets;
 using System;
 using System.IO;
 using System.Linq;
@@ -44,9 +47,14 @@ namespace Neo.Network.P2P.Payloads
         public uint Timestamp;
 
         /// <summary>
-        /// A random number used to identify the node.
+        /// Represents the public key associated with this node as an elliptic curve point.
         /// </summary>
-        public uint Nonce;
+        public required ECPoint NodeKey;
+
+        /// <summary>
+        /// Represents the unique identifier for the node as a 256-bit unsigned integer.
+        /// </summary>
+        public required UInt256 NodeId;
 
         /// <summary>
         /// A <see cref="string"/> used to identify the client software of the node.
@@ -63,35 +71,50 @@ namespace Neo.Network.P2P.Payloads
         /// </summary>
         public required NodeCapability[] Capabilities;
 
+        /// <summary>
+        /// The digital signature of the payload.
+        /// </summary>
+        public required byte[] Signature;
+
         public int Size =>
             sizeof(uint) +              // Network
             sizeof(uint) +              // Version
             sizeof(uint) +              // Timestamp
-            sizeof(uint) +              // Nonce
+            NodeKey.Size +              // NodeKey
+            UInt256.Length +            // NodeId
             UserAgent.GetVarSize() +    // UserAgent
-            Capabilities.GetVarSize();  // Capabilities
+            Capabilities.GetVarSize() + // Capabilities
+            Signature.GetVarSize();     // Signature
 
         /// <summary>
         /// Creates a new instance of the <see cref="VersionPayload"/> class.
         /// </summary>
-        /// <param name="network">The magic number of the network.</param>
-        /// <param name="nonce">The random number used to identify the node.</param>
+        /// <param name="protocol">The <see cref="ProtocolSettings"/> of the network.</param>
+        /// <param name="nodeKey">The <see cref="KeyPair"/> used to identify the node.</param>
         /// <param name="userAgent">The <see cref="string"/> used to identify the client software of the node.</param>
         /// <param name="capabilities">The capabilities of the node.</param>
         /// <returns></returns>
-        public static VersionPayload Create(uint network, uint nonce, string userAgent, params NodeCapability[] capabilities)
+        public static VersionPayload Create(ProtocolSettings protocol, KeyPair nodeKey, string userAgent, params NodeCapability[] capabilities)
         {
             var ret = new VersionPayload
             {
-                Network = network,
+                Network = protocol.Network,
                 Version = LocalNode.ProtocolVersion,
                 Timestamp = DateTime.UtcNow.ToTimestamp(),
-                Nonce = nonce,
+                NodeKey = nodeKey.PublicKey,
+                NodeId = nodeKey.PublicKey.GetNodeId(protocol),
                 UserAgent = userAgent,
                 Capabilities = capabilities,
+                Signature = [],
                 // Computed
                 AllowCompression = !capabilities.Any(u => u is DisableCompressionCapability)
             };
+
+            // Generate signature
+            using var ms = new MemoryStream();
+            using var writer = new BinaryWriter(ms);
+            ret.Serialize(writer, false);
+            ret.Signature = Crypto.Sign(ms.ToArray(), nodeKey.PrivateKey);
 
             return ret;
         }
@@ -101,7 +124,8 @@ namespace Neo.Network.P2P.Payloads
             Network = reader.ReadUInt32();
             Version = reader.ReadUInt32();
             Timestamp = reader.ReadUInt32();
-            Nonce = reader.ReadUInt32();
+            NodeKey = reader.ReadSerializable<ECPoint>();
+            NodeId = reader.ReadSerializable<UInt256>();
             UserAgent = reader.ReadVarString(1024);
 
             // Capabilities
@@ -112,17 +136,34 @@ namespace Neo.Network.P2P.Payloads
             if (capabilities.Select(p => p.Type).Distinct().Count() != capabilities.Count())
                 throw new FormatException("Duplicating capabilities are included");
 
+            Signature = reader.ReadVarMemory().ToArray();
             AllowCompression = !capabilities.Any(u => u is DisableCompressionCapability);
         }
 
         void ISerializable.Serialize(BinaryWriter writer)
         {
+            Serialize(writer, true);
+        }
+
+        void Serialize(BinaryWriter writer, bool withSignature)
+        {
             writer.Write(Network);
             writer.Write(Version);
             writer.Write(Timestamp);
-            writer.Write(Nonce);
+            writer.Write(NodeKey);
+            writer.Write(NodeId);
             writer.WriteVarString(UserAgent);
             writer.Write(Capabilities);
+            if (withSignature) writer.WriteVarBytes(Signature);
+        }
+
+        public bool Verify(ProtocolSettings protocol)
+        {
+            if (NodeId != NodeKey.GetNodeId(protocol)) return false;
+            using var ms = new MemoryStream();
+            using var writer = new BinaryWriter(ms);
+            Serialize(writer, false);
+            return Crypto.VerifySignature(ms.ToArray(), Signature, NodeKey);
         }
     }
 }

--- a/src/Neo/Network/P2P/RemoteNode.ProtocolHandler.cs
+++ b/src/Neo/Network/P2P/RemoteNode.ProtocolHandler.cs
@@ -378,18 +378,39 @@ namespace Neo.Network.P2P
         private void OnPingMessageReceived(PingPayload payload)
         {
             UpdateLastBlockIndex(payload.LastBlockIndex);
+
+            // Refresh routing table liveness on inbound Ping.
+            _localNode.RoutingTable.MarkSuccess(Version!.NodeId);
+
             EnqueueMessage(Message.Create(MessageCommand.Pong, PingPayload.Create(NativeContract.Ledger.CurrentIndex(_system.StoreView), payload.Nonce)));
         }
 
         private void OnPongMessageReceived(PingPayload payload)
         {
             UpdateLastBlockIndex(payload.LastBlockIndex);
+
+            // DHT: Pong means our probe succeeded, strongly refresh liveness.
+            _localNode.RoutingTable.MarkSuccess(Version!.NodeId);
         }
 
         private void OnVerackMessageReceived()
         {
             _verack = true;
             _system.TaskManager.Tell(new TaskManager.Register(Version!));
+
+            // DHT: a verack means the handshake is complete and the remote identity (NodeId) has been verified.
+            // Feed the remote contact into the local RoutingTable.
+            var nodeId = Version!.NodeId;
+
+            // Record both:
+            //  - Observed endpoint: what we actually connected to (may be NAT-mapped; not necessarily dialable)
+            //  - Advertised endpoint: what the peer claims to be listening on (dialable candidate)
+            _localNode.RoutingTable.Update(nodeId, new OverlayEndpoint(TransportProtocol.Tcp, Remote, EndpointKind.Observed));
+            if (ListenerTcpPort > 0)
+                _localNode.RoutingTable.Update(nodeId, new OverlayEndpoint(TransportProtocol.Tcp, Listener, EndpointKind.Advertised));
+
+            _localNode.RoutingTable.MarkSuccess(nodeId);
+
             CheckMessageQueue();
         }
 
@@ -411,9 +432,9 @@ namespace Neo.Network.P2P
                         break;
                 }
             }
-            if (!_localNode.AllowNewConnection(Self, this))
+            if (!_localNode.AllowNewConnection(Self, this, out DisconnectReason reason))
             {
-                Disconnect(true);
+                Disconnect(reason);
                 return;
             }
             SendMessage(Message.Create(MessageCommand.Verack));

--- a/src/Neo/Network/P2P/RemoteNode.ProtocolHandler.cs
+++ b/src/Neo/Network/P2P/RemoteNode.ProtocolHandler.cs
@@ -395,6 +395,7 @@ namespace Neo.Network.P2P
 
         private void OnVersionMessageReceived(VersionPayload payload)
         {
+            if (!payload.Verify(_system.Settings)) throw new ProtocolViolationException();
             Version = payload;
             foreach (NodeCapability capability in payload.Capabilities)
             {

--- a/src/Neo/Network/P2P/RemoteNode.cs
+++ b/src/Neo/Network/P2P/RemoteNode.cs
@@ -140,6 +140,12 @@ namespace Neo.Network.P2P
             CheckMessageQueue();
         }
 
+        protected override void OnDisconnect(DisconnectReason reason)
+        {
+            if (reason != DisconnectReason.Close && Version != null)
+                _localNode.RoutingTable.MarkFailure(Version.NodeId);
+        }
+
         protected override void OnData(ByteString data)
         {
             _messageBuffer = _messageBuffer.Concat(data);

--- a/src/Neo/Network/P2P/RemoteNode.cs
+++ b/src/Neo/Network/P2P/RemoteNode.cs
@@ -202,7 +202,7 @@ namespace Neo.Network.P2P
 
         private void OnStartProtocol()
         {
-            SendMessage(Message.Create(MessageCommand.Version, VersionPayload.Create(_system.Settings.Network, LocalNode.Nonce, LocalNode.UserAgent, _localNode.GetNodeCapabilities())));
+            SendMessage(Message.Create(MessageCommand.Version, VersionPayload.Create(_system.Settings, _localNode.NodeKey, LocalNode.UserAgent, _localNode.GetNodeCapabilities())));
         }
 
         protected override void PostStop()

--- a/src/Neo/Network/P2P/RoutingTable.cs
+++ b/src/Neo/Network/P2P/RoutingTable.cs
@@ -125,12 +125,9 @@ namespace Neo.Network.P2P
             ArgumentOutOfRangeException.ThrowIfNegative(count);
             if (count == 0) return Array.Empty<NodeContact>();
 
-            // Start from the bucket corresponding to target distance, then expand outward.
-            int start = GetBucketIndex(targetId);
-            if (start < 0) start = 0;
-
-            var candidates = new List<NodeContact>(Math.Min(count * 3, BucketSize * 8));
-            CollectFromBuckets(start, candidates, hardLimit: Math.Max(count * 8, BucketSize * 8));
+            var candidates = new List<NodeContact>();
+            foreach (var contact in EnumerateAllContacts())
+                candidates.Add(contact);
 
             // Sort by XOR distance to target.
             candidates.Sort((a, b) => CompareDistance(a.NodeId, b.NodeId, targetId));
@@ -177,34 +174,6 @@ namespace Neo.Network.P2P
                 }
             }
             return list;
-        }
-
-        void CollectFromBuckets(int start, List<NodeContact> output, int hardLimit)
-        {
-            void AddRange(int bucketIndex)
-            {
-                lock (_buckets[bucketIndex])
-                    foreach (var c in _buckets[bucketIndex].Contacts)
-                    {
-                        output.Add(c);
-                        if (output.Count >= hardLimit) return;
-                    }
-            }
-
-            AddRange(start);
-            if (output.Count >= hardLimit) return;
-
-            for (int step = 1; step < IdBits; step++)
-            {
-                int left = start - step;
-                int right = start + step;
-
-                if (left >= 0) AddRange(left);
-                if (output.Count >= hardLimit) break;
-                if (right < IdBits) AddRange(right);
-                if (output.Count >= hardLimit) break;
-                if (left < 0 && right >= IdBits) break;
-            }
         }
 
         IEnumerable<NodeContact> EnumerateAllContacts()

--- a/src/Neo/Network/P2P/RoutingTable.cs
+++ b/src/Neo/Network/P2P/RoutingTable.cs
@@ -1,0 +1,232 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// RoutingTable.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+
+namespace Neo.Network.P2P
+{
+    /// <summary>
+    /// Kademlia-style routing table built from 256 k-buckets.
+    /// </summary>
+    public sealed class RoutingTable
+    {
+        const int IdBits = UInt256.Length * 8;
+
+        readonly UInt256 _selfId;
+        readonly KBucket[] _buckets;
+
+        /// <summary>
+        /// Max contacts per bucket (K in Kademlia).
+        /// </summary>
+        public int BucketSize { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the RoutingTable class with the specified node identifier and bucket configuration
+        /// parameters.
+        /// </summary>
+        /// <remarks>The routing table is organized into buckets based on the distance from the local node
+        /// identifier. Adjusting bucketSize, replacementSize, or badThreshold can affect the table's resilience and
+        /// performance in peer-to-peer network scenarios.</remarks>
+        /// <param name="selfId">The unique identifier of the local node for which the routing table is constructed.</param>
+        /// <param name="bucketSize">The maximum number of entries allowed in each bucket. Must be positive.</param>
+        /// <param name="replacementSize">The maximum number of replacement entries maintained for each bucket. Must be non-negative.</param>
+        /// <param name="badThreshold">The number of failed contact attempts after which a node is considered bad and eligible for replacement. Must be
+        /// positive.</param>
+        public RoutingTable(UInt256 selfId, int bucketSize = 20, int replacementSize = 10, int badThreshold = 3)
+        {
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(bucketSize);
+            ArgumentOutOfRangeException.ThrowIfNegative(replacementSize);
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(badThreshold);
+
+            _selfId = selfId;
+            BucketSize = bucketSize;
+
+            _buckets = new KBucket[IdBits];
+            for (int i = 0; i < _buckets.Length; i++)
+                _buckets[i] = new KBucket(bucketSize, replacementSize, badThreshold);
+        }
+
+        /// <summary>
+        /// Adds or refreshes a contact in the routing table.
+        /// </summary>
+        /// <param name="nodeId">The unique identifier of the node whose contact information is to be updated.</param>
+        /// <param name="endpoint">The overlay endpoint associated with the node. Must not be null.</param>
+        /// <param name="features">An optional set of feature flags describing the node's capabilities. The default is 0, indicating no features.</param>
+        /// <returns>true if the node contact information was updated successfully; otherwise, false.</returns>
+        public bool Update(UInt256 nodeId, OverlayEndpoint endpoint, ulong features = 0)
+        {
+            return Update(new(nodeId, [endpoint], features));
+        }
+
+        /// <summary>
+        /// Adds or refreshes a contact in the routing table.
+        /// </summary>
+        /// <remarks>If the specified contact represents the local node, the update is ignored and the method
+        /// returns false.</remarks>
+        /// <param name="contact">The contact information for the node to update. Must not represent the local node.</param>
+        /// <returns>true if the contact was successfully updated; otherwise, false.</returns>
+        public bool Update(NodeContact contact)
+        {
+            int bucket = GetBucketIndex(contact.NodeId);
+            if (bucket < 0) return false; // ignore self
+            lock (_buckets[bucket])
+                return _buckets[bucket].Update(contact);
+        }
+
+        /// <summary>
+        /// Marks a contact as recently successful (e.g., handshake OK, DHT request succeeded).
+        /// </summary>
+        public void MarkSuccess(UInt256 nodeId)
+        {
+            int bucket = GetBucketIndex(nodeId);
+            if (bucket < 0) return;
+            lock (_buckets[bucket])
+                _buckets[bucket].MarkSuccess(nodeId);
+        }
+
+        /// <summary>
+        /// Marks a contact as failed (e.g., connection timeout). May evict it if it becomes bad.
+        /// </summary>
+        public void MarkFailure(UInt256 nodeId)
+        {
+            int bucket = GetBucketIndex(nodeId);
+            if (bucket < 0) return;
+            lock (_buckets[bucket])
+                _buckets[bucket].MarkFailure(nodeId);
+        }
+
+        /// <summary>
+        /// Removes a contact from the routing table.
+        /// </summary>
+        public void Remove(UInt256 nodeId)
+        {
+            int bucket = GetBucketIndex(nodeId);
+            if (bucket < 0) return;
+            lock (_buckets[bucket])
+                _buckets[bucket].Remove(nodeId);
+        }
+
+        /// <summary>
+        /// Returns up to <paramref name="count"/> contacts closest to <paramref name="targetId"/>.
+        /// </summary>
+        public IReadOnlyList<NodeContact> FindClosest(UInt256 targetId, int count)
+        {
+            ArgumentOutOfRangeException.ThrowIfNegative(count);
+            if (count == 0) return Array.Empty<NodeContact>();
+
+            // Start from the bucket corresponding to target distance, then expand outward.
+            int start = GetBucketIndex(targetId);
+            if (start < 0) start = 0;
+
+            var candidates = new List<NodeContact>(Math.Min(count * 3, BucketSize * 8));
+            CollectFromBuckets(start, candidates, hardLimit: Math.Max(count * 8, BucketSize * 8));
+
+            // Sort by XOR distance to target.
+            candidates.Sort((a, b) => CompareDistance(a.NodeId, b.NodeId, targetId));
+
+            if (candidates.Count <= count) return candidates;
+            return candidates.GetRange(0, count);
+        }
+
+        /// <summary>
+        /// Returns a sample of contacts across buckets (useful for bootstrap / gossip / health checks).
+        /// </summary>
+        public IReadOnlyList<NodeContact> Sample(int count)
+        {
+            ArgumentOutOfRangeException.ThrowIfNegative(count);
+            if (count == 0) return Array.Empty<NodeContact>();
+
+            var list = new List<NodeContact>(count);
+            // Prefer spread: take one from each bucket, round-robin.
+            int index = 0;
+            while (list.Count < count && index < IdBits)
+            {
+                lock (_buckets[index])
+                {
+                    var bucket = _buckets[index].Contacts;
+                    if (bucket.Count > 0)
+                    {
+                        // take most recently seen (tail)
+                        list.Add(bucket.Last());
+                    }
+                }
+                index++;
+            }
+
+            // If still short, just flatten and take.
+            if (list.Count < count)
+            {
+                foreach (var c in EnumerateAllContacts())
+                {
+                    if (!list.Contains(c))
+                    {
+                        list.Add(c);
+                        if (list.Count >= count) break;
+                    }
+                }
+            }
+            return list;
+        }
+
+        void CollectFromBuckets(int start, List<NodeContact> output, int hardLimit)
+        {
+            void AddRange(int bucketIndex)
+            {
+                lock (_buckets[bucketIndex])
+                    foreach (var c in _buckets[bucketIndex].Contacts)
+                    {
+                        output.Add(c);
+                        if (output.Count >= hardLimit) return;
+                    }
+            }
+
+            AddRange(start);
+            if (output.Count >= hardLimit) return;
+
+            for (int step = 1; step < IdBits; step++)
+            {
+                int left = start - step;
+                int right = start + step;
+
+                if (left >= 0) AddRange(left);
+                if (output.Count >= hardLimit) break;
+                if (right < IdBits) AddRange(right);
+                if (output.Count >= hardLimit) break;
+                if (left < 0 && right >= IdBits) break;
+            }
+        }
+
+        IEnumerable<NodeContact> EnumerateAllContacts()
+        {
+            for (int i = 0; i < IdBits; i++)
+                lock (_buckets[i])
+                    foreach (var c in _buckets[i].Contacts)
+                        yield return c;
+        }
+
+        int GetBucketIndex(UInt256 nodeId)
+        {
+            if (nodeId == _selfId) return -1;
+            int msb = (_selfId ^ nodeId).MostSignificantBit;
+            return msb; // -1..255
+        }
+
+        static int CompareDistance(UInt256 a, UInt256 b, UInt256 target)
+        {
+            var da = a ^ target;
+            var db = b ^ target;
+            return da.CompareTo(db);
+        }
+    }
+}

--- a/src/Neo/Network/P2P/TransportProtocol.cs
+++ b/src/Neo/Network/P2P/TransportProtocol.cs
@@ -1,0 +1,21 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// TransportProtocol.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+namespace Neo.Network.P2P
+{
+    /// <summary>
+    /// Transport protocol for an overlay endpoint.
+    /// </summary>
+    public enum TransportProtocol : byte
+    {
+        Tcp
+    }
+}

--- a/src/Neo/UInt256.cs
+++ b/src/Neo/UInt256.cs
@@ -15,6 +15,7 @@ using System;
 using System.Buffers.Binary;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
+using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -42,6 +43,27 @@ namespace Neo
         [FieldOffset(24)] private ulong _value4;
 
         public int Size => Length;
+
+        /// <summary>
+        /// Gets the index of the most significant set bit in the current value.
+        /// </summary>
+        /// <remarks>The most significant bit is the highest-order bit that is set to 1. If no bits are set, the
+        /// property returns -1.</remarks>
+        public int MostSignificantBit
+        {
+            get
+            {
+                if (_value4 != 0)
+                    return 192 + BitOperations.Log2(_value4);
+                if (_value3 != 0)
+                    return 128 + BitOperations.Log2(_value3);
+                if (_value2 != 0)
+                    return 64 + BitOperations.Log2(_value2);
+                if (_value1 != 0)
+                    return BitOperations.Log2(_value1);
+                return -1;
+            }
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="UInt256"/> class.
@@ -254,6 +276,23 @@ namespace Neo
         public static bool operator <=(UInt256 left, UInt256 right)
         {
             return left.CompareTo(right) <= 0;
+        }
+
+        /// <summary>
+        /// Performs a bitwise XOR operation on two <see cref="UInt256"/> values.
+        /// </summary>
+        /// <param name="left">The first operand.</param>
+        /// <param name="right">The second operand.</param>
+        /// <returns>The result of the bitwise XOR operation.</returns>
+        public static UInt256 operator ^(UInt256 left, UInt256 right)
+        {
+            return new UInt256
+            {
+                _value1 = left._value1 ^ right._value1,
+                _value2 = left._value2 ^ right._value2,
+                _value3 = left._value3 ^ right._value3,
+                _value4 = left._value4 ^ right._value4
+            };
         }
     }
 }

--- a/src/Neo/Wallets/KeyPair.cs
+++ b/src/Neo/Wallets/KeyPair.cs
@@ -43,6 +43,16 @@ namespace Neo.Wallets
         public UInt160 PublicKeyHash => PublicKey.EncodePoint(true).ToScriptHash();
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="KeyPair"/> class using a randomly generated 32-byte private key.
+        /// </summary>
+        /// <remarks>This constructor generates a cryptographically secure random private key for the key pair.
+        /// Use this overload when you want to create a new key pair with a unique, unpredictable private key suitable for
+        /// cryptographic operations.</remarks>
+        public KeyPair() : this(RandomNumberGenerator.GetBytes(32))
+        {
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="KeyPair"/> class.
         /// </summary>
         /// <param name="privateKey">The private key in the <see cref="KeyPair"/>.</param>

--- a/tests/Neo.UnitTests/Network/P2P/Payloads/UT_VersionPayload.cs
+++ b/tests/Neo.UnitTests/Network/P2P/Payloads/UT_VersionPayload.cs
@@ -14,7 +14,6 @@ using Neo.Extensions;
 using Neo.Network.P2P.Capabilities;
 using Neo.Network.P2P.Payloads;
 using System;
-using System.Linq;
 
 namespace Neo.UnitTests.Network.P2P.Payloads
 {
@@ -24,40 +23,30 @@ namespace Neo.UnitTests.Network.P2P.Payloads
         [TestMethod]
         public void SizeAndEndPoint_Get()
         {
-            var test = new VersionPayload() { Capabilities = Array.Empty<NodeCapability>(), UserAgent = "neo3" };
-            Assert.AreEqual(22, test.Size);
+            var test = VersionPayload.Create(ProtocolSettings.Default, new(), "neo3");
+            Assert.AreEqual(148, test.Size);
 
-            test = VersionPayload.Create(123, 456, "neo3", new NodeCapability[] { new ServerCapability(NodeCapabilityType.TcpServer, 22) });
-            Assert.AreEqual(25, test.Size);
+            test = VersionPayload.Create(ProtocolSettings.Default, new(), "neo3", new NodeCapability[] { new ServerCapability(NodeCapabilityType.TcpServer, 22) });
+            Assert.AreEqual(151, test.Size);
         }
 
         [TestMethod]
         public void DeserializeAndSerialize()
         {
-            var test = VersionPayload.Create(123, 456, "neo3", new NodeCapability[] { new ServerCapability(NodeCapabilityType.TcpServer, 22) });
+            var test = VersionPayload.Create(ProtocolSettings.Default, new(), "neo3", new NodeCapability[] { new ServerCapability(NodeCapabilityType.TcpServer, 22) });
             var clone = test.ToArray().AsSerializable<VersionPayload>();
 
             CollectionAssert.AreEqual(test.Capabilities.ToByteArray(), clone.Capabilities.ToByteArray());
             Assert.AreEqual(test.UserAgent, clone.UserAgent);
-            Assert.AreEqual(test.Nonce, clone.Nonce);
+            Assert.AreEqual(test.NodeId, clone.NodeId);
             Assert.AreEqual(test.Timestamp, clone.Timestamp);
             CollectionAssert.AreEqual(test.Capabilities.ToByteArray(), clone.Capabilities.ToByteArray());
 
-            Assert.ThrowsExactly<FormatException>(() => _ = VersionPayload.Create(123, 456, "neo3",
+            Assert.ThrowsExactly<FormatException>(() => _ = VersionPayload.Create(ProtocolSettings.Default, new(), "neo3",
                 new NodeCapability[] {
                     new ServerCapability(NodeCapabilityType.TcpServer, 22) ,
                     new ServerCapability(NodeCapabilityType.TcpServer, 22)
                 }).ToArray().AsSerializable<VersionPayload>());
-
-            var buf = test.ToArray();
-            buf[buf.Length - 2 - 1 - 1] += 3; // We've got 1 capability with 2 bytes, this adds three more to the array size.
-            buf = buf.Concat(new byte[] { 0xfe, 0x00 }).ToArray(); // Type = 0xfe, zero bytes of data.
-            buf = buf.Concat(new byte[] { 0xfd, 0x02, 0x00, 0x00 }).ToArray(); // Type = 0xfd, two bytes of data.
-            buf = buf.Concat(new byte[] { 0x10, 0x01, 0x00, 0x00, 0x00 }).ToArray(); // FullNode capability, 0x01 index.
-
-            clone = buf.AsSerializable<VersionPayload>();
-            Assert.HasCount(4, clone.Capabilities);
-            Assert.AreEqual(2, clone.Capabilities.OfType<UnknownCapability>().Count());
         }
     }
 }

--- a/tests/Neo.UnitTests/Network/P2P/UT_RemoteNode.cs
+++ b/tests/Neo.UnitTests/Network/P2P/UT_RemoteNode.cs
@@ -41,20 +41,10 @@ namespace Neo.UnitTests.Network.P2P
         public void RemoteNode_Test_Abort_DifferentNetwork()
         {
             var connectionTestProbe = CreateTestProbe();
-            var remoteNodeActor = ActorOfAsTestActorRef(() => new RemoteNode(_system, new LocalNode(_system), connectionTestProbe, null, null, new ChannelsConfig()));
+            var remoteNodeActor = ActorOfAsTestActorRef(() => new RemoteNode(_system, new LocalNode(_system, new()), connectionTestProbe, null, null, new ChannelsConfig()));
 
-            var msg = Message.Create(MessageCommand.Version, new VersionPayload
-            {
-                UserAgent = "".PadLeft(1024, '0'),
-                Nonce = 1,
-                Network = 2,
-                Timestamp = 5,
-                Version = 6,
-                Capabilities =
-                [
-                    new ServerCapability(NodeCapabilityType.TcpServer, 25)
-                ]
-            });
+            var msg = Message.Create(MessageCommand.Version,
+                VersionPayload.Create(ProtocolSettings.Default with { Network = 2 }, new(), "".PadLeft(1024, '0'), new ServerCapability(NodeCapabilityType.TcpServer, 25)));
 
             var testProbe = CreateTestProbe();
             testProbe.Send(remoteNodeActor, new Tcp.Received((ByteString)msg.ToArray()));
@@ -68,22 +58,12 @@ namespace Neo.UnitTests.Network.P2P
             var connectionTestProbe = CreateTestProbe();
             var remoteNodeActor = ActorOfAsTestActorRef(() =>
                 new RemoteNode(_system,
-                    new LocalNode(_system),
+                    new LocalNode(_system, new()),
                     connectionTestProbe,
                     new IPEndPoint(IPAddress.Parse("192.168.1.2"), 8080), new IPEndPoint(IPAddress.Parse("192.168.1.1"), 8080), new ChannelsConfig()));
 
-            var msg = Message.Create(MessageCommand.Version, new VersionPayload()
-            {
-                UserAgent = "Unit Test".PadLeft(1024, '0'),
-                Nonce = 1,
-                Network = TestProtocolSettings.Default.Network,
-                Timestamp = 5,
-                Version = 6,
-                Capabilities =
-                [
-                    new ServerCapability(NodeCapabilityType.TcpServer, 25)
-                ]
-            });
+            var msg = Message.Create(MessageCommand.Version,
+                VersionPayload.Create(TestProtocolSettings.Default, new(), "Unit Test".PadLeft(1024, '0'), new ServerCapability(NodeCapabilityType.TcpServer, 25)));
 
             var testProbe = CreateTestProbe();
             testProbe.Send(remoteNodeActor, new Tcp.Received((ByteString)msg.ToArray()));

--- a/tests/Neo.UnitTests/Network/P2P/UT_RoutingTable.cs
+++ b/tests/Neo.UnitTests/Network/P2P/UT_RoutingTable.cs
@@ -59,6 +59,25 @@ namespace Neo.UnitTests.Network.P2P
         }
 
         [TestMethod]
+        public void FindClosest_ConsidersAllBucketsWhenLowerBucketIsCloser()
+        {
+            var table = new RoutingTable(UInt256.Zero, bucketSize: 1, replacementSize: 0, badThreshold: 1);
+            UInt256 target = WithBit(128);
+            UInt256 closest = WithBit(0);
+
+            for (int bit = 127; bit >= 124; bit--)
+                table.Update(WithBit(bit), Endpoint(10000 + bit, EndpointKind.Observed));
+            for (int bit = 129; bit <= 132; bit++)
+                table.Update(WithBit(bit), Endpoint(10000 + bit, EndpointKind.Observed));
+            table.Update(closest, Endpoint(10000, EndpointKind.Observed));
+
+            var result = table.FindClosest(target, 1);
+
+            Assert.HasCount(1, result);
+            Assert.AreEqual(closest, result[0].NodeId);
+        }
+
+        [TestMethod]
         public void MarkFailure_PromotesMostRecentReplacement()
         {
             var table = new RoutingTable(UInt256.Zero, bucketSize: 1, replacementSize: 2, badThreshold: 2);

--- a/tests/Neo.UnitTests/Network/P2P/UT_RoutingTable.cs
+++ b/tests/Neo.UnitTests/Network/P2P/UT_RoutingTable.cs
@@ -1,0 +1,190 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// UT_RoutingTable.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.Network.P2P;
+using System;
+using System.Linq;
+using System.Net;
+
+namespace Neo.UnitTests.Network.P2P
+{
+    [TestClass]
+    public class UT_RoutingTable
+    {
+        [TestMethod]
+        public void Constructor_RejectsInvalidBucketConfiguration()
+        {
+            Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => new RoutingTable(UInt256.Zero, bucketSize: 0));
+            Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => new RoutingTable(UInt256.Zero, replacementSize: -1));
+            Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => new RoutingTable(UInt256.Zero, badThreshold: 0));
+        }
+
+        [TestMethod]
+        public void Update_FindClosest_Remove_And_Sample_WorkAcrossBuckets()
+        {
+            var table = new RoutingTable(UInt256.Zero, bucketSize: 2, replacementSize: 1, badThreshold: 1);
+            var ids = new[] { WithBit(0), WithBit(1), WithBit(2), WithBit(3) };
+
+            Assert.IsFalse(table.Update(UInt256.Zero, Endpoint(10000, EndpointKind.Observed)));
+
+            for (int i = 0; i < ids.Length; i++)
+                Assert.IsTrue(table.Update(ids[i], Endpoint(10001 + i, EndpointKind.Observed), (ulong)(1 << i)));
+
+            var closest = table.FindClosest(UInt256.Zero, 3);
+            Assert.HasCount(3, closest);
+            Assert.AreEqual(ids[0], closest[0].NodeId);
+            Assert.AreEqual(ids[1], closest[1].NodeId);
+            Assert.AreEqual(ids[2], closest[2].NodeId);
+
+            Assert.IsEmpty(table.FindClosest(UInt256.Zero, 0));
+            Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => table.FindClosest(UInt256.Zero, -1));
+
+            var sample = table.Sample(10);
+            Assert.HasCount(4, sample);
+            Assert.AreEqual(4, sample.Select(p => p.NodeId).Distinct().Count());
+            Assert.IsEmpty(table.Sample(0));
+            Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => table.Sample(-1));
+
+            table.Remove(ids[1]);
+            Assert.IsFalse(table.FindClosest(UInt256.Zero, 10).Any(p => p.NodeId == ids[1]));
+        }
+
+        [TestMethod]
+        public void MarkFailure_PromotesMostRecentReplacement()
+        {
+            var table = new RoutingTable(UInt256.Zero, bucketSize: 1, replacementSize: 2, badThreshold: 2);
+            var primary = WithBits(5);
+            var replacement = WithBits(5, 0);
+            var newestReplacement = WithBits(5, 1);
+
+            Assert.IsTrue(table.Update(primary, Endpoint(10001, EndpointKind.Observed)));
+            Assert.IsFalse(table.Update(replacement, Endpoint(10002, EndpointKind.Observed)));
+            Assert.IsFalse(table.Update(newestReplacement, Endpoint(10003, EndpointKind.Observed)));
+
+            table.MarkFailure(primary);
+            Assert.AreEqual(primary, table.FindClosest(primary, 1)[0].NodeId);
+
+            table.MarkFailure(primary);
+            Assert.AreEqual(newestReplacement, table.FindClosest(primary, 1)[0].NodeId);
+        }
+
+        [TestMethod]
+        public void MarkSuccess_ResetsFailureCountBeforeEviction()
+        {
+            var table = new RoutingTable(UInt256.Zero, bucketSize: 1, replacementSize: 1, badThreshold: 2);
+            var primary = WithBits(6);
+            var replacement = WithBits(6, 0);
+
+            table.Update(primary, Endpoint(10001, EndpointKind.Observed));
+            table.Update(replacement, Endpoint(10002, EndpointKind.Observed));
+
+            table.MarkFailure(primary);
+            table.MarkSuccess(primary);
+            table.MarkFailure(primary);
+
+            Assert.AreEqual(primary, table.FindClosest(primary, 1)[0].NodeId);
+        }
+
+        [TestMethod]
+        public void KBucket_UpdatesExistingContactsAndDropsFailedReplacements()
+        {
+            var bucket = new KBucket(capacity: 1, replacementCapacity: 1, badThreshold: 1);
+            var primary = WithBits(7);
+            var replacement = WithBits(7, 0);
+
+            Assert.IsTrue(bucket.Update(new NodeContact(primary, [Endpoint(10001, EndpointKind.Observed)], 1)));
+            Assert.IsFalse(bucket.Update(new NodeContact(replacement, [Endpoint(10002, EndpointKind.Observed)], 2)));
+
+            Assert.IsTrue(bucket.TryGet(primary, out var contact));
+            Assert.AreEqual(1ul, contact.Features);
+
+            bucket.Update(new NodeContact(primary, [Endpoint(10001, EndpointKind.Advertised)], 4));
+            Assert.IsTrue(bucket.TryGet(primary, out contact));
+            Assert.AreEqual(5ul, contact.Features);
+            Assert.HasCount(1, contact.Endpoints);
+            Assert.AreEqual(EndpointKind.Observed | EndpointKind.Advertised, contact.Endpoints[0].Kind);
+
+            bucket.MarkFailure(replacement);
+            bucket.MarkFailure(primary);
+            Assert.IsFalse(bucket.TryGet(primary, out _));
+            Assert.IsFalse(bucket.TryGet(replacement, out _));
+        }
+
+        [TestMethod]
+        public void NodeContact_MergesPromotesAndTrimsEndpoints()
+        {
+            var nodeId = WithBit(8);
+            var observed = Endpoint(10001, EndpointKind.Observed);
+            var advertised = observed.WithKind(EndpointKind.Advertised);
+            var derived = Endpoint(10002, EndpointKind.Derived);
+            var relay = Endpoint(10003, EndpointKind.Relay);
+            var unknown = Endpoint(10004, 0);
+            var secondAdvertised = Endpoint(10005, EndpointKind.Advertised);
+
+            var contact = new NodeContact(nodeId, [observed], features: 1);
+            contact.AddOrPromoteEndpoint(advertised);
+            Assert.HasCount(1, contact.Endpoints);
+            Assert.AreEqual(EndpointKind.Observed | EndpointKind.Advertised, contact.Endpoints[0].Kind);
+
+            contact.AddOrPromoteEndpoint(derived);
+            contact.AddOrPromoteEndpoint(relay);
+            contact.AddOrPromoteEndpoint(unknown);
+            contact.AddOrPromoteEndpoint(secondAdvertised);
+
+            Assert.HasCount(4, contact.Endpoints);
+            Assert.AreEqual(secondAdvertised, contact.Endpoints[0]);
+            Assert.IsFalse(contact.Endpoints.Any(p => p.EndPoint.Port == relay.EndPoint.Port));
+            Assert.StartsWith(nodeId.ToString(), contact.ToString());
+        }
+
+        [TestMethod]
+        public void OverlayEndpoint_EqualityIgnoresKind()
+        {
+            var observed = Endpoint(10001, EndpointKind.Observed);
+            var advertised = observed.WithKind(EndpointKind.Advertised);
+            var differentPort = Endpoint(10002, EndpointKind.Observed);
+
+            Assert.AreEqual(TransportProtocol.Tcp, observed.Transport);
+            Assert.AreEqual(EndpointKind.Observed, observed.Kind);
+            Assert.AreEqual(observed, advertised);
+            Assert.IsTrue(observed == advertised);
+            Assert.IsFalse(observed != advertised);
+            Assert.AreEqual(observed.GetHashCode(), advertised.GetHashCode());
+            Assert.AreNotEqual(observed, differentPort);
+            Assert.AreNotEqual(observed, new object());
+            Assert.AreEqual("tcp:127.0.0.1:10001", observed.ToString());
+        }
+
+        private static OverlayEndpoint Endpoint(int port, EndpointKind kind)
+        {
+            return new OverlayEndpoint(
+                TransportProtocol.Tcp,
+                new IPEndPoint(IPAddress.Loopback, port),
+                kind);
+        }
+
+        private static UInt256 WithBit(int bit)
+        {
+            var bytes = new byte[UInt256.Length];
+            bytes[bit / 8] = (byte)(1 << (bit % 8));
+            return new UInt256(bytes);
+        }
+
+        private static UInt256 WithBits(params int[] bits)
+        {
+            var bytes = new byte[UInt256.Length];
+            foreach (int bit in bits)
+                bytes[bit / 8] |= (byte)(1 << (bit % 8));
+            return new UInt256(bytes);
+        }
+    }
+}

--- a/tests/Neo.UnitTests/Network/P2P/UT_TaskSession.cs
+++ b/tests/Neo.UnitTests/Network/P2P/UT_TaskSession.cs
@@ -13,7 +13,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Neo.Network.P2P;
 using Neo.Network.P2P.Capabilities;
 using Neo.Network.P2P.Payloads;
-using System;
 
 namespace Neo.UnitTests.Network.P2P
 {
@@ -23,14 +22,14 @@ namespace Neo.UnitTests.Network.P2P
         [TestMethod]
         public void CreateTest()
         {
-            var ses = new TaskSession(new VersionPayload() { Capabilities = new NodeCapability[] { new FullNodeCapability(123) }, UserAgent = "" });
+            var ses = new TaskSession(VersionPayload.Create(ProtocolSettings.Default, new(), "", new FullNodeCapability(123)));
 
             Assert.IsFalse(ses.HasTooManyTasks);
             Assert.AreEqual((uint)123, ses.LastBlockIndex);
             Assert.IsEmpty(ses.IndexTasks);
             Assert.IsTrue(ses.IsFullNode);
 
-            ses = new TaskSession(new VersionPayload() { Capabilities = Array.Empty<NodeCapability>(), UserAgent = "" });
+            ses = new TaskSession(VersionPayload.Create(ProtocolSettings.Default, new(), ""));
 
             Assert.IsFalse(ses.HasTooManyTasks);
             Assert.AreEqual((uint)0, ses.LastBlockIndex);

--- a/tests/Neo.UnitTests/UT_UInt256.cs
+++ b/tests/Neo.UnitTests/UT_UInt256.cs
@@ -213,5 +213,79 @@ namespace Neo.UnitTests.IO
             Assert.ThrowsExactly<ArgumentException>(() => value.Serialize(shortBuffer.AsSpan()));
             Assert.ThrowsExactly<ArgumentException>(() => value.SafeSerialize(shortBuffer.AsSpan()));
         }
+
+        [TestMethod]
+        public void TestXorWithZeroIsIdentity()
+        {
+            var a = CreateSequential(0x10);
+            Assert.AreEqual(a, a ^ UInt256.Zero);
+            Assert.AreEqual(a, UInt256.Zero ^ a);
+        }
+
+        [TestMethod]
+        public void TestXorWithSelfIsZero()
+        {
+            var a = CreateSequential(0x42);
+            Assert.AreEqual(UInt256.Zero, a ^ a);
+        }
+
+        [TestMethod]
+        public void TestXorAssociative()
+        {
+            var a = CreateSequential(0x10);
+            var b = CreateSequential(0x20);
+            var c = CreateSequential(0x30);
+            var left = (a ^ b) ^ c;
+            var right = a ^ (b ^ c);
+
+            Assert.AreEqual(left, right);
+        }
+
+        [TestMethod]
+        public void TestXorCommutativeAndMatchesManual()
+        {
+            var a = CreateSequential(0x00);
+            var b = CreateSequential(0xF0);
+
+            var ab = a.ToArray();
+            var bb = b.ToArray();
+
+            var rb = new byte[UInt256.Length];
+            for (int i = 0; i < rb.Length; i++)
+                rb[i] = (byte)(ab[i] ^ bb[i]);
+
+            var expectedValue = new UInt256(rb);
+            Assert.AreEqual(expectedValue, a ^ b);
+            Assert.AreEqual(expectedValue, b ^ a);
+        }
+
+        [TestMethod]
+        public void TestMostSignificantBit()
+        {
+            Assert.AreEqual(-1, UInt256.Zero.MostSignificantBit);
+            Assert.AreEqual(0, WithBit(0).MostSignificantBit);
+            Assert.AreEqual(63, WithBit(63).MostSignificantBit);
+            Assert.AreEqual(64, WithBit(64).MostSignificantBit);
+            Assert.AreEqual(127, WithBit(127).MostSignificantBit);
+            Assert.AreEqual(128, WithBit(128).MostSignificantBit);
+            Assert.AreEqual(191, WithBit(191).MostSignificantBit);
+            Assert.AreEqual(192, WithBit(192).MostSignificantBit);
+            Assert.AreEqual(255, WithBit(255).MostSignificantBit);
+        }
+
+        private static UInt256 CreateSequential(byte start)
+        {
+            var bytes = new byte[UInt256.Length];
+            for (var i = 0; i < bytes.Length; i++)
+                bytes[i] = unchecked((byte)(start + i));
+            return new UInt256(bytes);
+        }
+
+        private static UInt256 WithBit(int bit)
+        {
+            var bytes = new byte[UInt256.Length];
+            bytes[bit / 8] = (byte)(1 << (bit % 8));
+            return new UInt256(bytes);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Backport signed node identity in the version handshake from #4420.
- Backport DHT routing table primitives and peer contact tracking from #4422.
- Correct closest-node selection to use full XOR-distance ordering before truncating results.
- Adapt the backport to the current master-n3 namespace and import style.

## Testing
- dotnet test tests/Neo.UnitTests/Neo.UnitTests.csproj --configuration Release --no-restore --filter "FullyQualifiedName~FindClosest_ConsidersAllBucketsWhenLowerBucketIsCloser" --verbosity minimal --disable-build-servers
- dotnet test tests/Neo.UnitTests/Neo.UnitTests.csproj --configuration Release --no-restore --filter "FullyQualifiedName~UT_RoutingTable|FullyQualifiedName~UT_UInt256" --verbosity minimal --disable-build-servers
- dotnet test tests/Neo.UnitTests/Neo.UnitTests.csproj --configuration Release --no-restore --filter "FullyQualifiedName~Network.P2P|FullyQualifiedName~UT_UInt256" --verbosity minimal --disable-build-servers
- dotnet test tests/Neo.UnitTests/Neo.UnitTests.csproj --configuration Release --no-restore --verbosity minimal --disable-build-servers
- dotnet format src/Neo/Neo.csproj --verify-no-changes --no-restore --verbosity minimal
- dotnet format tests/Neo.UnitTests/Neo.UnitTests.csproj --verify-no-changes --no-restore --verbosity minimal
- git diff --check