### PR TITLE
Remove `Witness` max script size

### DIFF
--- a/src/Neo/Network/P2P/Payloads/Witness.cs
+++ b/src/Neo/Network/P2P/Payloads/Witness.cs
@@ -23,13 +23,6 @@ namespace Neo.Network.P2P.Payloads
     /// </summary>
     public class Witness : ISerializable
     {
-        // This is designed to allow a MultiSig 21/11 (committee)
-        // Invocation = 11 * (64 + 2) = 726
-        public const int MaxInvocationScript = 1024;
-
-        // Verification = m + (PUSH_PubKey * 21) + length + null + syscall = 1 + ((2 + 33) * 21) + 2 + 1 + 5 = 744
-        public const int MaxVerificationScript = 1024;
-
         /// <summary>
         /// The invocation script of the witness. Used to pass arguments for <see cref="VerificationScript"/>.
         /// </summary>
@@ -62,8 +55,8 @@ namespace Neo.Network.P2P.Payloads
 
         void ISerializable.Deserialize(ref MemoryReader reader)
         {
-            InvocationScript = reader.ReadVarMemory(MaxInvocationScript);
-            VerificationScript = reader.ReadVarMemory(MaxVerificationScript);
+            InvocationScript = reader.ReadVarMemory(ushort.MaxValue);
+            VerificationScript = reader.ReadVarMemory(ushort.MaxValue);
         }
 
         void ISerializable.Serialize(BinaryWriter writer)

--- a/tests/Neo.UnitTests/Network/P2P/Payloads/UT_Witness.cs
+++ b/tests/Neo.UnitTests/Network/P2P/Payloads/UT_Witness.cs
@@ -99,7 +99,7 @@ namespace Neo.UnitTests.Network.P2P.Payloads
         {
             var witness = new Witness
             {
-                InvocationScript = new byte[1025],
+                InvocationScript = new byte[ushort.MaxValue + 1],
                 VerificationScript = new byte[10]
             };
 
@@ -110,7 +110,7 @@ namespace Neo.UnitTests.Network.P2P.Payloads
             // Check max size
 
             witness.InvocationScript = new byte[10];
-            witness.VerificationScript = new byte[1025];
+            witness.VerificationScript = new byte[ushort.MaxValue + 1];
             Assert.ThrowsExactly<FormatException>(() => _ = witness.ToArray().AsSerializable<Witness>());
         }
 
@@ -168,6 +168,86 @@ namespace Neo.UnitTests.Network.P2P.Payloads
             Assert.AreEqual(0, w2.InvocationScript.Length);
             Assert.AreEqual(0, w2.VerificationScript.Length);
             Assert.IsFalse(ReferenceEquals(w1, w2));
+        }
+
+        [TestMethod]
+        public void Serialize_InvocationScript_ExceedsUshortMaxValue_ThrowsException()
+        {
+            // InvocationScript con tamaño mayor a ushort.MaxValue no puede serializarse correctamente
+            var witness = new Witness
+            {
+                InvocationScript = new byte[ushort.MaxValue + 1],
+                VerificationScript = new byte[10]
+            };
+
+            Assert.ThrowsExactly<FormatException>(() => _ = witness.ToArray().AsSerializable<Witness>());
+        }
+
+        [TestMethod]
+        public void Serialize_VerificationScript_ExceedsUshortMaxValue_ThrowsException()
+        {
+            // VerificationScript con tamaño mayor a ushort.MaxValue no puede serializarse correctamente
+            var witness = new Witness
+            {
+                InvocationScript = new byte[10],
+                VerificationScript = new byte[ushort.MaxValue + 1]
+            };
+
+            Assert.ThrowsExactly<FormatException>(() => _ = witness.ToArray().AsSerializable<Witness>());
+        }
+
+        [TestMethod]
+        public void Serialize_InvocationScript_EqualsUshortMaxValue_Success()
+        {
+            // InvocationScript con tamaño exactamente igual a ushort.MaxValue debe serializarse correctamente
+            var witness = new Witness
+            {
+                InvocationScript = new byte[ushort.MaxValue],
+                VerificationScript = new byte[10]
+            };
+
+            var copy = witness.ToArray().AsSerializable<Witness>();
+
+            Assert.AreEqual(ushort.MaxValue, copy.InvocationScript.Length);
+            Assert.AreEqual(10, copy.VerificationScript.Length);
+            Assert.IsTrue(witness.InvocationScript.Span.SequenceEqual(copy.InvocationScript.Span));
+            Assert.IsTrue(witness.VerificationScript.Span.SequenceEqual(copy.VerificationScript.Span));
+        }
+
+        [TestMethod]
+        public void Serialize_VerificationScript_EqualsUshortMaxValue_Success()
+        {
+            // VerificationScript con tamaño exactamente igual a ushort.MaxValue debe serializarse correctamente
+            var witness = new Witness
+            {
+                InvocationScript = new byte[10],
+                VerificationScript = new byte[ushort.MaxValue]
+            };
+
+            var copy = witness.ToArray().AsSerializable<Witness>();
+
+            Assert.AreEqual(10, copy.InvocationScript.Length);
+            Assert.AreEqual(ushort.MaxValue, copy.VerificationScript.Length);
+            Assert.IsTrue(witness.InvocationScript.Span.SequenceEqual(copy.InvocationScript.Span));
+            Assert.IsTrue(witness.VerificationScript.Span.SequenceEqual(copy.VerificationScript.Span));
+        }
+
+        [TestMethod]
+        public void Serialize_BothScripts_LessThanUshortMaxValue_Success()
+        {
+            // Ambos scripts con tamaños menores a ushort.MaxValue deben serializarse correctamente
+            var witness = new Witness
+            {
+                InvocationScript = new byte[1000],
+                VerificationScript = new byte[2000]
+            };
+
+            var copy = witness.ToArray().AsSerializable<Witness>();
+
+            Assert.AreEqual(1000, copy.InvocationScript.Length);
+            Assert.AreEqual(2000, copy.VerificationScript.Length);
+            Assert.IsTrue(witness.InvocationScript.Span.SequenceEqual(copy.InvocationScript.Span));
+            Assert.IsTrue(witness.VerificationScript.Span.SequenceEqual(copy.VerificationScript.Span));
         }
     }
 }

