### PR TITLE
[Coverage] Grouped tests: persistence, IO extensions, and caches

### DIFF
--- a/tests/Neo.UnitTests/Extensions/UT_BinaryReaderExtensions.cs
+++ b/tests/Neo.UnitTests/Extensions/UT_BinaryReaderExtensions.cs
@@ -1,0 +1,73 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// UT_BinaryReaderExtensions.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.Extensions;
+using System;
+using System.IO;
+
+namespace Neo.UnitTests.Extensions
+{
+    [TestClass]
+    public class UT_BinaryReaderExtensions
+    {
+        [TestMethod]
+        public void ReadFixedBytes_ExactSize()
+        {
+            using var ms = new MemoryStream([1, 2, 3, 4]);
+            using var reader = new BinaryReader(ms);
+            var data = reader.ReadFixedBytes(4);
+            Assert.IsTrue(new byte[] { 1, 2, 3, 4 }.AsSpan().SequenceEqual(data));
+        }
+
+        [TestMethod]
+        public void ReadFixedBytes_TruncatedStream_Throws()
+        {
+            using var ms = new MemoryStream([1, 2]);
+            using var reader = new BinaryReader(ms);
+            Assert.ThrowsExactly<FormatException>(() => reader.ReadFixedBytes(4));
+        }
+
+        [TestMethod]
+        public void ReadVarInt_Encodings()
+        {
+            static ulong Read(params byte[] data)
+            {
+                using var ms = new MemoryStream(data);
+                using var reader = new BinaryReader(ms);
+                return reader.ReadVarInt();
+            }
+
+            Assert.AreEqual(0xFCul, Read(0xFC));
+            Assert.AreEqual(0x0100ul, Read(0xFD, 0x00, 0x01));
+            Assert.AreEqual(0x10000ul, Read(0xFE, 0x00, 0x00, 0x01, 0x00));
+        }
+
+        [TestMethod]
+        public void ReadVarInt_ExceedsMax_Throws()
+        {
+            using var ms = new MemoryStream([0x10]);
+            using var reader = new BinaryReader(ms);
+            Assert.ThrowsExactly<FormatException>(() => reader.ReadVarInt(max: 0x0F));
+        }
+
+        [TestMethod]
+        public void ReadVarBytes_RoundTrip()
+        {
+            using var ms = new MemoryStream();
+            using (var writer = new BinaryWriter(ms, System.Text.Encoding.UTF8, true))
+                writer.WriteVarBytes([9, 8, 7]);
+            ms.Position = 0;
+            using var reader = new BinaryReader(ms);
+            Assert.IsTrue(new byte[] { 9, 8, 7 }.AsSpan().SequenceEqual(reader.ReadVarBytes()));
+        }
+    }
+}

