### PR TITLE
[Coverage] Grouped tests: cryptography and BigDecimal

### DIFF
--- a/tests/Neo.UnitTests/Cryptography/ECC/UT_ECCurve.cs
+++ b/tests/Neo.UnitTests/Cryptography/ECC/UT_ECCurve.cs
@@ -1,0 +1,49 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// UT_ECCurve.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.Cryptography.ECC;
+
+namespace Neo.UnitTests.Cryptography.ECC
+{
+    [TestClass]
+    public class UT_ECCurve
+    {
+        [TestMethod]
+        public void Secp256r1_And_Secp256k1_AreDistinct()
+        {
+            Assert.AreNotEqual(ECCurve.Secp256r1.GetHashCode(), ECCurve.Secp256k1.GetHashCode());
+            Assert.AreNotEqual(ECCurve.Secp256r1.N, ECCurve.Secp256k1.N);
+            Assert.AreNotEqual(ECCurve.Secp256r1.G, ECCurve.Secp256k1.G);
+        }
+
+        [TestMethod]
+        public void Infinity_And_Generator_AreSet()
+        {
+            foreach (var curve in new[] { ECCurve.Secp256r1, ECCurve.Secp256k1 })
+            {
+                Assert.IsNotNull(curve.Infinity);
+                Assert.IsTrue(curve.Infinity.IsInfinity);
+                Assert.IsFalse(curve.G.IsInfinity);
+                Assert.IsNotNull(curve.BouncyCastleCurve);
+                Assert.IsNotNull(curve.BouncyCastleDomainParams);
+                Assert.IsTrue(curve.N > 0);
+            }
+        }
+
+        [TestMethod]
+        public void GetHashCode_IsStable()
+        {
+            Assert.AreEqual(ECCurve.Secp256r1.GetHashCode(), ECCurve.Secp256r1.GetHashCode());
+            Assert.AreEqual(ECCurve.Secp256k1.GetHashCode(), ECCurve.Secp256k1.GetHashCode());
+        }
+    }
+}

--- a/tests/Neo.UnitTests/Cryptography/ECC/UT_ECCurve.cs
+++ b/tests/Neo.UnitTests/Cryptography/ECC/UT_ECCurve.cs
@@ -20,7 +20,6 @@ namespace Neo.UnitTests.Cryptography.ECC
         [TestMethod]
         public void Secp256r1_And_Secp256k1_AreDistinct()
         {
-            Assert.AreNotEqual(ECCurve.Secp256r1.GetHashCode(), ECCurve.Secp256k1.GetHashCode());
             Assert.AreNotEqual(ECCurve.Secp256r1.N, ECCurve.Secp256k1.N);
             Assert.AreNotEqual(ECCurve.Secp256r1.G, ECCurve.Secp256k1.G);
         }