--- a/tests/Neo.UnitTests/Network/P2P/Payloads/UT_Witness.cs
+++ b/tests/Neo.UnitTests/Network/P2P/Payloads/UT_Witness.cs
@@ -173,7 +173,7 @@ namespace Neo.UnitTests.Network.P2P.Payloads
         [TestMethod]
         public void Serialize_InvocationScript_ExceedsUshortMaxValue_ThrowsException()
         {
-            // InvocationScript con tamaño mayor a ushort.MaxValue no puede serializarse correctamente
+            // InvocationScript with size greater than ushort.MaxValue cannot be serialized correctly
             var witness = new Witness
             {
                 InvocationScript = new byte[ushort.MaxValue + 1],
@@ -186,7 +186,7 @@ namespace Neo.UnitTests.Network.P2P.Payloads
         [TestMethod]
         public void Serialize_VerificationScript_ExceedsUshortMaxValue_ThrowsException()
         {
-            // VerificationScript con tamaño mayor a ushort.MaxValue no puede serializarse correctamente
+            // VerificationScript with size greater than ushort.MaxValue cannot be serialized correctly
             var witness = new Witness
             {
                 InvocationScript = new byte[10],
@@ -199,7 +199,7 @@ namespace Neo.UnitTests.Network.P2P.Payloads
         [TestMethod]
         public void Serialize_InvocationScript_EqualsUshortMaxValue_Success()
         {
-            // InvocationScript con tamaño exactamente igual a ushort.MaxValue debe serializarse correctamente
+            // InvocationScript with size exactly equal to ushort.MaxValue should serialize correctly
             var witness = new Witness
             {
                 InvocationScript = new byte[ushort.MaxValue],
@@ -217,7 +217,7 @@ namespace Neo.UnitTests.Network.P2P.Payloads
         [TestMethod]
         public void Serialize_VerificationScript_EqualsUshortMaxValue_Success()
         {
-            // VerificationScript con tamaño exactamente igual a ushort.MaxValue debe serializarse correctamente
+            // VerificationScript with size exactly equal to ushort.MaxValue should serialize correctly
             var witness = new Witness
             {
                 InvocationScript = new byte[10],
@@ -235,7 +235,7 @@ namespace Neo.UnitTests.Network.P2P.Payloads
         [TestMethod]
         public void Serialize_BothScripts_LessThanUshortMaxValue_Success()
         {
-            // Ambos scripts con tamaños menores a ushort.MaxValue deben serializarse correctamente
+            // Both scripts with sizes less than ushort.MaxValue should serialize correctly
             var witness = new Witness
             {
                 InvocationScript = new byte[1000],


### PR DESCRIPTION
# Description

Because the transaction has already a max size, we don't need to limit the Witness script size. I used the same limit as Transaction.Script.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Unit Testing
- [ ] Run Application
- [ ] Local Computer Tests
- [ ] No Testing


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