--- a/tests/Neo.UnitTests/Extensions/UT_BinaryWriterExtensions.cs
+++ b/tests/Neo.UnitTests/Extensions/UT_BinaryWriterExtensions.cs
@@ -1,0 +1,78 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// UT_BinaryWriterExtensions.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.Extensions;
+using System;
+using System.IO;
+
+namespace Neo.UnitTests.Extensions
+{
+    /// <summary>
+    /// BinaryWriterExtensions edges not fully covered by UT_IOHelper.
+    /// </summary>
+    [TestClass]
+    public class UT_BinaryWriterExtensions
+    {
+        [TestMethod]
+        public void Write_ISerializable_And_Collection()
+        {
+            using var ms = new MemoryStream();
+            using (var writer = new BinaryWriter(ms, System.Text.Encoding.UTF8, true))
+            {
+                writer.Write(UInt160.Zero);
+                writer.Write<UInt160>([UInt160.Zero, UInt160.Parse("0x0000000000000000000000000000000000000001")]);
+            }
+
+            var reader = new Neo.IO.MemoryReader(ms.ToArray());
+            Assert.AreEqual(UInt160.Zero, reader.ReadSerializable<UInt160>());
+            var array = reader.ReadSerializableArray<UInt160>();
+            Assert.HasCount(2, array);
+            Assert.AreEqual(UInt160.Zero, array[0]);
+        }
+
+        [TestMethod]
+        public void Write_Collection_Null_Throws()
+        {
+            using var ms = new MemoryStream();
+            using var writer = new BinaryWriter(ms);
+            Assert.ThrowsExactly<ArgumentNullException>(() => writer.Write<UInt160>(null!));
+        }
+
+        [TestMethod]
+        public void WriteVarString_RoundTrip()
+        {
+            using var ms = new MemoryStream();
+            using (var writer = new BinaryWriter(ms, System.Text.Encoding.UTF8, true))
+                writer.WriteVarString("neo-test");
+
+            ms.Position = 0;
+            using var reader = new BinaryReader(ms);
+            var bytes = reader.ReadVarBytes();
+            Assert.AreEqual("neo-test", System.Text.Encoding.UTF8.GetString(bytes));
+        }
+
+        [TestMethod]
+        public void WriteNullableArray_WithNulls()
+        {
+            using var ms = new MemoryStream();
+            using (var writer = new BinaryWriter(ms, System.Text.Encoding.UTF8, true))
+                writer.WriteNullableArray([UInt256.Zero, null, UInt256.Parse("0x0000000000000000000000000000000000000000000000000000000000000002")]);
+
+            var mem = new Neo.IO.MemoryReader(ms.ToArray());
+            var array = mem.ReadNullableArray<UInt256>();
+            Assert.HasCount(3, array);
+            Assert.AreEqual(UInt256.Zero, array[0]);
+            Assert.IsNull(array[1]);
+            Assert.IsNotNull(array[2]);
+        }
+    }
+}

--- a/tests/Neo.UnitTests/Extensions/UT_ICollection_GetVarSize.cs
+++ b/tests/Neo.UnitTests/Extensions/UT_ICollection_GetVarSize.cs
@@ -1,0 +1,59 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// UT_ICollection_GetVarSize.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.Extensions;
+using Neo.SmartContract;
+using System.Runtime.InteropServices;
+
+namespace Neo.UnitTests.Extensions
+{
+    [TestClass]
+    public class UT_ICollection_GetVarSize
+    {
+        [TestMethod]
+        public void GetVarSize_ISerializable_IncludesElementSizes()
+        {
+            UInt160[] hashes =
+            [
+                UInt160.Zero,
+                UInt160.Parse("0x0000000000000000000000000000000000000001")
+            ];
+            var size = hashes.GetVarSize();
+            Assert.AreEqual(1 + hashes[0].Size + hashes[1].Size, size);
+        }
+
+        [TestMethod]
+        public void GetVarSize_Enum_UsesUnderlyingSize()
+        {
+            CallFlags[] flags = [CallFlags.None, CallFlags.All];
+            var size = flags.GetVarSize();
+            Assert.AreEqual(1 + flags.Length * sizeof(byte), size);
+        }
+
+        [TestMethod]
+        public void GetVarSize_ValueType_UsesMarshalSize()
+        {
+            int[] values = [1, 2, 3];
+            var size = values.GetVarSize();
+            Assert.AreEqual(1 + values.Length * Marshal.SizeOf<int>(), size);
+        }
+
+        [TestMethod]
+        public void ToByteArray_SerializesCollection()
+        {
+            UInt160[] hashes = [UInt160.Zero];
+            var bytes = hashes.ToByteArray();
+            Assert.IsTrue(bytes.Length > 0);
+            Assert.AreEqual(hashes.GetVarSize(), bytes.Length);
+        }
+    }
+}