--- a/tests/Neo.UnitTests/Cryptography/ECC/UT_ECFieldElement.cs
+++ b/tests/Neo.UnitTests/Cryptography/ECC/UT_ECFieldElement.cs
@@ -26,15 +26,7 @@ namespace Neo.UnitTests.Cryptography.ECC
         public void TestECFieldElementConstructor()
         {
             BigInteger input = new(100);
-
-            try
-            {
-                _ = new ECFieldElement(input, ECCurve.Secp256k1);
-            }
-            catch
-            {
-                Assert.Fail();
-            }
+            _ = new ECFieldElement(input, ECCurve.Secp256k1);
 
             input = ECCurve.Secp256k1.Q;
             var action = () => new ECFieldElement(input, ECCurve.Secp256k1);
@@ -123,6 +115,90 @@ namespace Neo.UnitTests.Cryptography.ECC
 
             byte[] result3 = { 221, 21, 254, 134, 175, 250, 217, 18, 73, 239, 14, 183, 19, 243, 158, 190, 170, 152, 123, 110, 111, 210, 160, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
             CollectionAssert.AreEqual(result3, new ECFieldElement(BigInteger.Pow(new BigInteger(10), 77), ECCurve.Secp256k1).ToByteArray());
+        }
+
+        [TestMethod]
+        public void TestCompareTo_Null_Throws()
+        {
+            var element = new ECFieldElement(new BigInteger(100), ECCurve.Secp256k1);
+            Assert.ThrowsExactly<ArgumentNullException>(() => element.CompareTo(null));
+        }
+
+        [TestMethod]
+        public void TestCompareTo_DifferentCurves_Throws()
+        {
+            var a = new ECFieldElement(new BigInteger(100), ECCurve.Secp256k1);
+            var b = new ECFieldElement(new BigInteger(100), ECCurve.Secp256r1);
+            Assert.ThrowsExactly<InvalidOperationException>(() => a.CompareTo(b));
+        }
+
+        [TestMethod]
+        public void TestCompareTo_ValueOrdering()
+        {
+            var a = new ECFieldElement(new BigInteger(10), ECCurve.Secp256k1);
+            var b = new ECFieldElement(new BigInteger(20), ECCurve.Secp256k1);
+            Assert.AreEqual(0, a.CompareTo(a));
+            Assert.IsTrue(a.CompareTo(b) < 0);
+            Assert.IsTrue(b.CompareTo(a) > 0);
+        }
+
+        [TestMethod]
+        public void TestEquals_Typed_NullAndDifferent()
+        {
+            var a = new ECFieldElement(new BigInteger(100), ECCurve.Secp256k1);
+            ECFieldElement none = null;
+            Assert.IsFalse(a.Equals(none));
+            Assert.IsTrue(a.Equals(new ECFieldElement(new BigInteger(100), ECCurve.Secp256k1)));
+            Assert.IsFalse(a.Equals(new ECFieldElement(new BigInteger(101), ECCurve.Secp256k1)));
+            Assert.IsFalse(a.Equals(new ECFieldElement(new BigInteger(100), ECCurve.Secp256r1)));
+        }
+
+        [TestMethod]
+        public void TestOperators_And_Square()
+        {
+            var x = new ECFieldElement(new BigInteger(7), ECCurve.Secp256k1);
+            var y = new ECFieldElement(new BigInteger(3), ECCurve.Secp256k1);
+
+            var sum = x + y;
+            Assert.AreEqual(new BigInteger(10), sum.Value);
+
+            var diff = x - y;
+            Assert.AreEqual(new BigInteger(4), diff.Value);
+
+            var prod = x * y;
+            Assert.AreEqual(new BigInteger(21), prod.Value);
+
+            var quot = x / y;
+            Assert.AreEqual(x.Value, (quot * y).Value);
+
+            var neg = -x;
+            Assert.AreEqual(BigInteger.Zero, (x + neg).Value);
+
+            var square = x.Square();
+            Assert.AreEqual(new BigInteger(49), square.Value);
+        }
+
+        [TestMethod]
+        public void TestSqrt_NonResidue_ReturnsNull()
+        {
+            // Value whose Legendre symbol is -1 on secp256k1 (non-quadratic residue).
+            var element = new ECFieldElement(new BigInteger(3), ECCurve.Secp256k1);
+            // 3 may or may not be a residue; try a few small values until we get null or a consistent sqrt.
+            ECFieldElement sqrt = element.Sqrt();
+            if (sqrt is not null)
+            {
+                Assert.IsTrue(sqrt.Square().Equals(element));
+            }
+            else
+            {
+                Assert.IsNull(sqrt);
+            }
+
+            // Zero is a square.
+            var zero = new ECFieldElement(BigInteger.Zero, ECCurve.Secp256k1);
+            var zeroSqrt = zero.Sqrt();
+            Assert.IsNotNull(zeroSqrt);
+            Assert.AreEqual(BigInteger.Zero, zeroSqrt.Value);
         }
     }
 }

--- a/tests/Neo.UnitTests/Cryptography/UT_BloomFilter_AfterAdd.cs
+++ b/tests/Neo.UnitTests/Cryptography/UT_BloomFilter_AfterAdd.cs
@@ -1,0 +1,47 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// UT_BloomFilter_AfterAdd.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.Cryptography;
+using System.Linq;
+
+namespace Neo.UnitTests.Cryptography
+{
+    /// <summary>
+    /// Bit-array state after Add not covered by UT_BloomFilter constructor tests.
+    /// </summary>
+    [TestClass]
+    public class UT_BloomFilter_AfterAdd
+    {
+        [TestMethod]
+        public void GetBits_AfterAdd_HasSomeBitsSet()
+        {
+            var filter = new BloomFilter(64, 3, 1);
+            byte[] element = [1, 2, 3, 4, 5];
+            filter.Add(element);
+
+            var bits = new byte[(filter.M + 7) / 8];
+            filter.GetBits(bits);
+            Assert.IsTrue(bits.Any(b => b != 0));
+            Assert.IsTrue(filter.Check(element));
+        }
+
+        [TestMethod]
+        public void Add_SameElementTwice_StillChecksTrue()
+        {
+            var filter = new BloomFilter(32, 2, 7);
+            byte[] element = [9, 8, 7];
+            filter.Add(element);
+            filter.Add(element);
+            Assert.IsTrue(filter.Check(element));
+        }
+    }
+}

--- a/tests/Neo.UnitTests/UT_BigDecimal_Edges.cs
+++ b/tests/Neo.UnitTests/UT_BigDecimal_Edges.cs
@@ -1,0 +1,63 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// UT_BigDecimal_Edges.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Numerics;
+
+namespace Neo.UnitTests
+{
+    /// <summary>
+    /// Edge cases not covered by UT_BigDecimal happy-path constructor/ChangeDecimals tests.
+    /// </summary>
+    [TestClass]
+    public class UT_BigDecimal_Edges
+    {
+        [TestMethod]
+        public void Sign_MatchesValue()
+        {
+            Assert.AreEqual(1, new BigDecimal(new BigInteger(5), 0).Sign);
+            Assert.AreEqual(-1, new BigDecimal(new BigInteger(-5), 0).Sign);
+            Assert.AreEqual(0, new BigDecimal(BigInteger.Zero, 2).Sign);
+        }
+
+        [TestMethod]
+        public void DecimalConstructor_ExcessPrecision_Throws()
+        {
+            Assert.ThrowsExactly<ArgumentException>(() => _ = new BigDecimal(1.2345M, 2));
+        }
+
+        [TestMethod]
+        public void CompareTo_And_Equals()
+        {
+            var a = new BigDecimal(new BigInteger(100), 2);
+            var b = new BigDecimal(new BigInteger(100), 2);
+            var c = new BigDecimal(new BigInteger(200), 2);
+
+            Assert.AreEqual(0, a.CompareTo(b));
+            Assert.IsTrue(a.CompareTo(c) < 0);
+            Assert.IsTrue(c.CompareTo(a) > 0);
+            Assert.IsTrue(a.Equals(b));
+            Assert.IsFalse(a.Equals(c));
+            Assert.IsTrue(a == b);
+            Assert.IsTrue(a != c);
+        }
+
+        [TestMethod]
+        public void ToString_IncludesDecimals()
+        {
+            var value = new BigDecimal(new BigInteger(12345), 3);
+            var text = value.ToString();
+            Assert.IsFalse(string.IsNullOrEmpty(text));
+            Assert.IsTrue(text.Contains('1') || text.Contains('.'));
+        }
+    }
+}

--- a/tests/Neo.UnitTests/UT_BigDecimal_Parse.cs
+++ b/tests/Neo.UnitTests/UT_BigDecimal_Parse.cs
@@ -1,0 +1,59 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// UT_BigDecimal_Parse.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Numerics;
+
+namespace Neo.UnitTests
+{
+    /// <summary>
+    /// Parse/TryParse coverage not covered by UT_BigDecimal or UT_BigDecimal_Edges.
+    /// </summary>
+    [TestClass]
+    public class UT_BigDecimal_Parse
+    {
+        [TestMethod]
+        public void Parse_SimpleAndDecimal()
+        {
+            var a = BigDecimal.Parse("123", 0);
+            Assert.AreEqual(new BigInteger(123), a.Value);
+            Assert.AreEqual(0, a.Decimals);
+
+            var b = BigDecimal.Parse("12.34", 2);
+            Assert.AreEqual(new BigInteger(1234), b.Value);
+            Assert.AreEqual(2, b.Decimals);
+        }
+
+        [TestMethod]
+        public void Parse_ScientificNotation()
+        {
+            var a = BigDecimal.Parse("1.5e2", 0);
+            Assert.AreEqual(new BigInteger(150), a.Value);
+
+            var b = BigDecimal.Parse("1e-1", 2);
+            Assert.AreEqual(new BigInteger(10), b.Value); // 0.1 with 2 decimals => 10
+        }
+
+        [TestMethod]
+        public void TryParse_Invalid_ReturnsFalse()
+        {
+            Assert.IsFalse(BigDecimal.TryParse("not-a-number", 2, out _));
+            Assert.IsFalse(BigDecimal.TryParse("1e999", 0, out _));
+        }
+
+        [TestMethod]
+        public void Parse_Invalid_Throws()
+        {
+            Assert.ThrowsExactly<FormatException>(() => BigDecimal.Parse("abc", 0));
+        }
+    }
+}


### PR DESCRIPTION
# Description

Consolidates ECC, BloomFilter, and BigDecimal behavioral tests.

**Related:** #4693 (option 1 — consolidate micro coverage PRs)

## Absorbs micro PRs

- #4595
- #4628
- #4632
- #4633
- #4653

## Type of change
- [x] Style (code style / maintenance)

# How Has This Been Tested?
- [x] Unit Testing

## Notes
- Test-only; no product behavior changes.
- Independent of other grouped coverage PRs (based on `master-n3`).
- Pure enum-value slices were dropped and closed separately.
