### PR TITLE
[N3] - Optimize ECRecover

### DIFF
--- a/src/Neo/Cryptography/Crypto.cs
+++ b/src/Neo/Cryptography/Crypto.cs
@@ -426,7 +426,7 @@ namespace Neo.Cryptography
                     // yParity is fused into the top bit of s.
 
                     r = new BigInteger(1, signature[..32]);
-                    var yParityAndS = new BigInteger(1, signature[32..64]);
+                    var yParityAndS = new BigInteger(1, signature[32..]);
 
                     // Mask out top bit to get s
                     var mask = BigInteger.One.ShiftLeft(255).Subtract(BigInteger.One);

--- a/src/Neo/Cryptography/Crypto.cs
+++ b/src/Neo/Cryptography/Crypto.cs
@@ -411,8 +411,8 @@ namespace Neo.Cryptography
                 if (signature.Length == 65)
                 {
                     // Format: r[32] || s[32] || v[1]
-                    r = new BigInteger(1, [.. signature.Take(32)]);
-                    s = new BigInteger(1, [.. signature.Skip(32).Take(32)]);
+                    r = new BigInteger(1, signature[..32]);
+                    s = new BigInteger(1, signature[32..64]);
 
                     // v could be 0..3 or 27..30 (Ethereum style).
                     var v = signature[64];
@@ -425,8 +425,8 @@ namespace Neo.Cryptography
                     // 64 bytes "compact" format: r[32] || yParityAndS[32]
                     // yParity is fused into the top bit of s.
 
-                    r = new BigInteger(1, [.. signature.Take(32)]);
-                    var yParityAndS = new BigInteger(1, signature.Skip(32).ToArray());
+                    r = new BigInteger(1, signature[..32]);
+                    var yParityAndS = new BigInteger(1, signature[32..64]);
 
                     // Mask out top bit to get s
                     var mask = BigInteger.One.ShiftLeft(255).Subtract(BigInteger.One);


### PR DESCRIPTION
# Description

`signature.Take(32)`, `signature.Skip(32).Take(32)` and `signature.Skip(32).ToArray()` create LINQ iterators and temporary arrays. Since signature is a byte[] it can be split directly.

## Type of change

- [x] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Unit Testing
- [ ] Run Application
- [ ] Local Computer Tests
- [ ] No Testing


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
