### PR TITLE
Avoid saving and copying the `StorageKey.key` twice.

### DIFF
--- a/src/Neo/Persistence/StoreCache.cs
+++ b/src/Neo/Persistence/StoreCache.cs
@@ -89,7 +89,7 @@ public sealed class StoreCache : DataCache, IDisposable
 
     protected override IEnumerable<(StorageKey, StorageItem)> SeekInternal(byte[] keyOrPrefix, SeekDirection direction)
     {
-        return _store.Find(keyOrPrefix, direction).Select(p => (new StorageKey(p.Key, false), new StorageItem(p.Value)));
+        return _store.Find(keyOrPrefix, direction).Select(p => (new StorageKey(p.Key), new StorageItem(p.Value)));
     }
 
     /// <inheritdoc/>

--- a/src/Neo/SmartContract/KeyBuilder.cs
+++ b/src/Neo/SmartContract/KeyBuilder.cs
@@ -111,5 +111,5 @@ public class KeyBuilder : IEnumerable
     /// <returns>The storage key.</returns>
     public byte[] ToArray() => _cacheData[.._keyLength];
 
-    public static implicit operator StorageKey(KeyBuilder builder) => new(builder._cacheData.AsMemory(0, builder._keyLength), false);
+    public static implicit operator StorageKey(KeyBuilder builder) => new(builder._cacheData.AsMemory(0, builder._keyLength));
 }

--- a/src/Neo/SmartContract/StorageKey.cs
+++ b/src/Neo/SmartContract/StorageKey.cs
@@ -24,42 +24,39 @@ public sealed record StorageKey
     /// <summary>
     /// The id of the contract.
     /// </summary>
-    public int Id { get; init; }
+    public int Id
+    {
+        get => _id;
+        init
+        {
+            if (!_memory.IsEmpty)
+                BinaryPrimitives.WriteInt32LittleEndian(_memory.Span, value);
+            _id = value;
+        }
+    }
 
     /// <summary>
     /// The key of the storage entry.
     /// </summary>
     public ReadOnlyMemory<byte> Key
     {
-        get => _key;
-        // The example below shows how you would of been
-        // able to overwrite keys in the pass
-        // Example:
-        //      byte[] keyData = [0x00, 0x00, 0x00, 0x00, 0x12];
-        //      var keyMemory = new ReadOnlyMemory<byte>(keyData);
-        //      var storageKey1 = new StorageKey { Id = 0, Key = keyMemory };
-        //      // Below will overwrite the key in "storageKey1.Key"
-        //      keyData[0] = 0xff;
-        init => _key = value.ToArray(); // make new region of memory (a copy).
-    }
-
-    /// <summary>
-    /// Get key length
-    /// </summary>
-    public int Length
-    {
-        get
+        get => _memory.IsEmpty ? ReadOnlyMemory<byte>.Empty : _memory[sizeof(int)..];
+        init
         {
-            if (_cache is { IsEmpty: true })
-            {
-                _cache = Build();
-            }
-            return _cache.Length;
+            _memory = new byte[(sizeof(int) + value.Length)];
+            BinaryPrimitives.WriteInt32LittleEndian(_memory.Span, Id);
+            value.CopyTo(_memory[sizeof(int)..]);
         }
     }
 
-    private ReadOnlyMemory<byte> _cache;
-    private readonly ReadOnlyMemory<byte> _key;
+    /// <summary>
+    /// Get StorageKey length(sizeof(int) + key.Length)
+    /// </summary>
+    public int Length => _memory.Length;
+
+    private readonly int _id;
+
+    private readonly Memory<byte> _memory;
 
     // NOTE: StorageKey is readonly, so we can cache the hash code.
     private int _hashCode = 0;
@@ -81,26 +78,20 @@ public sealed record StorageKey
     public StorageKey() { }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="StorageKey"/> class.
+    /// Initializes a StorageKey from not shared memory.
+    /// The size must greater than sizeof(int).
     /// </summary>
-    /// <param name="cache">The cached byte array.</param>
-    internal StorageKey(ReadOnlySpan<byte> cache) : this(cache.ToArray(), false) { }
-
-    internal StorageKey(ReadOnlyMemory<byte> cache, bool copy)
+    internal StorageKey(Memory<byte> memory)
     {
-        if (copy) cache = cache.ToArray();
-        _cache = cache;
-        Id = BinaryPrimitives.ReadInt32LittleEndian(_cache.Span);
-        Key = _cache[sizeof(int)..]; // "Key" init makes a copy already.
+        _memory = memory;
+        Id = BinaryPrimitives.ReadInt32LittleEndian(_memory.Span);
     }
 
     public bool Equals(StorageKey? other)
     {
-        if (other is null)
-            return false;
-        if (ReferenceEquals(this, other))
-            return true;
-        return Id == other.Id && Key.Span.SequenceEqual(other.Key.Span);
+        if (other is null) return false;
+        if (ReferenceEquals(this, other)) return true;
+        return Id == other.Id && _memory.Span.SequenceEqual(other._memory.Span);
     }
 
     public override int GetHashCode()
