### PR TITLE
Make Witness constants public

### DIFF
--- a/src/Neo/Network/P2P/Payloads/Witness.cs
+++ b/src/Neo/Network/P2P/Payloads/Witness.cs
@@ -25,10 +25,10 @@ namespace Neo.Network.P2P.Payloads
     {
         // This is designed to allow a MultiSig 21/11 (committee)
         // Invocation = 11 * (64 + 2) = 726
-        private const int MaxInvocationScript = 1024;
+        public const int MaxInvocationScript = 1024;
 
         // Verification = m + (PUSH_PubKey * 21) + length + null + syscall = 1 + ((2 + 33) * 21) + 2 + 1 + 5 = 744
-        private const int MaxVerificationScript = 1024;
+        public const int MaxVerificationScript = 1024;
 
         /// <summary>
         /// The invocation script of the witness. Used to pass arguments for <see cref="VerificationScript"/>.


### PR DESCRIPTION
# Description

This pull request makes a small but important change to the `Witness` class in `Witness.cs`. The constants `MaxInvocationScript` and `MaxVerificationScript` have been changed from `private` to `public`, making them accessible outside the class for use in other parts of the codebase.

- Made the `MaxInvocationScript` and `MaxVerificationScript` constants public in the `Witness` class to allow external access.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Unit Testing
- [ ] Run Application
- [ ] Local Computer Tests
- [x] No Testing


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
