### PR TITLE
Refactor HashSetCache

### DIFF
--- a/src/Neo.IO/Caching/HashSetCache.cs
+++ b/src/Neo.IO/Caching/HashSetCache.cs
@@ -25,9 +25,9 @@ namespace Neo.IO.Caching
     /// <typeparam name="T">The type of the items in the cache.</typeparam>
     internal class HashSetCache<T> : ICollection<T> where T : IEquatable<T>
     {
-        private class Items(int initialCapacity) : KeyedCollectionSlim<T, Tuple<T, DateTime?>>(initialCapacity)
+        private sealed class Items(int initialCapacity) : KeyedCollectionSlim<T, Tuple<T, DateTime?>>(initialCapacity)
         {
-            protected override T GetKeyForItem(Tuple<T, DateTime?> item) => item.Item1;
+            protected sealed override T GetKeyForItem(Tuple<T, DateTime?> item) => item.Item1;
         }
 
         private readonly int _capacity;

--- a/src/Neo.IO/Caching/HashSetCache.cs
+++ b/src/Neo.IO/Caching/HashSetCache.cs
@@ -14,6 +14,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.CompilerServices;
 
 namespace Neo.IO.Caching
@@ -24,13 +25,14 @@ namespace Neo.IO.Caching
     /// <typeparam name="T">The type of the items in the cache.</typeparam>
     internal class HashSetCache<T> : ICollection<T> where T : IEquatable<T>
     {
-        private class Items(int initialCapacity) : KeyedCollectionSlim<T, T>(initialCapacity)
+        private class Items(int initialCapacity) : KeyedCollectionSlim<T, Tuple<T, DateTime?>>(initialCapacity)
         {
-            protected sealed override T GetKeyForItem(T item) => item;
+            protected override T GetKeyForItem(Tuple<T, DateTime?> item) => item.Item1;
         }
 
         private readonly int _capacity;
         private readonly Items _items;
+        private readonly Func<DateTime>? _timeProvider;
 
         /// <summary>
         /// Gets the number of items in the cache.
@@ -43,14 +45,17 @@ namespace Neo.IO.Caching
         /// Initializes a new instance of the <see cref="HashSetCache{T}"/> class.
         /// </summary>
         /// <param name="capacity">The maximum number of items in the cache.</param>
+        /// <param name="timeProvider">A function that provides the current time. If null, pruning is disabled.</param>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="capacity"/> is less than 0.</exception>
-        public HashSetCache(int capacity)
+        public HashSetCache(int capacity, Func<DateTime>? timeProvider = null)
         {
             if (capacity <= 0) throw new ArgumentOutOfRangeException(nameof(capacity), $"{capacity} less than 0.");
 
             _capacity = capacity;
+            _timeProvider = timeProvider;
+
             // Avoid allocating a large memory at initialization
-            _items = new(Math.Min(capacity, 4096));
+            _items = new Items(Math.Min(capacity, 4096));
         }
 
         /// <summary>
@@ -63,7 +68,7 @@ namespace Neo.IO.Caching
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool TryAdd(T item)
         {
-            if (!_items.TryAdd(item)) return false;
+            if (!_items.TryAdd(new(item, _timeProvider?.Invoke()))) return false;
             if (_items.Count > _capacity) _items.RemoveFirst();
             return true;
         }
@@ -98,7 +103,7 @@ namespace Neo.IO.Caching
         /// Returns an enumerator that iterates through the cache.
         /// </summary>
         /// <returns>An enumerator that can be used to iterate through the cache.</returns>
-        public IEnumerator<T> GetEnumerator() => _items.GetEnumerator();
+        public IEnumerator<T> GetEnumerator() => _items.Select(u => u.Item1).GetEnumerator();
 
         /// <summary>
         /// Returns an enumerator that iterates through the cache.
@@ -130,6 +135,18 @@ namespace Neo.IO.Caching
             foreach (var item in this)
             {
                 array[i++] = item;
+            }
+        }
+
+        public void Prune(DateTime lessThan)
+        {
+            if (_timeProvider == null) throw new InvalidOperationException("Pruning is not allowed for this cache.");
+
+            while (Count > 0)
+            {
+                var (_, time) = _items.FirstOrDefault!;
+                if (lessThan <= time) break;
+                if (!_items.RemoveFirst()) break;
             }
         }
     }

--- a/src/Neo.IO/Caching/HashSetCache.cs
+++ b/src/Neo.IO/Caching/HashSetCache.cs
@@ -138,6 +138,11 @@ namespace Neo.IO.Caching
             }
         }
 