--- a/tests/Neo.UnitTests/Extensions/UT_MemoryExtensions.cs
+++ b/tests/Neo.UnitTests/Extensions/UT_MemoryExtensions.cs
@@ -1,0 +1,79 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// UT_MemoryExtensions.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.Extensions;
+using Neo.Network.P2P.Payloads;
+using System;
+
+namespace Neo.UnitTests.Extensions
+{
+    [TestClass]
+    public class UT_MemoryExtensions
+    {
+        [TestMethod]
+        public void AsSerializable_Empty_Throws()
+        {
+            ReadOnlyMemory<byte> empty = ReadOnlyMemory<byte>.Empty;
+            Assert.ThrowsExactly<FormatException>(() => empty.AsSerializable<UInt160>());
+            Assert.ThrowsExactly<FormatException>(() => empty.AsSerializableArray<UInt160>());
+        }
+
+        [TestMethod]
+        public void AsSerializable_Generic_RoundTrip()
+        {
+            var hash = UInt160.Parse("0x0000000000000000000000000000000000000001");
+            ReadOnlyMemory<byte> memory = hash.ToArray();
+            var clone = memory.AsSerializable<UInt160>();
+            Assert.AreEqual(hash, clone);
+        }
+
+        [TestMethod]
+        public void AsSerializable_ByType_RoundTrip()
+        {
+            var hash = UInt256.Zero;
+            ReadOnlyMemory<byte> memory = hash.ToArray();
+            var clone = memory.AsSerializable(typeof(UInt256));
+            Assert.IsInstanceOfType<UInt256>(clone);
+            Assert.AreEqual(hash, clone);
+        }
+
+        [TestMethod]
+        public void AsSerializable_ByType_NotISerializable_Throws()
+        {
+            ReadOnlyMemory<byte> data = new byte[] { 1 };
+            Assert.ThrowsExactly<InvalidCastException>(() => data.AsSerializable(typeof(string)));
+        }
+
+        [TestMethod]
+        public void AsSerializableArray_RoundTrip()
+        {
+            UInt160[] hashes =
+            [
+                UInt160.Zero,
+                UInt160.Parse("0x0000000000000000000000000000000000000002")
+            ];
+            ReadOnlyMemory<byte> memory = hashes.ToByteArray();
+            var clone = memory.AsSerializableArray<UInt160>();
+            Assert.HasCount(2, clone);
+            Assert.AreEqual(hashes[0], clone[0]);
+            Assert.AreEqual(hashes[1], clone[1]);
+        }
+
+        [TestMethod]
+        public void GetVarSize_IncludesPrefixAndLength()
+        {
+            ReadOnlyMemory<byte> data = new byte[] { 1, 2, 3 };
+            Assert.AreEqual(1 + 3, data.GetVarSize());
+            Assert.AreEqual(0.GetVarSize() + 0, ReadOnlyMemory<byte>.Empty.GetVarSize());
+        }
+    }
+}

--- a/tests/Neo.UnitTests/Extensions/UT_MemoryReaderExtensions.cs
+++ b/tests/Neo.UnitTests/Extensions/UT_MemoryReaderExtensions.cs
@@ -1,0 +1,75 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// UT_MemoryReaderExtensions.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.Extensions;
+using Neo.IO;
+using System.IO;
+
+namespace Neo.UnitTests.Extensions
+{
+    [TestClass]
+    public class UT_MemoryReaderExtensions
+    {
+        [TestMethod]
+        public void ReadSerializableArray_Empty()
+        {
+            using var ms = new MemoryStream();
+            using (var writer = new BinaryWriter(ms, System.Text.Encoding.UTF8, true))
+                writer.WriteVarInt(0);
+            var reader = new MemoryReader(ms.ToArray());
+            var array = reader.ReadSerializableArray<UInt160>();
+            Assert.IsEmpty(array);
+        }
+
+        [TestMethod]
+        public void ReadSerializableArray_TwoHashes()
+        {
+            UInt160[] hashes =
+            [
+                UInt160.Zero,
+                UInt160.Parse("0x0000000000000000000000000000000000000001")
+            ];
+            var bytes = hashes.ToByteArray();
+            var reader = new MemoryReader(bytes);
+            var clone = reader.ReadSerializableArray<UInt160>();
+            Assert.HasCount(2, clone);
+            Assert.AreEqual(hashes[0], clone[0]);
+            Assert.AreEqual(hashes[1], clone[1]);
+        }
+
+        [TestMethod]
+        public void ReadNullableArray_WithNullEntry()
+        {
+            using var ms = new MemoryStream();
+            using (var writer = new BinaryWriter(ms, System.Text.Encoding.UTF8, true))
+            {
+                writer.WriteVarInt(2);
+                writer.Write(true);
+                writer.Write(UInt256.Zero);
+                writer.Write(false);
+            }
+            var reader = new MemoryReader(ms.ToArray());
+            var array = reader.ReadNullableArray<UInt256>();
+            Assert.HasCount(2, array);
+            Assert.AreEqual(UInt256.Zero, array[0]);
+            Assert.IsNull(array[1]);
+        }
+
+        [TestMethod]
+        public void ReadSerializable_Single()
+        {
+            var hash = UInt160.Parse("0x0102030405060708090a0b0c0d0e0f1011121314");
+            var reader = new MemoryReader(hash.ToArray());
+            Assert.AreEqual(hash, reader.ReadSerializable<UInt160>());
+        }
+    }
+}

--- a/tests/Neo.UnitTests/Extensions/UT_SpanExtensions_Lz4.cs
+++ b/tests/Neo.UnitTests/Extensions/UT_SpanExtensions_Lz4.cs
@@ -1,0 +1,56 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// UT_SpanExtensions_Lz4.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.Extensions;
+using System;
+
+namespace Neo.UnitTests.Extensions
+{
+    /// <summary>
+    /// Span/ReadOnlySpan LZ4 overloads and empty-input edges beyond UT_IOHelper.
+    /// </summary>
+    [TestClass]
+    public class UT_SpanExtensions_Lz4
+    {
+        [TestMethod]
+        public void CompressDecompress_ReadOnlySpan_Empty()
+        {
+            ReadOnlySpan<byte> empty = ReadOnlySpan<byte>.Empty;
+            var compressed = empty.CompressLz4();
+            Assert.IsTrue(compressed.Length >= sizeof(int));
+            var restored = compressed.Span.DecompressLz4(maxOutput: 0);
+            Assert.HasCount(0, restored);
+        }
+
+        [TestMethod]
+        public void CompressDecompress_Span_RoundTrip()
+        {
+            byte[] data = [1, 2, 3, 4, 5, 1, 2, 3, 4, 5];
+            var compressed = data.AsSpan().CompressLz4();
+            var restored = compressed.Span.DecompressLz4(maxOutput: 64);
+            Assert.IsTrue(data.AsSpan().SequenceEqual(restored));
+        }
+
+        [TestMethod]
+        public void Decompress_Span_MismatchedLength_Throws()
+        {
+            byte[] data = [9, 8, 7];
+            var compressed = data.AsSpan().CompressLz4().ToArray();
+            // Corrupt stored length header to exceed maxOutput
+            compressed[0] = 0xFF;
+            compressed[1] = 0xFF;
+            compressed[2] = 0x00;
+            compressed[3] = 0x00;
+            Assert.ThrowsExactly<FormatException>(() => compressed.AsSpan().DecompressLz4(maxOutput: 10));
+        }
+    }
+}

--- a/tests/Neo.UnitTests/IO/Actors/UT_Idle.cs
+++ b/tests/Neo.UnitTests/IO/Actors/UT_Idle.cs
@@ -1,0 +1,27 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// UT_Idle.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.IO.Actors;
+
+namespace Neo.UnitTests.IO.Actors
+{
+    [TestClass]
+    public class UT_Idle
+    {
+        [TestMethod]
+        public void Instance_IsSingleton()
+        {
+            Assert.IsNotNull(Idle.Instance);
+            Assert.AreSame(Idle.Instance, Idle.Instance);
+        }
+    }
+}

--- a/tests/Neo.UnitTests/IO/Actors/UT_PriorityMailbox.cs
+++ b/tests/Neo.UnitTests/IO/Actors/UT_PriorityMailbox.cs
@@ -1,0 +1,55 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// UT_PriorityMailbox.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.Dispatch;
+using Akka.TestKit.MsTest;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.IO.Actors;
+using System.Collections;
+using System.Linq;
+
+namespace Neo.UnitTests.IO.Actors
+{
+    [TestClass]
+    public class UT_PriorityMailbox : TestKit
+    {
+        private sealed class TestMailbox(Settings settings, Config config) : PriorityMailbox(settings, config)
+        {
+            // expose defaults via base virtuals
+            public bool CallIsHighPriority(object message) => IsHighPriority(message);
+            public bool CallShallDrop(object message, IEnumerable queue) => ShallDrop(message, queue);
+        }
+
+        [TestCleanup]
+        public void Cleanup() => Shutdown();
+
+        [TestMethod]
+        public void Defaults_IsHighPriority_And_ShallDrop_AreFalse()
+        {
+            var akkaSettings = new Settings(Sys, DefaultConfig);
+            var mailbox = new TestMailbox(akkaSettings, DefaultConfig);
+
+            Assert.IsFalse(mailbox.CallIsHighPriority("anything"));
+            Assert.IsFalse(mailbox.CallShallDrop("anything", Enumerable.Empty<object>()));
+        }
+
+        [TestMethod]
+        public void Create_ReturnsPriorityMessageQueue()
+        {
+            var akkaSettings = new Settings(Sys, DefaultConfig);
+            var mailbox = new TestMailbox(akkaSettings, DefaultConfig);
+            var queue = mailbox.Create(ActorRefs.NoSender, Sys);
+            Assert.IsInstanceOfType<PriorityMessageQueue>(queue);
+        }
+    }
+}

--- a/tests/Neo.UnitTests/IO/Actors/UT_PriorityMessageQueue.cs
+++ b/tests/Neo.UnitTests/IO/Actors/UT_PriorityMessageQueue.cs
@@ -1,0 +1,76 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// UT_PriorityMessageQueue.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Akka.Actor;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.IO.Actors;
+using System.Collections;
+
+namespace Neo.UnitTests.IO.Actors
+{
+    [TestClass]
+    public class UT_PriorityMessageQueue
+    {
+        private static Envelope Env(object message) => new(message, ActorRefs.NoSender);
+
+        [TestMethod]
+        public void Enqueue_Dequeue_RespectsPriority()
+        {
+            var queue = new PriorityMessageQueue(
+                dropper: static (_, _) => false,
+                priorityGenerator: static msg => msg is string s && s == "high");
+
+            queue.Enqueue(ActorRefs.NoSender, Env("low"));
+            queue.Enqueue(ActorRefs.NoSender, Env("high"));
+            Assert.IsTrue(queue.HasMessages);
+            Assert.AreEqual(2, queue.Count);
+
+            Assert.IsTrue(queue.TryDequeue(out var first));
+            Assert.AreEqual("high", first.Message);
+            Assert.IsTrue(queue.TryDequeue(out var second));
+            Assert.AreEqual("low", second.Message);
+        }
+
+        [TestMethod]
+        public void Dropper_PreventsEnqueue()
+        {
+            var queue = new PriorityMessageQueue(
+                dropper: static (_, _) => true,
+                priorityGenerator: static _ => false);
+
+            queue.Enqueue(ActorRefs.NoSender, Env("x"));
+            Assert.IsFalse(queue.HasMessages);
+            Assert.AreEqual(0, queue.Count);
+        }
+
+        [TestMethod]
+        public void Idle_Message_IsNotQueued_ButCanBeSyntheticDequeued()
+        {
+            var queue = new PriorityMessageQueue(
+                dropper: static (_, _) => false,
+                priorityGenerator: static _ => false);
+
+            queue.Enqueue(ActorRefs.NoSender, Env(Idle.Instance));
+            Assert.IsFalse(queue.HasMessages);
+            // After an enqueue (even Idle), TryDequeue may synthesize Idle once.
+            Assert.IsTrue(queue.TryDequeue(out var idle));
+            Assert.AreSame(Idle.Instance, idle.Message);
+            Assert.IsFalse(queue.TryDequeue(out _));
+        }
+
+        [TestMethod]
+        public void CleanUp_IsNoOp()
+        {
+            var queue = new PriorityMessageQueue(static (_, _) => false, static _ => false);
+            queue.CleanUp(ActorRefs.NoSender, null!);
+        }
+    }
+}

--- a/tests/Neo.UnitTests/IO/Caching/UT_ECDsaCache.cs
+++ b/tests/Neo.UnitTests/IO/Caching/UT_ECDsaCache.cs
@@ -1,0 +1,46 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// UT_ECDsaCache.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.IO.Caching;
+using System.Security.Cryptography;
+using ECCurve = Neo.Cryptography.ECC.ECCurve;
+using ECPoint = Neo.Cryptography.ECC.ECPoint;
+
+namespace Neo.UnitTests.IO.Caching
+{
+    [TestClass]
+    public class UT_ECDsaCache
+    {
+        [TestMethod]
+        public void Add_And_TryGet_ByPoint()
+        {
+            using var cache = new ECDsaCache(4);
+            var point = ECCurve.Secp256r1.G;
+            using var ecdsa = ECDsa.Create();
+            // Create a disposable ECDsa instance; cache stores wrapper
+            var item = new ECDsaCacheItem(point, ecdsa);
+            cache.Add(item);
+
+            Assert.AreEqual(1, cache.Count);
+            Assert.IsTrue(cache.TryGet(point, out var found));
+            Assert.AreSame(item, found);
+            Assert.AreEqual(point, found.Key);
+        }
+
+        [TestMethod]
+        public void DefaultCapacity_IsPositive()
+        {
+            using var cache = new ECDsaCache();
+            Assert.AreEqual(0, cache.Count);
+        }
+    }
+}

--- a/tests/Neo.UnitTests/IO/Caching/UT_ECPointCache_Capacity.cs
+++ b/tests/Neo.UnitTests/IO/Caching/UT_ECPointCache_Capacity.cs
@@ -1,0 +1,49 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// UT_ECPointCache_Capacity.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.Cryptography.ECC;
+using Neo.IO.Caching;
+
+namespace Neo.UnitTests.IO.Caching
+{
+    /// <summary>
+    /// Capacity eviction edges not covered by UT_ECPointCache.
+    /// </summary>
+    [TestClass]
+    public class UT_ECPointCache_Capacity
+    {
+        [TestMethod]
+        public void Evicts_When_OverCapacity()
+        {
+            var cache = new ECPointCache(1)
+            {
+                ECCurve.Secp256r1.G
+            };
+            var k1 = ECCurve.Secp256k1.G;
+            cache.Add(k1);
+            Assert.AreEqual(1, cache.Count);
+            Assert.IsTrue(cache.TryGet(k1.EncodePoint(true), out _));
+            Assert.IsFalse(cache.TryGet(ECCurve.Secp256r1.G.EncodePoint(true), out _));
+        }
+
+        [TestMethod]
+        public void Count_TracksAddedPoints()
+        {
+            var cache = new ECPointCache(4);
+            Assert.AreEqual(0, cache.Count);
+            cache.Add(ECCurve.Secp256r1.G);
+            Assert.AreEqual(1, cache.Count);
+            cache.Add(ECCurve.Secp256k1.G);
+            Assert.AreEqual(2, cache.Count);
+        }
+    }
+}

--- a/tests/Neo.UnitTests/IO/Caching/UT_FIFOCache.cs
+++ b/tests/Neo.UnitTests/IO/Caching/UT_FIFOCache.cs
@@ -1,0 +1,57 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// UT_FIFOCache.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.IO.Caching;
+
+namespace Neo.UnitTests.IO.Caching
+{
+    [TestClass]
+    public class UT_FIFOCache
+    {
+        private sealed class StringCache(int maxCapacity) : FIFOCache<string, string>(maxCapacity)
+        {
+            protected override string GetKeyForItem(string item) => item;
+        }
+
+        [TestMethod]
+        public void Access_DoesNotReorder_FifoEviction()
+        {
+            var cache = new StringCache(2)
+            {
+                "a",
+                "b"
+            };
+            // Touch "a" — FIFO OnAccess is no-op, so "a" should still be evicted first
+            Assert.IsTrue(cache.TryGet("a", out _));
+            cache.Add("c");
+
+            Assert.IsFalse(cache.TryGet("a", out _));
+            Assert.IsTrue(cache.TryGet("b", out _));
+            Assert.IsTrue(cache.TryGet("c", out _));
+            Assert.AreEqual(2, cache.Count);
+        }
+
+        [TestMethod]
+        public void Add_SameKey_UpdatesValue()
+        {
+            var cache = new StringCache(2)
+            {
+                "x"
+            };
+            Assert.AreEqual(1, cache.Count);
+            cache.Add("x");
+            Assert.AreEqual(1, cache.Count);
+            Assert.IsTrue(cache.TryGet("x", out var value));
+            Assert.AreEqual("x", value);
+        }
+    }
+}

--- a/tests/Neo.UnitTests/IO/Caching/UT_ReflectionCacheAttribute.cs
+++ b/tests/Neo.UnitTests/IO/Caching/UT_ReflectionCacheAttribute.cs
@@ -1,0 +1,38 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// UT_ReflectionCacheAttribute.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.IO.Caching;
+using System;
+
+namespace Neo.UnitTests.IO.Caching
+{
+    [TestClass]
+    public class UT_ReflectionCacheAttribute
+    {
+        [TestMethod]
+        public void Constructor_StoresType()
+        {
+            var attr = new ReflectionCacheAttribute(typeof(string));
+            Assert.AreEqual(typeof(string), attr.Type);
+        }
+
+        [TestMethod]
+        public void AttributeUsage_IsFieldOnly()
+        {
+            var usage = (AttributeUsageAttribute)Attribute.GetCustomAttribute(
+                typeof(ReflectionCacheAttribute), typeof(AttributeUsageAttribute))!;
+            Assert.IsNotNull(usage);
+            Assert.AreEqual(AttributeTargets.Field, usage.ValidOn);
+            Assert.IsFalse(usage.AllowMultiple);
+        }
+    }
+}

--- a/tests/Neo.UnitTests/IO/Caching/UT_RelayCache_Capacity.cs
+++ b/tests/Neo.UnitTests/IO/Caching/UT_RelayCache_Capacity.cs
@@ -1,0 +1,48 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// UT_RelayCache_Capacity.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.IO.Caching;
+using System.Linq;
+
+namespace Neo.UnitTests.IO.Caching
+{
+    /// <summary>
+    /// Capacity / eviction coverage not covered by UT_RelayCache.TestGetKeyForItem.
+    /// </summary>
+    [TestClass]
+    public class UT_RelayCache_Capacity
+    {
+        [TestMethod]
+        public void Evicts_Oldest_WhenCapacityExceeded()
+        {
+            var cache = new RelayCache(2);
+            var tx1 = TestUtils.GetTransaction(UInt160.Zero);
+            var tx2 = TestUtils.GetTransaction(UInt160.Zero);
+            tx2.Nonce = tx1.Nonce + 1;
+            var tx3 = TestUtils.GetTransaction(UInt160.Zero);
+            tx3.Nonce = tx1.Nonce + 2;
+
+            cache.Add(tx1);
+            cache.Add(tx2);
+            Assert.HasCount(2, cache.ToArray());
+            Assert.IsTrue(cache.Contains(tx1.Hash));
+            Assert.IsTrue(cache.Contains(tx2.Hash));
+
+            cache.Add(tx3);
+            Assert.HasCount(2, cache.ToArray());
+            Assert.IsTrue(cache.Contains(tx3.Hash));
+            // FIFO: first inserted should be gone
+            Assert.IsFalse(cache.Contains(tx1.Hash));
+            Assert.IsTrue(cache.Contains(tx2.Hash));
+        }
+    }
+}

