### PR TITLE
Avoid duplicate conflicts attribute

### DIFF
--- a/src/Neo/Network/P2P/Payloads/Conflicts.cs
+++ b/src/Neo/Network/P2P/Payloads/Conflicts.cs
@@ -15,6 +15,7 @@ using Neo.Json;
 using Neo.Persistence;
 using Neo.SmartContract.Native;
 using System.IO;
+using System.Linq;
 
 namespace Neo.Network.P2P.Payloads
 {
@@ -50,6 +51,14 @@ namespace Neo.Network.P2P.Payloads
 
         public override bool Verify(DataCache snapshot, Transaction tx)
         {
+            // Ensure that there are no duplicated conflicting transactions in the attributes.
+
+            var conflicts = tx.Attributes.Where(u => u is Conflicts).Cast<Conflicts>().ToArray();
+            if (conflicts.Length != conflicts.Select(u => u.Hash).Distinct().Count())
+            {
+                return false;
+            }
+
             // Only check if conflicting transaction is on chain. It's OK if the
             // conflicting transaction was in the Conflicts attribute of some other
             // on-chain transaction.

--- a/tests/Neo.UnitTests/Network/P2P/Payloads/UT_Conflicts.cs
+++ b/tests/Neo.UnitTests/Network/P2P/Payloads/UT_Conflicts.cs
@@ -109,5 +109,56 @@ namespace Neo.UnitTests.Network.P2P.Payloads
             snapshotCache.Delete(key);
             Assert.IsTrue(test.Verify(snapshotCache, tx));
         }
+
+        [TestMethod]
+        public void Verify_DuplicateConflictHash()
+        {
+            var snapshotCache = TestBlockchain.GetTestSnapshotCache();
+
+            // Create two Conflicts attributes with the same hash
+            var conflict1 = new Conflicts() { Hash = _u };
+            var conflict2 = new Conflicts() { Hash = _u };
+
+            var tx = new Transaction()
+            {
+                Script = new byte[] { (byte)OpCode.RET },
+                Witnesses = [Witness.Empty],
+                Signers = [new Signer() { Account = UInt160.Zero }],
+                Attributes = [conflict1, conflict2]
+            };
+
+            // Verify should return false because there are duplicate conflict hashes
+            Assert.IsFalse(conflict1.Verify(snapshotCache, tx));
+            Assert.IsFalse(conflict2.Verify(snapshotCache, tx));
+        }
+
+        [TestMethod]
+        public void Verify_MultipleConflictsDifferentHashes()
+        {
+            var snapshotCache = TestBlockchain.GetTestSnapshotCache();
+
+            var hash2 = new UInt256(new byte[32] {
+                0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02,
+                0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02,
+                0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02,
+                0x02, 0x02
+            });
+
+            // Create two Conflicts attributes with different hashes
+            var conflict1 = new Conflicts() { Hash = _u };
+            var conflict2 = new Conflicts() { Hash = hash2 };
+
+            var tx = new Transaction()
+            {
+                Script = new byte[] { (byte)OpCode.RET },
+                Witnesses = [Witness.Empty],
+                Signers = [new Signer() { Account = UInt160.Zero }],
+                Attributes = [conflict1, conflict2]
+            };
+
+            // Verify should return true because the hashes are different and neither is on-chain
+            Assert.IsTrue(conflict1.Verify(snapshotCache, tx));
+            Assert.IsTrue(conflict2.Verify(snapshotCache, tx));
+        }
     }
 }


### PR DESCRIPTION
# Description

This pull request introduces an important validation step to the `Conflicts` attribute logic in the P2P payloads code. The main change ensures that a transaction cannot include duplicate conflicting transactions in its attributes, improving the integrity of conflict handling.

**Validation improvements:**

* Added a check in the `Verify` method of the `Conflicts` class to ensure there are no duplicate conflicting transactions (by hash) in the transaction's attributes. If duplicates are found, the transaction fails verification.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Unit Testing
- [ ] Run Application
- [ ] Local Computer Tests
- [ ] No Testing


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