@@ -112,32 +103,26 @@ public sealed record StorageKey
 
     public byte[] ToArray()
     {
-        if (_cache is { IsEmpty: true })
+        if (_memory.IsEmpty)
         {
-            _cache = Build();
+            var buffer = new byte[sizeof(int)];
+            BinaryPrimitives.WriteInt32LittleEndian(buffer, Id);
+            return buffer;
         }
-        return _cache.ToArray(); // Make a copy
-    }
-
-    private byte[] Build()
-    {
-        var buffer = new byte[sizeof(int) + Key.Length];
-        BinaryPrimitives.WriteInt32LittleEndian(buffer.AsSpan(), Id);
-        Key.CopyTo(buffer.AsMemory(sizeof(int)..));
-        return buffer;
+        return _memory.ToArray();
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static implicit operator StorageKey(byte[] value) => new(value);
+    public static implicit operator StorageKey(byte[] value) => new(value[..].AsMemory());
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static implicit operator StorageKey(ReadOnlyMemory<byte> value) => new(value, true);
+    public static implicit operator StorageKey(ReadOnlyMemory<byte> value) => new(value.ToArray().AsMemory());
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static implicit operator StorageKey(ReadOnlySpan<byte> value) => new(value);
+    public static implicit operator StorageKey(ReadOnlySpan<byte> value) => new(value.ToArray().AsMemory());
 
     public override string ToString()
     {
-        return _key.IsEmpty ? $"StorageKey{{Id={Id}}}" : $"StorageKey{{Id={Id},Key={_key.ToHexString()}}}";
+        return _memory.IsEmpty ? $"StorageKey{{Id={Id}}}" : $"StorageKey{{Id={Id},Key={Key.ToHexString()}}}";
     }
 }

--- a/tests/Neo.UnitTests/SmartContract/UT_Storage.cs
+++ b/tests/Neo.UnitTests/SmartContract/UT_Storage.cs
@@ -73,7 +73,7 @@ public class UT_Storage
         // Make sure we create copies of the memory in StorageKey class
         // WE DO NOT WANT DATA REFERENCED TO OVER THE MEMORY REGION
         byte[] dataCopy = [0xff, 0xff, 0xff, 0xfe, 0xff];
-        storageKey2 = new StorageKey(dataCopy);
+        storageKey2 = dataCopy;
         Assert.IsTrue(storageKey2.Key.Span.SequenceEqual([(byte)0xff]));
         Assert.AreNotEqual(storageKey1, storageKey2);
         ((byte[])[0x00, 0x00, 0x00, 0x00, 0x01]).CopyTo(dataCopy.AsMemory());
@@ -82,6 +82,18 @@ public class UT_Storage
         // This shows data isn't referenced
         dataCopy.CopyTo(keyData.AsMemory());
         Assert.IsFalse(storageKey1.Key.Span.SequenceEqual(dataCopy));
+
+        var onlyId = new StorageKey { Id = 1 };
+        Assert.AreEqual("01000000", onlyId.ToArray().ToHexString());
+
+        var onlyKey = new StorageKey { Key = new ReadOnlyMemory<byte>([0x01, 0x02, 0x03]) };
+        Assert.AreEqual("00000000010203", onlyKey.ToArray().ToHexString());
+
+        var idKey = new StorageKey { Id = 1, Key = new ReadOnlyMemory<byte>([0x01, 0x02, 0x03]) };
+        Assert.AreEqual("01000000010203", idKey.ToArray().ToHexString());
+
+        idKey = new StorageKey { Key = new ReadOnlyMemory<byte>([0x04, 0x05, 0x06]), Id = 2 };
+        Assert.AreEqual("02000000040506", idKey.ToArray().ToHexString());
     }
 
     [TestMethod]


### PR DESCRIPTION
# Description

Avoid saving and copying the key twice for the `StorageKey`:
1. Two copies: `_cache` and `_key`;
2. Copy Twice: Copy to `_cache` and `_key`;

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Unit Testing
- [ ] Run Application
- [ ] Local Computer Tests
- [ ] No Testing


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
