### PR TITLE
[Coverage 81/N] Add DisableCompressionCapability unit tests

### DIFF
--- a/tests/Neo.UnitTests/Network/P2P/Capabilities/UT_DisableCompressionCapability.cs
+++ b/tests/Neo.UnitTests/Network/P2P/Capabilities/UT_DisableCompressionCapability.cs
@@ -1,0 +1,38 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// UT_DisableCompressionCapability.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.Extensions;
+using Neo.Network.P2P.Capabilities;
+
+namespace Neo.UnitTests.Network.P2P.Capabilities
+{
+    [TestClass]
+    public class UT_DisableCompressionCapability
+    {
+        [TestMethod]
+        public void Size_And_Type()
+        {
+            var cap = new DisableCompressionCapability();
+            Assert.AreEqual(2, cap.Size);
+            Assert.AreEqual(NodeCapabilityType.DisableCompression, cap.Type);
+        }
+
+        [TestMethod]
+        public void Serialize_WritesTypeAndZeroByte()
+        {
+            var bytes = new DisableCompressionCapability().ToArray();
+            Assert.HasCount(2, bytes);
+            Assert.AreEqual((byte)NodeCapabilityType.DisableCompression, bytes[0]);
+            Assert.AreEqual(0, bytes[1]);
+        }
+    }
+}


### PR DESCRIPTION
# Description

Adds unit tests for `DisableCompressionCapability` size, type, and serialize layout.

**Independent** — only adds `UT_DisableCompressionCapability.cs`.

## Type of change
- [x] Style (code style / maintenance)

# How Has This Been Tested?
- [x] Unit Testing