### PR TITLE
Fix GroupCondition equality to use ECPoint.Equals

### DIFF
--- a/src/Neo/Network/P2P/Payloads/Conditions/CalledByGroupCondition.cs
+++ b/src/Neo/Network/P2P/Payloads/Conditions/CalledByGroupCondition.cs
@@ -43,7 +43,7 @@ namespace Neo.Network.P2P.Payloads.Conditions
             if (other is null) return false;
             return
                 Type == other.Type &&
-                Group == other.Group;
+                Group.Equals(other.Group);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Neo/Network/P2P/Payloads/Conditions/CalledByGroupCondition.cs
+++ b/src/Neo/Network/P2P/Payloads/Conditions/CalledByGroupCondition.cs
@@ -43,7 +43,7 @@ namespace Neo.Network.P2P.Payloads.Conditions
             if (other is null) return false;
             return
                 Type == other.Type &&
-                Group.Equals(other.Group);
+                Equals(Group, other.Group);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Neo/Network/P2P/Payloads/Conditions/GroupCondition.cs
+++ b/src/Neo/Network/P2P/Payloads/Conditions/GroupCondition.cs
@@ -43,7 +43,7 @@ namespace Neo.Network.P2P.Payloads.Conditions
             if (other is null) return false;
             return
                 Type == other.Type &&
-                Group == other.Group;
+                Group.Equals(other.Group);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Neo/Network/P2P/Payloads/Conditions/GroupCondition.cs
+++ b/src/Neo/Network/P2P/Payloads/Conditions/GroupCondition.cs
@@ -43,7 +43,7 @@ namespace Neo.Network.P2P.Payloads.Conditions
             if (other is null) return false;
             return
                 Type == other.Type &&
-                Group.Equals(other.Group);
+                Equals(Group, other.Group);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/tests/Neo.UnitTests/Network/P2P/Payloads/UT_GroupCondition_Equals.cs
+++ b/tests/Neo.UnitTests/Network/P2P/Payloads/UT_GroupCondition_Equals.cs
@@ -1,0 +1,54 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// UT_GroupCondition_Equals.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.Cryptography.ECC;
+using Neo.Extensions;
+using Neo.IO;
+using Neo.Network.P2P.Payloads.Conditions;
+
+namespace Neo.UnitTests.Network.P2P.Payloads
+{
+    [TestClass]
+    public class UT_GroupCondition_Equals
+    {
+        private static readonly ECPoint s_point = ECPoint.Parse(
+            "03b209fd4f53a7170ea4444e0cb0a6bb6a53c2bd016926989cf85f9b0fba17a70c", ECCurve.Secp256r1);
+
+        [TestMethod]
+        public void GroupCondition_Equals_AfterDeserialize_UsesValueEquality()
+        {
+            // ECPoint has no operator==; Equals must use Group.Equals so deserialized
+            // instances with equal points compare equal (not reference equality).
+            var original = new GroupCondition { Group = s_point };
+            var reader = new MemoryReader(original.ToArray());
+            var clone = (GroupCondition)WitnessCondition.DeserializeFrom(ref reader, WitnessCondition.MaxNestingDepth);
+
+            Assert.IsTrue(original.Group.Equals(clone.Group));
+            Assert.IsTrue(original.Equals(clone));
+            Assert.IsTrue(original == clone);
+            Assert.AreEqual(original.GetHashCode(), clone.GetHashCode());
+        }
+
+        [TestMethod]
+        public void CalledByGroupCondition_Equals_AfterDeserialize_UsesValueEquality()
+        {
+            var original = new CalledByGroupCondition { Group = s_point };
+            var reader = new MemoryReader(original.ToArray());
+            var clone = (CalledByGroupCondition)WitnessCondition.DeserializeFrom(ref reader, WitnessCondition.MaxNestingDepth);
+
+            Assert.IsTrue(original.Group.Equals(clone.Group));
+            Assert.IsTrue(original.Equals(clone));
+            Assert.IsTrue(original == clone);
+            Assert.AreEqual(original.GetHashCode(), clone.GetHashCode());
+        }
+    }
+}


### PR DESCRIPTION
# Description

`GroupCondition` and `CalledByGroupCondition` used `Group == other.Group`. `ECPoint` has no `operator==`, so this is **reference equality**. After deserialize (or any value-equal but distinct instances), `IEquatable` and `==` incorrectly returned false even when public keys matched.

**Fix:** use `Group.Equals(other.Group)`.

Includes a regression test that fails without the fix.

# Change Log

- Modified `src/Neo/Network/P2P/Payloads/Conditions/GroupCondition.cs`
- Modified `src/Neo/Network/P2P/Payloads/Conditions/CalledByGroupCondition.cs`
- Added `tests/Neo.UnitTests/Network/P2P/Payloads/UT_GroupCondition_Equals.cs`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Unit Testing (`UT_GroupCondition_Equals`)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings