### PR TITLE
[Coverage 1/N] Add more StringExtensions unit tests

### DIFF
--- a/tests/Neo.Extensions.Tests/UT_StringExtensions.cs
+++ b/tests/Neo.Extensions.Tests/UT_StringExtensions.cs
@@ -480,12 +480,6 @@ namespace Neo.Extensions.Tests
             Assert.IsTrue(ex.Message.Contains("Length: 40 bytes"));
         }
 
-        [TestMethod]
-        public void TestHexToBytes_Null_ReturnsEmpty()
-        {
-            string? value = null;
-            CollectionAssert.AreEqual(Array.Empty<byte>(), value.HexToBytes());
-        }
 
         [TestMethod]
         public void TestHexToBytes_Span_OddLength_Throws()

--- a/tests/Neo.Extensions.Tests/UT_StringExtensions.cs
+++ b/tests/Neo.Extensions.Tests/UT_StringExtensions.cs
@@ -436,6 +436,86 @@ namespace Neo.Extensions.Tests
             Assert.IsNull(value);
         }
 
+        [TestMethod]
+        public void TestTryToStrictUtf8String_Success()
+        {
+            ReadOnlySpan<byte> span = "hello"u8;
+            Assert.IsTrue(span.TryToStrictUtf8String(out var value));
+            Assert.AreEqual("hello", value);
+        }
+
+        [TestMethod]
+        public void TestToStrictUtf8String_ByteArrayWithRange_InvalidUtf8_Throws()
+        {
+            byte[] invalidUtf8 = [0x41, 0xFF, 0xFE];
+            var ex = Assert.ThrowsExactly<DecoderFallbackException>(() => invalidUtf8.ToStrictUtf8String(0, 3));
+            Assert.IsTrue(ex.Message.Contains("Failed to decode byte array range"));
+            Assert.IsTrue(ex.Message.Contains("invalid UTF-8"));
+        }
+
+        [TestMethod]
+        public void TestToStrictUtf8String_ByteArrayWithRange_Null_Throws()
+        {
+            byte[]? nullArray = null;
+            var ex = Assert.ThrowsExactly<ArgumentNullException>(() => nullArray!.ToStrictUtf8String(0, 1));
+            Assert.AreEqual("value", ex.ParamName);
+        }
+
+        [TestMethod]
+        public void TestToStrictUtf8String_ByteArrayWithRange_LargeInvalid_ShowsLengthInMessage()
+        {
+            var large = new byte[50];
+            Array.Fill(large, (byte)0xFF);
+            var ex = Assert.ThrowsExactly<DecoderFallbackException>(() => large.ToStrictUtf8String(0, 50));
+            Assert.IsTrue(ex.Message.Contains("Length: 50 bytes"));
+            Assert.IsTrue(ex.Message.Contains("First 16:"));
+        }
+
+        [TestMethod]
+        public void TestToStrictUtf8String_ReadOnlySpan_LargeInvalid_ShowsLengthInMessage()
+        {
+            var large = new byte[40];
+            Array.Fill(large, (byte)0xFF);
+            var ex = Assert.ThrowsExactly<DecoderFallbackException>(() => ((ReadOnlySpan<byte>)large).ToStrictUtf8String());
+            Assert.IsTrue(ex.Message.Contains("Length: 40 bytes"));
+        }
+
+        [TestMethod]
+        public void TestHexToBytes_Null_ReturnsEmpty()
+        {
+            string? value = null;
+            CollectionAssert.AreEqual(Array.Empty<byte>(), value.HexToBytes());
+        }
+
+        [TestMethod]
+        public void TestHexToBytes_Span_OddLength_Throws()
+        {
+            var ex = Assert.ThrowsExactly<FormatException>(() => "abc".AsSpan().HexToBytes());
+            Assert.IsTrue(ex.Message.Contains("Failed to convert hex span to bytes"));
+        }
+
+        [TestMethod]
+        public void TestHexToBytesReversed_OddLength_Throws()
+        {
+            var ex = Assert.ThrowsExactly<FormatException>(() => "abc".AsSpan().HexToBytesReversed());
+            Assert.IsTrue(ex.Message.Contains("Failed to convert hex span to reversed bytes"));
+        }
+
+        [TestMethod]
+        public void TestTrimStartIgnoreCase_NoMatch_ReturnsOriginal()
+        {
+            Assert.AreEqual("hello", "hello".AsSpan().TrimStartIgnoreCase("0x").ToString());
+            Assert.AreEqual("0x", "0x".AsSpan().TrimStartIgnoreCase("00").ToString());
+        }
+
+        [TestMethod]
+        public void TestIsHex_NullAndInvalidChars()
+        {
+            Assert.IsFalse(((string?)null)!.IsHex());
+            Assert.IsFalse("0G".IsHex());
+            Assert.IsTrue("AbCdEf".IsHex());
+        }
+
         #endregion
     }
 }


### PR DESCRIPTION
# Description

Adds unit tests for uncovered `StringExtensions` paths: `TryToStrictUtf8String` success, range decode failures, hex edge cases, `IsHex`, and `TrimStartIgnoreCase` no-match.

**Independent coverage PR** — only touches `tests/Neo.Extensions.Tests/UT_StringExtensions.cs`. No product code changes.

# Change Log

- Modified `tests/Neo.Extensions.Tests/UT_StringExtensions.cs`

## Type of change

- [x] Style (the change is only a code style for better maintenance or standard purpose)

# How Has This Been Tested?

- [x] Unit Testing

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings