### PR TITLE
[Coverage] ApplicationEngine Runtime/Storage/Contract behavioral tests

### DIFF
--- a/tests/Neo.UnitTests/SmartContract/TestEngineRunner.cs
+++ b/tests/Neo.UnitTests/SmartContract/TestEngineRunner.cs
@@ -1,0 +1,67 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// TestEngineRunner.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Neo.Network.P2P.Payloads;
+using Neo.Persistence;
+using Neo.SmartContract;
+using Neo.VM;
+using System;
+
+namespace Neo.UnitTests.SmartContract
+{
+    /// <summary>
+    /// Shared helpers for ApplicationEngine coverage tests.
+    /// </summary>
+    internal static class TestEngineRunner
+    {
+        public static ApplicationEngine Create(
+            DataCache snapshot,
+            IVerifiable container = null,
+            TriggerType trigger = TriggerType.Application,
+            long gas = 100_0000_0000,
+            ProtocolSettings settings = null)
+        {
+            return ApplicationEngine.Create(
+                trigger,
+                container,
+                snapshot,
+                settings: settings ?? TestProtocolSettings.Default,
+                gas: gas);
+        }
+
+        public static ApplicationEngine CreateWithScript(
+            DataCache snapshot,
+            ReadOnlyMemory<byte> script,
+            IVerifiable container = null,
+            long gas = 100_0000_0000)
+        {
+            var engine = Create(snapshot, container, gas: gas);
+            engine.LoadScript(script);
+            return engine;
+        }
+
+        public static Transaction EmptyTx(UInt160 account)
+        {
+            return new Transaction
+            {
+                Version = 0,
+                Nonce = 1,
+                SystemFee = 0,
+                NetworkFee = 0,
+                ValidUntilBlock = 100,
+                Attributes = [],
+                Signers = [new Signer { Account = account, Scopes = WitnessScope.CalledByEntry }],
+                Script = new byte[] { (byte)OpCode.RET },
+                Witnesses = []
+            };
+        }
+    }
+}

--- a/tests/Neo.UnitTests/SmartContract/UT_ApplicationEngine_Contract_Coverage.cs
+++ b/tests/Neo.UnitTests/SmartContract/UT_ApplicationEngine_Contract_Coverage.cs
@@ -1,0 +1,107 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// UT_ApplicationEngine_Contract_Coverage.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.Cryptography.ECC;
+using Neo.Extensions;
+using Neo.Persistence;
+using Neo.SmartContract;
+using Neo.SmartContract.Native;
+using Neo.VM;
+using System;
+using Array = Neo.VM.Types.Array;
+
+namespace Neo.UnitTests.SmartContract
+{
+    [TestClass]
+    public class UT_ApplicationEngine_Contract_Coverage
+    {
+        private DataCache _snapshot;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _snapshot = TestBlockchain.GetTestSnapshotCache().CloneCache();
+        }
+
+        [TestMethod]
+        public void CallContract_UnderscoreMethod_Throws()
+        {
+            using var engine = TestEngineRunner.CreateWithScript(_snapshot, new byte[] { (byte)OpCode.NOP });
+            Assert.ThrowsExactly<ArgumentException>(() =>
+                engine.CallContract(NativeContract.NEO.Hash, "_hidden", CallFlags.All, new Array()));
+        }
+
+        [TestMethod]
+        public void CallContract_InvalidCallFlags_Throws()
+        {
+            using var engine = TestEngineRunner.CreateWithScript(_snapshot, new byte[] { (byte)OpCode.NOP });
+            Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+                engine.CallContract(NativeContract.NEO.Hash, "symbol", (CallFlags)0xFF, new Array()));
+        }
+
+        [TestMethod]
+        public void CallContract_MissingContract_Throws()
+        {
+            using var engine = TestEngineRunner.CreateWithScript(_snapshot, new byte[] { (byte)OpCode.NOP });
+            Assert.ThrowsExactly<InvalidOperationException>(() =>
+                engine.CallContract(UInt160.Zero, "symbol", CallFlags.ReadOnly, new Array()));
+        }
+
+        [TestMethod]
+        public void CallContract_MissingMethod_Throws()
+        {
+            using var engine = TestEngineRunner.CreateWithScript(_snapshot, new byte[] { (byte)OpCode.NOP });
+            Assert.ThrowsExactly<InvalidOperationException>(() =>
+                engine.CallContract(NativeContract.NEO.Hash, "methodThatDoesNotExist", CallFlags.ReadOnly, new Array()));
+        }
+
+        [TestMethod]
+        public void CallNativeContract_FromNonNative_Throws()
+        {
+            using var engine = TestEngineRunner.CreateWithScript(_snapshot, new byte[] { (byte)OpCode.NOP });
+            Assert.ThrowsExactly<InvalidOperationException>(() => engine.CallNativeContract(0));
+        }
+
+        [TestMethod]
+        public void CreateStandardAccount_MatchesContractHelper()
+        {
+            using var engine = TestEngineRunner.CreateWithScript(_snapshot, new byte[] { (byte)OpCode.NOP }, gas: 100_0000_0000);
+            var pub = TestProtocolSettings.Default.StandbyCommittee[0];
+            var hash = engine.CreateStandardAccount(pub);
+            Assert.AreEqual(Contract.CreateSignatureRedeemScript(pub).ToScriptHash(), hash);
+        }
+
+        [TestMethod]
+        public void CreateMultisigAccount_MatchesContractHelper()
+        {
+            using var engine = TestEngineRunner.CreateWithScript(_snapshot, new byte[] { (byte)OpCode.NOP }, gas: 100_0000_0000);
+            ECPoint[] keys =
+            [
+                TestProtocolSettings.Default.StandbyCommittee[0],
+                TestProtocolSettings.Default.StandbyCommittee[1],
+                TestProtocolSettings.Default.StandbyCommittee[2]
+            ];
+            var hash = engine.CreateMultisigAccount(2, keys);
+            Assert.AreEqual(Contract.CreateMultiSigRedeemScript(2, keys).ToScriptHash(), hash);
+        }
+
+        [TestMethod]
+        public void NativeOnPersist_WrongTrigger_Faults()
+        {
+            using var engine = TestEngineRunner.Create(_snapshot, trigger: TriggerType.Application);
+            engine.LoadScript(new byte[] { (byte)OpCode.NOP });
+            engine.NativeOnPersistAsync();
+            // async fault is queued; execute to observe FAULT
+            Assert.AreEqual(VMState.FAULT, engine.Execute());
+        }
+    }
+}

--- a/tests/Neo.UnitTests/SmartContract/UT_ApplicationEngine_Runtime_Coverage.cs
+++ b/tests/Neo.UnitTests/SmartContract/UT_ApplicationEngine_Runtime_Coverage.cs
@@ -1,0 +1,142 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// UT_ApplicationEngine_Runtime_Coverage.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.Cryptography.ECC;
+using Neo.Extensions;
+using Neo.Network.P2P.Payloads;
+using Neo.Persistence;
+using Neo.SmartContract;
+using Neo.VM;
+using System;
+using Array = Neo.VM.Types.Array;
+
+namespace Neo.UnitTests.SmartContract
+{
+    [TestClass]
+    public class UT_ApplicationEngine_Runtime_Coverage
+    {
+        private DataCache _snapshot;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _snapshot = TestBlockchain.GetTestSnapshotCache().CloneCache();
+        }
+
+        [TestMethod]
+        public void BurnGas_Positive_IncreasesFee_NegativeOrZero_Throws()
+        {
+            using var engine = TestEngineRunner.CreateWithScript(_snapshot, new byte[] { (byte)OpCode.NOP });
+            var before = engine.FeeConsumed;
+            engine.BurnGas(10_000);
+            Assert.IsTrue(engine.FeeConsumed > before);
+            Assert.ThrowsExactly<InvalidOperationException>(() => engine.BurnGas(0));
+            Assert.ThrowsExactly<InvalidOperationException>(() => engine.BurnGas(-1));
+        }
+
+        [TestMethod]
+        public void CheckWitness_InvalidLength_Throws()
+        {
+            using var engine = TestEngineRunner.CreateWithScript(_snapshot, new byte[] { (byte)OpCode.NOP });
+            Assert.ThrowsExactly<ArgumentException>(() => engine.CheckWitness(new byte[5]));
+            Assert.ThrowsExactly<ArgumentException>(() => engine.CheckWitness(new byte[32]));
+        }
+
+        [TestMethod]
+        public void CheckWitness_WithTransactionSigner_ReturnsTrue()
+        {
+            var account = UInt160.Parse("0x0000000000000000000000000000000000000001");
+            var tx = TestEngineRunner.EmptyTx(account);
+            using var engine = TestEngineRunner.CreateWithScript(_snapshot, new byte[] { (byte)OpCode.NOP }, tx);
+            Assert.IsTrue(engine.CheckWitness(account.ToArray()));
+            Assert.IsFalse(engine.CheckWitness(UInt160.Zero.ToArray()));
+        }
+
+        [TestMethod]
+        public void CheckWitness_NullContainer_ReturnsFalse()
+        {
+            using var engine = TestEngineRunner.CreateWithScript(_snapshot, new byte[] { (byte)OpCode.NOP });
+            Assert.IsFalse(engine.CheckWitness(UInt160.Zero.ToArray()));
+        }
+
+        [TestMethod]
+        public void GetCurrentSigners_WithAndWithoutTransaction()
+        {
+            using (var engine = TestEngineRunner.CreateWithScript(_snapshot, new byte[] { (byte)OpCode.NOP }))
+            {
+                Assert.IsNull(engine.GetCurrentSigners());
+            }
+
+            var tx = TestEngineRunner.EmptyTx(UInt160.Zero);
+            using var engineTx = TestEngineRunner.CreateWithScript(_snapshot, new byte[] { (byte)OpCode.NOP }, tx);
+            var signers = engineTx.GetCurrentSigners();
+            Assert.IsNotNull(signers);
+            Assert.HasCount(1, signers);
+            Assert.AreEqual(UInt160.Zero, signers[0].Account);
+        }
+
+        [TestMethod]
+        public void GetCallFlags_ReturnsContextFlags()
+        {
+            using var engine = TestEngineRunner.CreateWithScript(_snapshot, new byte[] { (byte)OpCode.NOP });
+            Assert.AreEqual(CallFlags.All, engine.GetCallFlags());
+        }
+
+        [TestMethod]
+        public void GetInvocationCounter_StartsAtOne()
+        {
+            using var engine = TestEngineRunner.CreateWithScript(_snapshot, new byte[] { (byte)OpCode.NOP });
+            Assert.AreEqual(1, engine.GetInvocationCounter());
+            Assert.AreEqual(1, engine.GetInvocationCounter());
+        }
+
+        [TestMethod]
+        public void GetRandom_ReturnsNonNegative()
+        {
+            using var engine = TestEngineRunner.CreateWithScript(_snapshot, new byte[] { (byte)OpCode.NOP }, gas: 100_0000_0000);
+            var a = engine.GetRandom();
+            var b = engine.GetRandom();
+            Assert.IsTrue(a >= 0);
+            Assert.IsTrue(b >= 0);
+        }
+
+        [TestMethod]
+        public void RuntimeLog_InvalidUtf8_Throws()
+        {
+            using var engine = TestEngineRunner.CreateWithScript(_snapshot, new byte[] { (byte)OpCode.NOP });
+            Assert.ThrowsExactly<ArgumentException>(() => engine.RuntimeLog([0xFF, 0xFE]));
+        }
+
+        [TestMethod]
+        public void RuntimeLoadScript_InvalidCallFlags_Throws()
+        {
+            using var engine = TestEngineRunner.CreateWithScript(_snapshot, new byte[] { (byte)OpCode.NOP });
+            Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+                engine.RuntimeLoadScript([(byte)OpCode.RET], (CallFlags)0xFF, new Array()));
+        }
+
+        [TestMethod]
+        public void GetPlatform_And_Trigger()
+        {
+            using var engine = TestEngineRunner.CreateWithScript(_snapshot, new byte[] { (byte)OpCode.NOP });
+            Assert.AreEqual("NEO", ApplicationEngine.GetPlatform());
+            Assert.AreEqual(TriggerType.Application, engine.Trigger);
+        }
+
+        [TestMethod]
+        public void GetScriptContainer_WithoutInteroperable_Throws()
+        {
+            using var engine = TestEngineRunner.CreateWithScript(_snapshot, new byte[] { (byte)OpCode.NOP });
+            Assert.ThrowsExactly<InvalidOperationException>(() => engine.GetScriptContainer());
+        }
+    }
+}

--- a/tests/Neo.UnitTests/SmartContract/UT_ApplicationEngine_Runtime_Coverage.cs
+++ b/tests/Neo.UnitTests/SmartContract/UT_ApplicationEngine_Runtime_Coverage.cs
@@ -100,13 +100,17 @@ namespace Neo.UnitTests.SmartContract
         }
 
         [TestMethod]
-        public void GetRandom_ReturnsNonNegative()
+        public void GetRandom_IncreasesFeeConsumed()
         {
+            // GetRandom returns an unsigned BigInteger, so non-negativity is not a useful assert.
+            // Observable behavior: each call charges fee via AddFee.
             using var engine = TestEngineRunner.CreateWithScript(_snapshot, new byte[] { (byte)OpCode.NOP }, gas: 100_0000_0000);
-            var a = engine.GetRandom();
-            var b = engine.GetRandom();
-            Assert.IsTrue(a >= 0);
-            Assert.IsTrue(b >= 0);
+            var fee0 = engine.FeeConsumed;
+            _ = engine.GetRandom();
+            var fee1 = engine.FeeConsumed;
+            Assert.IsTrue(fee1 > fee0);
+            _ = engine.GetRandom();
+            Assert.IsTrue(engine.FeeConsumed > fee1);
         }
 
         [TestMethod]

--- a/tests/Neo.UnitTests/SmartContract/UT_ApplicationEngine_Storage_Coverage.cs
+++ b/tests/Neo.UnitTests/SmartContract/UT_ApplicationEngine_Storage_Coverage.cs
@@ -1,0 +1,122 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// UT_ApplicationEngine_Storage_Coverage.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.Persistence;
+using Neo.SmartContract;
+using Neo.VM;
+using System;
+using System.Linq;
+
+namespace Neo.UnitTests.SmartContract
+{
+    [TestClass]
+    public class UT_ApplicationEngine_Storage_Coverage
+    {
+        private DataCache _snapshot;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _snapshot = TestBlockchain.GetTestSnapshotCache().CloneCache();
+        }
+
+        [TestMethod]
+        public void GetStorageContext_WithoutDeployedContract_Throws()
+        {
+            using var engine = TestEngineRunner.CreateWithScript(_snapshot, new byte[] { (byte)OpCode.NOP });
+            Assert.ThrowsExactly<InvalidOperationException>(() => engine.GetStorageContext());
+            Assert.ThrowsExactly<InvalidOperationException>(() => engine.GetReadOnlyContext());
+        }
+
+        [TestMethod]
+        public void AsReadOnly_MarksContextReadOnly()
+        {
+            var ctx = new StorageContext { Id = 1, IsReadOnly = false };
+            var ro = ApplicationEngine.AsReadOnly(ctx);
+            Assert.IsTrue(ro.IsReadOnly);
+            Assert.AreEqual(1, ro.Id);
+
+            var already = new StorageContext { Id = 2, IsReadOnly = true };
+            Assert.IsTrue(ApplicationEngine.AsReadOnly(already).IsReadOnly);
+        }
+
+        [TestMethod]
+        public void Put_ReadOnlyContext_Throws()
+        {
+            using var engine = TestEngineRunner.CreateWithScript(_snapshot, new byte[] { (byte)OpCode.NOP }, gas: 100_0000_0000);
+            var ctx = new StorageContext { Id = -1, IsReadOnly = true };
+            Assert.ThrowsExactly<ArgumentException>(() => engine.Put(ctx, [1], [2]));
+        }
+
+        [TestMethod]
+        public void Put_KeyOrValueTooLarge_Throws()
+        {
+            using var engine = TestEngineRunner.CreateWithScript(_snapshot, new byte[] { (byte)OpCode.NOP }, gas: 100_0000_0000);
+            var ctx = new StorageContext { Id = -1, IsReadOnly = false };
+            var bigKey = new byte[ApplicationEngine.MaxStorageKeySize + 1];
+            Assert.ThrowsExactly<ArgumentException>(() => engine.Put(ctx, bigKey, [1]));
+
+            var bigValue = new byte[ApplicationEngine.MaxStorageValueSize + 1];
+            Assert.ThrowsExactly<ArgumentException>(() => engine.Put(ctx, [1], bigValue));
+        }
+
+        [TestMethod]
+        public void Put_Get_Delete_RoundTrip()
+        {
+            using var engine = TestEngineRunner.CreateWithScript(_snapshot, new byte[] { (byte)OpCode.NOP }, gas: 100_0000_0000);
+            var ctx = new StorageContext { Id = -1, IsReadOnly = false };
+            engine.Put(ctx, [0xAB], [1, 2, 3]);
+            var value = engine.Get(ctx, [0xAB]);
+            Assert.IsTrue(value.HasValue);
+            Assert.IsTrue(new byte[] { 1, 2, 3 }.AsSpan().SequenceEqual(value.Value.Span));
+
+            engine.Delete(ctx, [0xAB]);
+            Assert.IsFalse(engine.Get(ctx, [0xAB]).HasValue);
+        }
+
+        [TestMethod]
+        public void Find_InvalidOptions_Throw()
+        {
+            using var engine = TestEngineRunner.CreateWithScript(_snapshot, new byte[] { (byte)OpCode.NOP });
+            var ctx = new StorageContext { Id = -1, IsReadOnly = true };
+
+            Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+                engine.Find(ctx, [], (FindOptions)0xFF));
+
+            Assert.ThrowsExactly<ArgumentException>(() =>
+                engine.Find(ctx, [], FindOptions.KeysOnly | FindOptions.ValuesOnly));
+
+            Assert.ThrowsExactly<ArgumentException>(() =>
+                engine.Find(ctx, [], FindOptions.ValuesOnly | FindOptions.RemovePrefix));
+
+            Assert.ThrowsExactly<ArgumentException>(() =>
+                engine.Find(ctx, [], FindOptions.PickField0 | FindOptions.PickField1));
+
+            Assert.ThrowsExactly<ArgumentException>(() =>
+                engine.Find(ctx, [], FindOptions.PickField0));
+        }
+
+        [TestMethod]
+        public void Find_ValidOptions_ReturnsIterator()
+        {
+            using var engine = TestEngineRunner.CreateWithScript(_snapshot, new byte[] { (byte)OpCode.NOP }, gas: 100_0000_0000);
+            var write = new StorageContext { Id = -1, IsReadOnly = false };
+            engine.Put(write, [0x01], [0x11]);
+            engine.Put(write, [0x02], [0x22]);
+
+            var read = new StorageContext { Id = -1, IsReadOnly = true };
+            using var it = engine.Find(read, [], FindOptions.None);
+            Assert.IsNotNull(it);
+            Assert.IsTrue(it.Next());
+        }
+    }
+}


### PR DESCRIPTION
# Description

Adds exclusive ApplicationEngine behavioral coverage for high-ROI Runtime, Storage, and Contract interop paths, plus a small shared `TestEngineRunner` fixture. Part of the larger ~90% coverage track. Test-only; no product behavior changes.

Related: #4693

# Change Log

- Add File `tests/Neo.UnitTests/SmartContract/TestEngineRunner.cs`
- Add File `tests/Neo.UnitTests/SmartContract/UT_ApplicationEngine_Runtime_Coverage.cs`
- Add File `tests/Neo.UnitTests/SmartContract/UT_ApplicationEngine_Storage_Coverage.cs`
- Add File `tests/Neo.UnitTests/SmartContract/UT_ApplicationEngine_Contract_Coverage.cs`

Fixes #4693 (partial — ApplicationEngine slice)

## Type of change

- [ ] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Unit Testing
- [ ] Run Application
- [ ] Local Computer Tests
- [ ] No Testing

`dotnet test tests/Neo.UnitTests --filter FullyQualifiedName~UT_ApplicationEngine_`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules