### PR TITLE
Optimize routing table closest-node selection

### DIFF
--- a/src/Neo/Network/P2P/RoutingTable.cs
+++ b/src/Neo/Network/P2P/RoutingTable.cs
@@ -122,13 +122,28 @@ public sealed class RoutingTable
         ArgumentOutOfRangeException.ThrowIfNegative(count);
         if (count == 0) return Array.Empty<NodeContact>();
 
-        var candidates = EnumerateAllContacts().ToList();
+        var farthestFirst = Comparer<UInt256>.Create((x, y) => y.CompareTo(x));
+        var candidates = new PriorityQueue<NodeContact, UInt256>(farthestFirst);
 
-        // Sort by XOR distance to target.
-        candidates.Sort((a, b) => CompareDistance(a.NodeId, b.NodeId, targetId));
+        foreach (var contact in EnumerateAllContacts())
+        {
+            var distance = contact.NodeId ^ targetId;
+            if (candidates.Count < count)
+            {
+                candidates.Enqueue(contact, distance);
+                continue;
+            }
 
-        if (candidates.Count <= count) return candidates;
-        return candidates.GetRange(0, count);
+            candidates.TryPeek(out _, out var farthestDistance);
+            if (distance.CompareTo(farthestDistance) >= 0) continue;
+
+            candidates.Dequeue();
+            candidates.Enqueue(contact, distance);
+        }
+
+        var result = candidates.UnorderedItems.ToList();
+        result.Sort((a, b) => a.Priority.CompareTo(b.Priority));
+        return result.Select(static item => item.Element).ToList();
     }
 
     /// <summary>
@@ -186,10 +201,4 @@ public sealed class RoutingTable
         return msb; // -1..255
     }
 
-    static int CompareDistance(UInt256 a, UInt256 b, UInt256 target)
-    {
-        var da = a ^ target;
-        var db = b ^ target;
-        return da.CompareTo(db);
-    }
 }

--- a/tests/Neo.UnitTests/Network/P2P/UT_RoutingTable.cs
+++ b/tests/Neo.UnitTests/Network/P2P/UT_RoutingTable.cs
@@ -55,6 +55,28 @@ public class UT_RoutingTable
         Assert.AreEqual(closest, result[0].NodeId);
     }
 
+    [TestMethod]
+    public void FindClosest_ReturnsClosestContactsEvenWhenDiscoveredAfterManyCandidates()
+    {
+        var table = new RoutingTable(UInt256.Zero, bucketSize: 1, replacementSize: 0, badThreshold: 1);
+        UInt256 target = WithBit(128);
+
+        for (int bit = 117; bit <= 127; bit++)
+            Add(table, WithBit(bit), 10000 + bit);
+        for (int bit = 129; bit <= 141; bit++)
+            Add(table, WithBit(bit), 10000 + bit);
+        Add(table, WithBit(2), 10002);
+        Add(table, WithBit(1), 10001);
+        Add(table, WithBit(0), 10000);
+
+        IReadOnlyList<NodeContact> result = table.FindClosest(target, 3);
+
+        Assert.HasCount(3, result);
+        Assert.AreEqual(WithBit(0), result[0].NodeId);
+        Assert.AreEqual(WithBit(1), result[1].NodeId);
+        Assert.AreEqual(WithBit(2), result[2].NodeId);
+    }
+
     private static void Add(RoutingTable table, UInt256 nodeId, int port)
     {
         table.Update(nodeId, new OverlayEndpoint(


### PR DESCRIPTION
# Description

Optimize `RoutingTable.FindClosest` so it no longer materializes and sorts every known contact when callers request only a small result set. The method still considers every known contact to preserve the exact XOR-distance closest-node semantics from #4547, but it now keeps a bounded top-k priority queue and sorts only the returned candidates.

Follow-up to #4547.

# Change Log

- Update `RoutingTable.FindClosest` to keep only the current closest `count` candidates while scanning the routing table.
- Add a routing table unit test that keeps closest contacts in late-scanned buckets to guard against reverting to local bucket-neighborhood selection.

## Type of change

- [x] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Unit Testing
- [ ] Run Application
- [x] Local Computer Tests
- [ ] No Testing

Validation:

- `dotnet test tests/Neo.UnitTests/Neo.UnitTests.csproj --filter UT_RoutingTable --no-restore`
- `dotnet test tests/Neo.UnitTests/Neo.UnitTests.csproj --no-restore`
- `dotnet test tests/Neo.UnitTests/Neo.UnitTests.csproj --no-restore --no-build`
- `dotnet format neo.sln --verify-no-changes --no-restore --verbosity minimal`
- `git diff --check`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