--- a/tests/Neo.UnitTests/Persistence/UT_MemoryStoreProvider.cs
+++ b/tests/Neo.UnitTests/Persistence/UT_MemoryStoreProvider.cs
@@ -1,0 +1,43 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// UT_MemoryStoreProvider.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.Persistence;
+using Neo.Persistence.Providers;
+
+namespace Neo.UnitTests.Persistence
+{
+    [TestClass]
+    public class UT_MemoryStoreProvider
+    {
+        [TestMethod]
+        public void Name_IsMemoryStore()
+        {
+            var provider = new MemoryStoreProvider();
+            Assert.AreEqual(nameof(MemoryStore), provider.Name);
+        }
+
+        [TestMethod]
+        public void GetStore_ReturnsIndependentStores()
+        {
+            var provider = new MemoryStoreProvider();
+            using var store1 = provider.GetStore(null);
+            using var store2 = provider.GetStore("ignored");
+
+            Assert.IsInstanceOfType<MemoryStore>(store1);
+            Assert.IsInstanceOfType<MemoryStore>(store2);
+            Assert.AreNotSame(store1, store2);
+
+            store1.Put([1], [2]);
+            Assert.IsFalse(store2.TryGet([1], out _));
+        }
+    }
+}

--- a/tests/Neo.UnitTests/Persistence/UT_StoreFactory.cs
+++ b/tests/Neo.UnitTests/Persistence/UT_StoreFactory.cs
@@ -1,0 +1,55 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// UT_StoreFactory.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.Persistence;
+using Neo.Persistence.Providers;
+using System;
+
+namespace Neo.UnitTests.Persistence
+{
+    [TestClass]
+    public class UT_StoreFactory
+    {
+        [TestMethod]
+        public void GetStoreProvider_MemoryStore_IsRegistered()
+        {
+            var provider = StoreFactory.GetStoreProvider(nameof(MemoryStore));
+            Assert.IsNotNull(provider);
+            Assert.IsInstanceOfType<MemoryStoreProvider>(provider);
+            Assert.AreEqual(nameof(MemoryStore), provider.Name);
+        }
+
+        [TestMethod]
+        public void GetStoreProvider_EmptyName_ReturnsDefaultMemoryProvider()
+        {
+            var provider = StoreFactory.GetStoreProvider("");
+            Assert.IsNotNull(provider);
+            Assert.IsInstanceOfType<MemoryStoreProvider>(provider);
+        }
+
+        [TestMethod]
+        public void GetStoreProvider_Unknown_ReturnsNull()
+        {
+            Assert.IsNull(StoreFactory.GetStoreProvider("does-not-exist-provider"));
+        }
+
+        [TestMethod]
+        public void GetStore_CreatesUsableMemoryStore()
+        {
+            using var store = StoreFactory.GetStore(nameof(MemoryStore), "ignored");
+            Assert.IsInstanceOfType<MemoryStore>(store);
+            store.Put([1], [2]);
+            Assert.IsTrue(store.TryGet([1], out var value));
+            Assert.IsTrue(new byte[] { 2 }.AsSpan().SequenceEqual(value));
+        }
+    }
+}


### PR DESCRIPTION
# Description

Consolidates persistence, serialization extension, cache, and actor queue tests.

**Related:** #4693 (option 1 — consolidate micro coverage PRs)

## Absorbs micro PRs

- #4623
- #4641
- #4648
- #4652
- #4655
- #4659
- #4666
- #4667
- #4668
- #4672
- #4674
- #4679
- #4686
- #4687
- #4688
- #4692

## Type of change
- [x] Style (code style / maintenance)

# How Has This Been Tested?
- [x] Unit Testing

## Notes
- Test-only; no product behavior changes.
- Independent of other grouped coverage PRs (based on `master-n3`).
- Pure enum-value slices were dropped and closed separately.
- Does **not** include already-approved StoreCache (#4671).