### PR TITLE
[Coverage] Grouped tests: ApplicationEngine helpers and ledger

### DIFF
--- a/tests/Neo.UnitTests/Ledger/UT_ApplicationExecuted.cs
+++ b/tests/Neo.UnitTests/Ledger/UT_ApplicationExecuted.cs
@@ -1,0 +1,75 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// UT_ApplicationExecuted.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.Ledger;
+using Neo.Network.P2P.Payloads;
+using Neo.SmartContract;
+using Neo.VM;
+using System;
+
+namespace Neo.UnitTests.Ledger
+{
+    [TestClass]
+    public class UT_ApplicationExecuted
+    {
+        [TestMethod]
+        public void FromEngine_Halt_WithoutTransaction()
+        {
+            var snapshot = TestBlockchain.GetTestSnapshotCache();
+            using var engine = ApplicationEngine.Run(new byte[] { (byte)OpCode.PUSH1 }, snapshot);
+            Assert.AreEqual(VMState.HALT, engine.State);
+
+            var executed = new Blockchain.ApplicationExecuted(engine);
+            Assert.IsNull(executed.Transaction);
+            Assert.AreEqual(TriggerType.Application, executed.Trigger);
+            Assert.AreEqual(VMState.HALT, executed.VMState);
+            Assert.IsNull(executed.Exception);
+            Assert.IsTrue(executed.GasConsumed >= 0);
+            Assert.HasCount(1, executed.Stack);
+            Assert.IsEmpty(executed.Notifications);
+        }
+
+        [TestMethod]
+        public void FromEngine_Fault_CapturesException()
+        {
+            var snapshot = TestBlockchain.GetTestSnapshotCache();
+            using var engine = ApplicationEngine.Run(new byte[] { (byte)OpCode.ABORT }, snapshot);
+            Assert.AreEqual(VMState.FAULT, engine.State);
+
+            var executed = new Blockchain.ApplicationExecuted(engine);
+            Assert.AreEqual(VMState.FAULT, executed.VMState);
+            Assert.IsNotNull(executed.Exception);
+            Assert.IsInstanceOfType<Exception>(executed.Exception);
+        }
+
+        [TestMethod]
+        public void FromEngine_WithTransactionContainer()
+        {
+            var snapshot = TestBlockchain.GetTestSnapshotCache();
+            var tx = new Transaction
+            {
+                Version = 0,
+                Nonce = 1,
+                SystemFee = 0,
+                NetworkFee = 0,
+                ValidUntilBlock = 100,
+                Attributes = [],
+                Signers = [new Signer { Account = UInt160.Zero, Scopes = WitnessScope.None }],
+                Script = new byte[] { (byte)OpCode.RET },
+                Witnesses = []
+            };
+            using var engine = ApplicationEngine.Run(new byte[] { (byte)OpCode.RET }, snapshot, container: tx);
+            var executed = new Blockchain.ApplicationExecuted(engine);
+            Assert.AreSame(tx, executed.Transaction);
+        }
+    }
+}

--- a/tests/Neo.UnitTests/Ledger/UT_NewTransactionEventArgs.cs
+++ b/tests/Neo.UnitTests/Ledger/UT_NewTransactionEventArgs.cs
@@ -1,0 +1,55 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// UT_NewTransactionEventArgs.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.Ledger;
+using Neo.Network.P2P.Payloads;
+using Neo.Persistence;
+using Neo.Persistence.Providers;
+
+namespace Neo.UnitTests.Ledger
+{
+    [TestClass]
+    public class UT_NewTransactionEventArgs
+    {
+        [TestMethod]
+        public void Properties_And_Cancel()
+        {
+            var tx = new Transaction
+            {
+                Version = 0,
+                Nonce = 2,
+                SystemFee = 0,
+                NetworkFee = 0,
+                ValidUntilBlock = 10,
+                Attributes = [],
+                Signers = [new Signer { Account = UInt160.Zero, Scopes = WitnessScope.None }],
+                Script = new byte[] { 0x41 },
+                Witnesses = []
+            };
+
+            using var store = new MemoryStore();
+            using var cache = new StoreCache(store);
+            var args = new NewTransactionEventArgs
+            {
+                Transaction = tx,
+                Snapshot = cache
+            };
+
+            Assert.AreSame(tx, args.Transaction);
+            Assert.AreSame(cache, args.Snapshot);
+            Assert.IsFalse(args.Cancel);
+
+            args.Cancel = true;
+            Assert.IsTrue(args.Cancel);
+        }
+    }
+}

--- a/tests/Neo.UnitTests/Ledger/UT_TransactionRemovedEventArgs.cs
+++ b/tests/Neo.UnitTests/Ledger/UT_TransactionRemovedEventArgs.cs
@@ -1,0 +1,48 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// UT_TransactionRemovedEventArgs.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.Ledger;
+using Neo.Network.P2P.Payloads;
+
+namespace Neo.UnitTests.Ledger
+{
+    [TestClass]
+    public class UT_TransactionRemovedEventArgs
+    {
+        [TestMethod]
+        public void Properties_RoundTrip()
+        {
+            var tx = new Transaction
+            {
+                Version = 0,
+                Nonce = 1,
+                SystemFee = 0,
+                NetworkFee = 0,
+                ValidUntilBlock = 100,
+                Attributes = [],
+                Signers = [new Signer { Account = UInt160.Zero, Scopes = WitnessScope.None }],
+                Script = new byte[] { 0x40 },
+                Witnesses = []
+            };
+
+            var args = new TransactionRemovedEventArgs
+            {
+                Transactions = [tx],
+                Reason = TransactionRemovalReason.CapacityExceeded
+            };
+
+            Assert.AreEqual(1, args.Transactions.Count);
+            Assert.AreSame(tx, System.Linq.Enumerable.First(args.Transactions));
+            Assert.AreEqual(TransactionRemovalReason.CapacityExceeded, args.Reason);
+        }
+    }
+}

--- a/tests/Neo.UnitTests/Ledger/UT_TransactionRouter_Records.cs
+++ b/tests/Neo.UnitTests/Ledger/UT_TransactionRouter_Records.cs
@@ -1,0 +1,53 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// UT_TransactionRouter_Records.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.Ledger;
+using Neo.Network.P2P.Payloads;
+
+namespace Neo.UnitTests.Ledger
+{
+    [TestClass]
+    public class UT_TransactionRouter_Records
+    {
+        private static Transaction SampleTx() => new()
+        {
+            Version = 0,
+            Nonce = 1,
+            SystemFee = 0,
+            NetworkFee = 0,
+            ValidUntilBlock = 10,
+            Attributes = [],
+            Signers = [new Signer { Account = UInt160.Zero, Scopes = WitnessScope.None }],
+            Script = new byte[] { 0x40 },
+            Witnesses = []
+        };
+
+        [TestMethod]
+        public void Preverify_Record_HoldsFields()
+        {
+            var tx = SampleTx();
+            var msg = new TransactionRouter.Preverify(tx, Relay: true);
+            Assert.AreSame(tx, msg.Transaction);
+            Assert.IsTrue(msg.Relay);
+        }
+
+        [TestMethod]
+        public void PreverifyCompleted_Record_HoldsFields()
+        {
+            var tx = SampleTx();
+            var msg = new TransactionRouter.PreverifyCompleted(tx, Relay: false, VerifyResult.Succeed);
+            Assert.AreSame(tx, msg.Transaction);
+            Assert.IsFalse(msg.Relay);
+            Assert.AreEqual(VerifyResult.Succeed, msg.Result);
+        }
+    }
+}

--- a/tests/Neo.UnitTests/SmartContract/UT_ApplicationEngine_Helper.cs
+++ b/tests/Neo.UnitTests/SmartContract/UT_ApplicationEngine_Helper.cs
@@ -1,0 +1,49 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// UT_ApplicationEngine_Helper.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.SmartContract;
+using Neo.VM;
+using System;
+
+namespace Neo.UnitTests.SmartContract
+{
+    [TestClass]
+    public class UT_ApplicationEngine_Helper
+    {
+        [TestMethod]
+        public void FaultHelpers_ReturnEmpty_WhenNotFaulted()
+        {
+            var snapshot = TestBlockchain.GetTestSnapshotCache();
+            using var engine = ApplicationEngine.Create(TriggerType.Application, null, snapshot);
+            Assert.AreEqual(VMState.BREAK, engine.State);
+            Assert.AreEqual("", engine.GetEngineStackInfoOnFault());
+            Assert.AreEqual("", engine.GetEngineExceptionInfo());
+        }
+
+        [TestMethod]
+        public void FaultHelpers_IncludeMessage_WhenFaulted()
+        {
+            var snapshot = TestBlockchain.GetTestSnapshotCache();
+            // ABORT forces FAULT
+            using var engine = ApplicationEngine.Run(new byte[] { (byte)OpCode.ABORT }, snapshot);
+            Assert.AreEqual(VMState.FAULT, engine.State);
+            Assert.IsNotNull(engine.FaultException);
+
+            var messageOnly = engine.GetEngineExceptionInfo(exceptionStackTrace: false, exceptionMessage: true);
+            Assert.IsFalse(string.IsNullOrWhiteSpace(messageOnly));
+
+            var stackInfo = engine.GetEngineStackInfoOnFault(exceptionStackTrace: false, exceptionMessage: true);
+            Assert.IsTrue(stackInfo.Contains("CurrentScriptHash=", StringComparison.Ordinal));
+            Assert.IsTrue(stackInfo.Contains("EntryScriptHash=", StringComparison.Ordinal));
+        }
+    }
+}

--- a/tests/Neo.UnitTests/UT_NeoSystemExtensions.cs
+++ b/tests/Neo.UnitTests/UT_NeoSystemExtensions.cs
@@ -1,0 +1,45 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// UT_NeoSystemExtensions.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+
+namespace Neo.UnitTests
+{
+    [TestClass]
+    public class UT_NeoSystemExtensions
+    {
+        [TestMethod]
+        public void Snapshot_Helpers_MatchProtocolSettings_BeforeEchidnaPolicyOverride()
+        {
+            var snapshot = TestBlockchain.GetTestSnapshotCache();
+            var settings = TestProtocolSettings.Default;
+
+            Assert.AreEqual(
+                TimeSpan.FromMilliseconds(settings.MillisecondsPerBlock),
+                snapshot.GetTimePerBlock(settings));
+            Assert.AreEqual(settings.MaxValidUntilBlockIncrement, snapshot.GetMaxValidUntilBlockIncrement(settings));
+            Assert.AreEqual(settings.MaxTraceableBlocks, snapshot.GetMaxTraceableBlocks(settings));
+        }
+
+        [TestMethod]
+        public void System_Helpers_MatchSnapshotHelpers()
+        {
+            var system = TestBlockchain.GetSystem();
+            var settings = system.Settings;
+            var snapshot = system.StoreView;
+
+            Assert.AreEqual(snapshot.GetTimePerBlock(settings), system.GetTimePerBlock());
+            Assert.AreEqual(snapshot.GetMaxValidUntilBlockIncrement(settings), system.GetMaxValidUntilBlockIncrement());
+            Assert.AreEqual(snapshot.GetMaxTraceableBlocks(settings), system.GetMaxTraceableBlocks());
+        }
+    }
+}


### PR DESCRIPTION
# Description

Consolidates ApplicationEngine fault helpers, ApplicationExecuted, NeoSystemExtensions, and ledger event tests.

**Related:** #4693 (option 1 — consolidate micro coverage PRs)

## Absorbs micro PRs

- #4650
- #4651
- #4678
- #4680
- #4681
- #4691

## Type of change
- [x] Style (code style / maintenance)

# How Has This Been Tested?
- [x] Unit Testing

## Notes
- Test-only; no product behavior changes.
- Independent of other grouped coverage PRs (based on `master-n3`).
- Pure enum-value slices were dropped and closed separately.
