### PR TITLE
[Coverage 10/N] Add ChannelsConfig defaults and MessageFlags tests

### DIFF
--- a/tests/Neo.UnitTests/Network/P2P/UT_ChannelsConfig_Defaults.cs
+++ b/tests/Neo.UnitTests/Network/P2P/UT_ChannelsConfig_Defaults.cs
@@ -1,0 +1,57 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// UT_ChannelsConfig_Defaults.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.Network.P2P;
+
+namespace Neo.UnitTests.Network.P2P
+{
+    /// <summary>
+    /// Default constant coverage not asserted in UT_ChannelsConfig.CreateTest.
+    /// </summary>
+    [TestClass]
+    public class UT_ChannelsConfig_Defaults
+    {
+        [TestMethod]
+        public void DefaultConstants_MatchPublicFields()
+        {
+            Assert.IsTrue(ChannelsConfig.DefaultEnableCompression);
+            Assert.AreEqual(10, ChannelsConfig.DefaultMinDesiredConnections);
+            Assert.AreEqual(40, ChannelsConfig.DefaultMaxConnections);
+            Assert.AreEqual(3, ChannelsConfig.DefaultMaxConnectionsPerAddress);
+            Assert.AreEqual(1000, ChannelsConfig.DefaultMaxKnownHashes);
+        }
+
+        [TestMethod]
+        public void NewInstance_UsesCompressionAndKnownHashesDefaults()
+        {
+            var config = new ChannelsConfig();
+            Assert.AreEqual(ChannelsConfig.DefaultEnableCompression, config.EnableCompression);
+            Assert.AreEqual(ChannelsConfig.DefaultMaxKnownHashes, config.MaxKnownHashes);
+        }
+
+        [TestMethod]
+        public void EnableCompression_CanBeDisabled()
+        {
+            var config = new ChannelsConfig { EnableCompression = false };
+            Assert.IsFalse(config.EnableCompression);
+        }
+
+        [TestMethod]
+        public void MessageFlags_Compressed_IsDistinctFromNone()
+        {
+            Assert.AreEqual(MessageFlags.None, (MessageFlags)0);
+            Assert.AreNotEqual(MessageFlags.None, MessageFlags.Compressed);
+            Assert.IsTrue(MessageFlags.Compressed.HasFlag(MessageFlags.Compressed));
+            Assert.IsFalse(MessageFlags.None.HasFlag(MessageFlags.Compressed));
+        }
+    }
+}


### PR DESCRIPTION
# Description

Asserts `ChannelsConfig` default constants, `EnableCompression` / `MaxKnownHashes` defaults, and `MessageFlags.Compressed` vs `None`.

**Independent** — only adds `UT_ChannelsConfig_Defaults.cs` (does not modify `UT_ChannelsConfig.cs`).

# Change Log
- Added `tests/Neo.UnitTests/Network/P2P/UT_ChannelsConfig_Defaults.cs`

## Type of change
- [x] Style (code style / maintenance)

# How Has This Been Tested?
- [x] Unit Testing