+        /// <summary>
+        /// Removes all cache entries with timestamps earlier than the specified time.
+        /// </summary>
+        /// <param name="lessThan">The DateTime threshold. Entries with timestamps before this value are removed.</param>
+        /// <exception cref="InvalidOperationException">Thrown when pruning is not allowed for this cache.</exception>
         public void Prune(DateTime lessThan)
         {
             if (_timeProvider == null) throw new InvalidOperationException("Pruning is not allowed for this cache.");

--- a/src/Neo/Network/P2P/RemoteNode.ProtocolHandler.cs
+++ b/src/Neo/Network/P2P/RemoteNode.ProtocolHandler.cs
@@ -30,11 +30,6 @@ namespace Neo.Network.P2P
     partial class RemoteNode
     {
         private class Timer { }
-        private class PendingKnownHashesCollection : KeyedCollectionSlim<UInt256, Tuple<UInt256, DateTime>>
-        {
-            protected override UInt256 GetKeyForItem(Tuple<UInt256, DateTime> item) => item.Item1;
-        }
-
         public static event MessageReceivedHandler MessageReceived
         {
             add => s_handlers.Add(value);
@@ -42,7 +37,7 @@ namespace Neo.Network.P2P
         }
 
         private static readonly List<MessageReceivedHandler> s_handlers = new();
-        private readonly PendingKnownHashesCollection _pendingKnownHashes = new();
+        private readonly HashSetCache<UInt256> _pendingKnownHashes;
         private readonly HashSetCache<UInt256> _knownHashes;
         private readonly HashSetCache<UInt256> _sentHashes;
         private bool _verack = false;
@@ -365,7 +360,7 @@ namespace Neo.Network.P2P
             }
             if (hashes.Length == 0) return;
             foreach (var hash in hashes)
-                _pendingKnownHashes.TryAdd(Tuple.Create(hash, TimeProvider.Current.UtcNow));
+                _pendingKnownHashes.TryAdd(hash);
             _system.TaskManager.Tell(new TaskManager.NewTasks(InvPayload.Create(payload.Type, hashes)));
         }
 
@@ -421,12 +416,7 @@ namespace Neo.Network.P2P
         private void OnTimer()
         {
             var oneMinuteAgo = TimeProvider.Current.UtcNow.AddMinutes(-1);
-            while (_pendingKnownHashes.Count > 0)
-            {
-                var (_, time) = _pendingKnownHashes.FirstOrDefault!;
-                if (oneMinuteAgo <= time) break;
-                if (!_pendingKnownHashes.RemoveFirst()) break;
-            }
+            _pendingKnownHashes.Prune(oneMinuteAgo);
             if (oneMinuteAgo > _lastSent)
                 EnqueueMessage(Message.Create(MessageCommand.Ping, PingPayload.Create(NativeContract.Ledger.CurrentIndex(_system.StoreView))));
         }

--- a/src/Neo/Network/P2P/RemoteNode.cs
+++ b/src/Neo/Network/P2P/RemoteNode.cs
@@ -84,6 +84,7 @@ namespace Neo.Network.P2P
             _localNode = localNode;
             _knownHashes = new HashSetCache<UInt256>(Math.Max(1, config.MaxKnownHashes));
             _sentHashes = new HashSetCache<UInt256>(Math.Max(1, config.MaxKnownHashes));
+            _pendingKnownHashes = new HashSetCache<UInt256>(Math.Max(1, config.MaxKnownHashes), () => TimeProvider.Current.UtcNow);
             localNode.RemoteNodes.TryAdd(Self, this);
         }
 
@@ -210,6 +211,7 @@ namespace Neo.Network.P2P
             timer.CancelIfNotNull();
             if (_localNode.RemoteNodes.TryRemove(Self, out _))
             {
+                _pendingKnownHashes.Clear();
                 _knownHashes.Clear();
                 _sentHashes.Clear();
             }

--- a/tests/Neo.UnitTests/IO/Caching/UT_HashSetCache.cs
+++ b/tests/Neo.UnitTests/IO/Caching/UT_HashSetCache.cs
@@ -58,11 +58,8 @@ namespace Neo.UnitTests.IO.Caching
         [TestMethod]
         public void TestConstructor()
         {
-            Action action1 = () => new HashSetCache<UInt256>(-1);
-            Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => action1());
-
-            Action action2 = () => new HashSetCache<UInt256>(-1);
-            Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => action2());
+            Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => new HashSetCache<UInt256>(-1));
+            Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => new HashSetCache<UInt256>(-1));
         }
 
         [TestMethod]
@@ -150,6 +147,85 @@ namespace Neo.UnitTests.IO.Caching
             set.TryAdd(c);
             set.ExceptWith([c]);
             CollectionAssert.AreEqual(set.ToArray(), new UInt256[] { a, b });
+        }
+
+        [TestMethod]
+        public void TestPrune()
+        {
+            var cache = new HashSetCache<int>(100, () => DateTime.UtcNow)
+            {
+                // Add elements at different timestamps
+                1,
+                2,
+                3,
+                4,
+                5
+            };
+
+            // Wait to create a time difference
+            System.Threading.Thread.Sleep(100);
+            var pruneTime = DateTime.UtcNow;
+            System.Threading.Thread.Sleep(100);
+
+            // Add more elements after prune time
+            cache.Add(6);
+            cache.Add(7);
+            cache.Add(8);
+
+            Assert.HasCount(8, cache);
+
+            // Prune old elements (first 5)
+            cache.Prune(pruneTime);
+
+            // Verify only elements added after prune time remain
+            Assert.HasCount(3, cache);
+            Assert.Contains(6, cache);
+            Assert.Contains(7, cache);
+            Assert.Contains(8, cache);
+            Assert.DoesNotContain(1, cache);
+            Assert.DoesNotContain(2, cache);
+            Assert.DoesNotContain(3, cache);
+            Assert.DoesNotContain(4, cache);
+            Assert.DoesNotContain(5, cache);
+        }
+
+        [TestMethod]
+        public void TestPruneAll()
+        {
+            var cache = new HashSetCache<int>(100, () => DateTime.UtcNow)
+            {
+                1,
+                2,
+                3
+            };
+
+            Assert.HasCount(3, cache);
+
+            // Prune all elements (future date)
+            cache.Prune(DateTime.UtcNow.AddHours(1));
+
+            Assert.IsEmpty(cache);
+        }
+
+        [TestMethod]
+        public void TestPruneNone()
+        {
+            var cache = new HashSetCache<int>(100, () => DateTime.UtcNow)
+            {
+                1,
+                2,
+                3
+            };
+
+            Assert.HasCount(3, cache);
+
+            // Prune nothing (past date)
+            cache.Prune(DateTime.UtcNow.AddHours(-1));
+
+            Assert.HasCount(3, cache);
+            Assert.Contains(1, cache);
+            Assert.Contains(2, cache);
+            Assert.Contains(3, cache);
         }
     }
 }


### PR DESCRIPTION
# Description

This pull request enhances the `HashSetCache<T>` class to support time-based pruning of cache entries, and refactors its usage in the P2P networking code to leverage this new capability. It also introduces comprehensive unit tests for the pruning logic. The main changes are grouped below:

### HashSetCache Enhancements

* Updated `HashSetCache<T>` to store items as tuples of value and timestamp, allowing each item to track when it was added. A new optional `timeProvider` parameter enables timestamping and time-based operations. [[1]](diffhunk://#diff-d357116ea8a9f6ee9f8925e7366db8e3bad62532e6cb219b5b80a057a0b812deL27-R35) [[2]](diffhunk://#diff-d357116ea8a9f6ee9f8925e7366db8e3bad62532e6cb219b5b80a057a0b812deR48-R58) [[3]](diffhunk://#diff-d357116ea8a9f6ee9f8925e7366db8e3bad62532e6cb219b5b80a057a0b812deL66-R71)
* Added a `Prune(DateTime lessThan)` method to `HashSetCache<T>`, which removes all items added before a specified time, and throws if called when time tracking is disabled.
* Changed enumerator and collection logic to work with the new tuple-based storage, ensuring compatibility with existing interfaces.

### P2P Protocol Refactoring

* Replaced the custom `PendingKnownHashesCollection` in `RemoteNode` with the enhanced `HashSetCache<UInt256>`, utilizing time-based pruning for managing pending known hashes. [[1]](diffhunk://#diff-b13599013b9d1e66d55ebdab7a9bbe5f05223a8c04758d4a9f57c8b01bcdb56aL33-R40) [[2]](diffhunk://#diff-3a1843e770a5943d4c3fe2850e9a6b2672d60009b20f3fc98b445f7a2bcc5cbbR87)
* Refactored message handling and timer logic in `RemoteNode.ProtocolHandler` to use the new `Prune` method for expiring old hashes, simplifying the code and improving maintainability. [[1]](diffhunk://#diff-b13599013b9d1e66d55ebdab7a9bbe5f05223a8c04758d4a9f57c8b01bcdb56aL368-R363) [[2]](diffhunk://#diff-b13599013b9d1e66d55ebdab7a9bbe5f05223a8c04758d4a9f57c8b01bcdb56aL424-R419)
* Ensured proper cleanup of cache instances on node shutdown by clearing the pending known hashes cache.

### Testing Improvements

* Added detailed unit tests for the new pruning functionality in `HashSetCache<T>`, covering scenarios for pruning some, all, or none of the elements.
* Minor cleanup in constructor tests for `HashSetCache<T>`.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Unit Testing
- [ ] Run Application
- [ ] Local Computer Tests
- [ ] No Testing


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
