### PR TITLE
crypto: check for R and S in ECRecover

### DIFF
--- a/src/Neo/Cryptography/Crypto.cs
+++ b/src/Neo/Cryptography/Crypto.cs
@@ -397,6 +397,17 @@ namespace Neo.Cryptography
         /// <exception cref="ArgumentException">Thrown if signature or hash is invalid</exception>
         public static ECC.ECPoint ECRecover(byte[] signature, byte[] hash)
         {
+            return ECRecoverInternal(signature, hash, true);
+        }
+
+        // Similar to ECRecover, has known bugs, for compatibility only.
+        public static ECC.ECPoint ECRecoverV0(byte[] signature, byte[] hash)
+        {
+            return ECRecoverInternal(signature, hash, false);
+        }
+
+        internal static ECC.ECPoint ECRecoverInternal(byte[] signature, byte[] hash, bool checkRS)
+        {
             if (signature.Length != 65 && signature.Length != 64)
                 throw new ArgumentException("Signature must be 65 or 64 bytes", nameof(signature));
             if (hash.Length != 32)
@@ -440,12 +451,16 @@ namespace Neo.Cryptography
                     recId = yParity ? 1 : 0;
                 }
 
+                // BouncyCastle curve constant
+                var n = ECC.ECCurve.Secp256k1.BouncyCastleCurve.N;
+
+                if (checkRS && (r.SignValue == 0 || s.SignValue == 0 || r.CompareTo(n) >= 0 || s.CompareTo(n) >= 0))
+                    throw new ArgumentException("Invalid R or S value", nameof(signature));
+
                 // Decompose recId into i = recId >> 1 and yBit = recId & 1
                 var iPart = recId >> 1;   // usually 0..1
                 var yBit = (recId & 1) == 1;
 
-                // BouncyCastle curve constants
-                var n = ECC.ECCurve.Secp256k1.BouncyCastleCurve.N;
                 var e = new BigInteger(1, hash);
 
                 // eInv = -e mod n

--- a/src/Neo/SmartContract/Native/CryptoLib.cs
+++ b/src/Neo/SmartContract/Native/CryptoLib.cs
@@ -39,8 +39,8 @@ namespace Neo.SmartContract.Native
         /// <param name="messageHash">The hash of the message that was signed.</param>
         /// <param name="signature">The 65-byte signature in format: r[32] + s[32] + v[1]. 64-bytes for eip-2098, where v must be 27 or 28.</param>
         /// <returns>The recovered public key in compressed format, or null if recovery fails.</returns>
-        [ContractMethod(Hardfork.HF_Echidna, CpuFee = 1 << 15, Name = "recoverSecp256K1")]
-        public static byte[]? RecoverSecp256K1(byte[] messageHash, byte[] signature)
+        [ContractMethod(Hardfork.HF_Huyao, CpuFee = 1 << 15, Name = "recoverSecp256K1")]
+        public static byte[]? RecoverSecp256K1V1(byte[] messageHash, byte[] signature)
         {
             // It will be checked in Crypto.ECRecover
             // if (signature.Length != 65 && signature.Length != 64)
@@ -49,6 +49,21 @@ namespace Neo.SmartContract.Native
             try
             {
                 var point = Crypto.ECRecover(signature, messageHash);
+                return point.EncodePoint(true);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        // Compatibility only, doesn't check for R and S validity.
+        [ContractMethod(Hardfork.HF_Echidna, Hardfork.HF_Huyao, CpuFee = 1 << 15, Name = "recoverSecp256K1")]
+        public static byte[]? RecoverSecp256K1V0(byte[] messageHash, byte[] signature)
+        {
+            try
+            {
+                var point = Crypto.ECRecoverV0(signature, messageHash);
                 return point.EncodePoint(true);
             }
             catch

--- a/tests/Neo.UnitTests/Cryptography/UT_Crypto.cs
+++ b/tests/Neo.UnitTests/Cryptography/UT_Crypto.cs
@@ -185,6 +185,13 @@ namespace Neo.UnitTests.Cryptography
             // Test with wrong message hash
             var recoveredWrongHash = Crypto.ECRecover(signature1, messageHash2);
             CollectionAssert.AreNotEquivalent(expectedPubKey1, recoveredWrongHash.EncodePoint(true));
+
+            // Zero S can't be valid.
+            var invalidSSignature = signature1.ToArray();
+            Array.Copy(invalidSignature, 0, invalidSSignature, 32, 32); // Zero out S.
+            Assert.ThrowsExactly<ArgumentException>(() => _ = Crypto.ECRecover(invalidSSignature, messageHash1));
+            // But compatibility code still allows for that.
+            _ = Crypto.ECRecoverV0(invalidSSignature, messageHash1);
         }
 
         [TestMethod]


### PR DESCRIPTION
R and S can not be zero and are always less than N by their definition, so proper signature recovery (or verification) algorithms start with checking their validity otherwise some key can be recovered from an invalid signature with unknown security consequences.

This was initially reported as execution result difference between NeoGo and C# node, since NeoGo libraries do perform these checks by default. Since this is a behavior change for native contract the change is introduced with Huyao hardfork gate.

Reported-by: Majid Mohammed <majidcoderlun3x@gmail.com>
