### PR TITLE
[Coverage] TaskSession and RemoteNode ProtocolHandler TestKit tests

### DIFF
--- a/tests/Neo.UnitTests/Network/P2P/UT_RemoteNode_ProtocolHandler.cs
+++ b/tests/Neo.UnitTests/Network/P2P/UT_RemoteNode_ProtocolHandler.cs
@@ -47,7 +47,7 @@ namespace Neo.UnitTests.Network.P2P
             s_system = TestBlockchain.GetSystem();
         }
 
-        private static VersionPayload MakeVersion(uint startHeight = 7, ushort tcpPort = 20333)
+        private static VersionPayload MakeVersion(uint startHeight = 7, ushort tcpPort = 20333, string userAgent = "ProtocolHandlerUT")
         {
             // Nonce must not equal LocalNode.Nonce or AllowNewConnection rejects the peer.
             var nonce = s_nextNonce++;
@@ -56,7 +56,7 @@ namespace Neo.UnitTests.Network.P2P
 
             return new VersionPayload
             {
-                UserAgent = "ProtocolHandlerUT",
+                UserAgent = userAgent,
                 Nonce = nonce,
                 Network = TestProtocolSettings.Default.Network,
                 Timestamp = 1,
@@ -68,6 +68,9 @@ namespace Neo.UnitTests.Network.P2P
                 ]
             };
         }
+
+        private static VersionPayload MakeVersionWithAgent(string userAgent, uint startHeight = 0)
+            => MakeVersion(startHeight, userAgent: userAgent);
 
         private static Tcp.Received AsReceived(Message message)
         {
@@ -234,23 +237,34 @@ namespace Neo.UnitTests.Network.P2P
         [TestMethod]
         public void MessageReceived_ReturningFalse_StopsProtocolHandling()
         {
-            var received = new List<MessageCommand>();
+            // MessageReceived is static and shared by every RemoteNode in the process.
+            // Scope the short-circuit to this test's Version only so other nodes (or residual
+            // actors) are not blocked and we do not count unrelated traffic.
+            const string marker = "UT-MessageReceived-ShortCircuit";
+            var intercepted = 0;
             MessageReceivedHandler handler = (_, msg) =>
             {
-                received.Add(msg.Command);
-                return false; // stop further OnMessage handling
+                if (msg.Command == MessageCommand.Version
+                    && msg.Payload is VersionPayload vp
+                    && vp.UserAgent == marker)
+                {
+                    intercepted++;
+                    return false; // stop OnMessage for this Version only
+                }
+                return true;
             };
             RemoteNode.MessageReceived += handler;
             try
             {
                 var (remote, connection) = SpawnRemoteNode();
                 var sender = CreateTestProbe();
-                sender.Send(remote, AsReceived(Message.Create(MessageCommand.Version, MakeVersion())));
+                var version = MakeVersion();
+                version.UserAgent = marker;
+                sender.Send(remote, AsReceived(Message.Create(MessageCommand.Version, version)));
 
                 connection.ExpectNoMsg(TimeSpan.FromMilliseconds(400), cancellationToken: CancellationToken.None);
                 Assert.IsNull(remote.UnderlyingActor.Version);
-                Assert.HasCount(1, received);
-                Assert.AreEqual(MessageCommand.Version, received[0]);
+                Assert.AreEqual(1, intercepted);
             }
             finally
             {
@@ -261,21 +275,43 @@ namespace Neo.UnitTests.Network.P2P
         [TestMethod]
         public void MessageReceived_ReturningTrue_IsInvoked_AndAllowsHandshake()
         {
-            var seen = new List<MessageCommand>();
+            // Scope observation to this handshake's UserAgent so static-event noise is ignored.
+            const string marker = "UT-MessageReceived-Allow";
+            var versionSeen = 0;
+            var verackSeen = 0;
             MessageReceivedHandler handler = (system, msg) =>
             {
-                Assert.AreSame(s_system, system);
-                seen.Add(msg.Command);
+                if (!ReferenceEquals(system, s_system))
+                    return true;
+                if (msg.Command == MessageCommand.Version
+                    && msg.Payload is VersionPayload vp
+                    && vp.UserAgent == marker)
+                {
+                    versionSeen++;
+                }
+                else if (msg.Command == MessageCommand.Verack && versionSeen > 0)
+                {
+                    // Verack has no payload; count only after our Version was observed.
+                    verackSeen++;
+                }
                 return true;
             };
             RemoteNode.MessageReceived += handler;
             try
             {
                 var (remote, connection) = SpawnRemoteNode();
-                CompleteHandshake(remote, connection);
+                var sender = CreateTestProbe();
+                // Handshake with a unique UserAgent so Version is attributable to this test.
+                sender.Send(remote, AsReceived(Message.Create(MessageCommand.Version, MakeVersionWithAgent(marker))));
+                connection.ExpectMsg<Tcp.Write>(TimeSpan.FromSeconds(3), cancellationToken: CancellationToken.None);
+                sender.Send(remote, Connection.Ack.Instance);
+                sender.Send(remote, AsReceived(Message.Create(MessageCommand.Verack)));
+                DrainTaskManagerOutbound(remote, connection, sender);
 
-                Assert.IsTrue(seen.Contains(MessageCommand.Version));
-                Assert.IsTrue(seen.Contains(MessageCommand.Verack));
+                Assert.IsNotNull(remote.UnderlyingActor.Version);
+                Assert.AreEqual(marker, remote.UnderlyingActor.Version.UserAgent);
+                Assert.IsTrue(versionSeen >= 1);
+                Assert.IsTrue(verackSeen >= 1);
             }
             finally
             {

--- a/tests/Neo.UnitTests/Network/P2P/UT_RemoteNode_ProtocolHandler.cs
+++ b/tests/Neo.UnitTests/Network/P2P/UT_RemoteNode_ProtocolHandler.cs
@@ -1,0 +1,369 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// UT_RemoteNode_ProtocolHandler.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Akka.Actor;
+using Akka.IO;
+using Akka.TestKit;
+using Akka.TestKit.MsTest;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.Cryptography;
+using Neo.Extensions;
+using Neo.Network.P2P;
+using Neo.Network.P2P.Capabilities;
+using Neo.Network.P2P.Payloads;
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Threading;
+
+namespace Neo.UnitTests.Network.P2P
+{
+    /// <summary>
+    /// Behavioral coverage for <see cref="RemoteNode"/> protocol handling via Akka.TestKit.
+    /// Drives framed <see cref="Tcp.Received"/> messages and asserts outbound <see cref="Tcp.Write"/> replies.
+    /// </summary>
+    [TestClass]
+    public class UT_RemoteNode_ProtocolHandler : TestKit
+    {
+        private static NeoSystem s_system;
+        private static uint s_nextNonce = 0xA11CE;
+
+        public UT_RemoteNode_ProtocolHandler()
+            : base($"remote-node-mailbox {{ mailbox-type: \"{typeof(RemoteNodeMailbox).AssemblyQualifiedName}\" }}")
+        {
+        }
+
+        [ClassInitialize]
+        public static void TestSetup(TestContext ctx)
+        {
+            s_system = TestBlockchain.GetSystem();
+        }
+
+        private static VersionPayload MakeVersion(uint startHeight = 7, ushort tcpPort = 20333)
+        {
+            // Nonce must not equal LocalNode.Nonce or AllowNewConnection rejects the peer.
+            var nonce = s_nextNonce++;
+            if (nonce == LocalNode.Nonce)
+                nonce = s_nextNonce++;
+
+            return new VersionPayload
+            {
+                UserAgent = "ProtocolHandlerUT",
+                Nonce = nonce,
+                Network = TestProtocolSettings.Default.Network,
+                Timestamp = 1,
+                Version = LocalNode.ProtocolVersion,
+                Capabilities =
+                [
+                    new FullNodeCapability(startHeight),
+                    new ServerCapability(NodeCapabilityType.TcpServer, tcpPort)
+                ]
+            };
+        }
+
+        private static Tcp.Received AsReceived(Message message)
+        {
+            return new Tcp.Received((ByteString)message.ToArray());
+        }
+
+        private (TestActorRef<RemoteNode> remote, TestProbe connection) SpawnRemoteNode()
+        {
+            var connection = CreateTestProbe("conn");
+            var remoteEp = new IPEndPoint(IPAddress.Parse("192.0.2.10"), 20333);
+            var localEp = new IPEndPoint(IPAddress.Loopback, 20334);
+            var remote = ActorOfAsTestActorRef(() =>
+                new RemoteNode(
+                    s_system,
+                    new LocalNode(s_system),
+                    connection,
+                    remoteEp,
+                    localEp,
+                    new ChannelsConfig()));
+            return (remote, connection);
+        }
+
+        /// <summary>
+        /// Completes Version/Verack handshake. Leaves the connection ready for post-handshake commands.
+        /// Default peer height is 0 so TaskManager only enqueues Mempool (not GetHeaders/GetBlocks).
+        /// </summary>
+        private void CompleteHandshake(
+            TestActorRef<RemoteNode> remote,
+            TestProbe connection,
+            uint startHeight = 0,
+            TestProbe sender = null)
+        {
+            sender ??= CreateTestProbe();
+            sender.Send(remote, AsReceived(Message.Create(MessageCommand.Version, MakeVersion(startHeight))));
+
+            // Remote replies with Verack via Tcp.Write (ack token is Connection.Ack).
+            connection.ExpectMsg<Tcp.Write>(TimeSpan.FromSeconds(3), cancellationToken: CancellationToken.None);
+            // Re-enable outbound queue (Tcp layer would normally deliver this ack).
+            sender.Send(remote, Connection.Ack.Instance);
+
+            // Peer sends Verack to finish handshake.
+            sender.Send(remote, AsReceived(Message.Create(MessageCommand.Verack)));
+
+            Assert.IsNotNull(remote.UnderlyingActor.Version);
+            Assert.IsTrue(remote.UnderlyingActor.IsFullNode);
+            Assert.AreEqual(startHeight, remote.UnderlyingActor.LastBlockIndex);
+
+            // OnVerack → TaskManager.Register → RequestTasks may Tell Mempool/GetHeaders/GetBlocks
+            // back to this RemoteNode (cross NeoSystem actor system). Drain those first.
+            DrainTaskManagerOutbound(remote, connection, sender);
+        }
+
+        /// <summary>
+        /// Consumes outbound Tcp.Write frames produced by TaskManager after Register, acking each.
+        /// </summary>
+        private static void DrainTaskManagerOutbound(
+            TestActorRef<RemoteNode> remote,
+            TestProbe connection,
+            TestProbe sender,
+            TimeSpan? quiet = null)
+        {
+            var idle = quiet ?? TimeSpan.FromMilliseconds(400);
+            while (true)
+            {
+                var next = connection.ReceiveOne(idle);
+                if (next is null) return;
+                if (next is Tcp.Write)
+                {
+                    sender.Send(remote, Connection.Ack.Instance);
+                    continue;
+                }
+                // Unexpected non-Write; put back is not supported — fail loudly.
+                Assert.Fail($"Unexpected message while draining TaskManager outbound: {next.GetType().Name}");
+            }
+        }
+
+        /// <summary>
+        /// Waits for an outbound wire message with the given command, acking intermediate writes
+        /// (TaskManager noise or queue siblings).
+        /// </summary>
+        private static Message ExpectOutboundCommand(
+            TestActorRef<RemoteNode> remote,
+            TestProbe connection,
+            TestProbe sender,
+            MessageCommand command,
+            TimeSpan? timeout = null)
+        {
+            var deadline = DateTime.UtcNow + (timeout ?? TimeSpan.FromSeconds(3));
+            while (DateTime.UtcNow < deadline)
+            {
+                var remaining = deadline - DateTime.UtcNow;
+                if (remaining < TimeSpan.Zero) remaining = TimeSpan.Zero;
+                var next = connection.ReceiveOne(remaining);
+                Assert.IsNotNull(next, $"Timed out waiting for outbound {command}");
+                Assert.IsInstanceOfType<Tcp.Write>(next);
+                var write = (Tcp.Write)next;
+                sender.Send(remote, Connection.Ack.Instance);
+                var msg = ParseOutbound(write);
+                if (msg.Command == command)
+                    return msg;
+            }
+            Assert.Fail($"Timed out waiting for outbound {command}");
+            return null;
+        }
+
+        private static Message ParseOutbound(Tcp.Write write)
+        {
+            var length = Message.TryDeserialize(write.Data, out var msg);
+            Assert.IsTrue(length > 0, "Outbound Tcp.Write did not contain a parseable Message");
+            Assert.IsNotNull(msg);
+            return msg;
+        }
+
+        [TestMethod]
+        public void Handshake_Version_SetsCapabilities_And_SendsVerack()
+        {
+            var (remote, connection) = SpawnRemoteNode();
+            var sender = CreateTestProbe();
+
+            sender.Send(remote, AsReceived(Message.Create(MessageCommand.Version, MakeVersion(42, 10333))));
+            var write = connection.ExpectMsg<Tcp.Write>(TimeSpan.FromSeconds(3), cancellationToken: CancellationToken.None);
+            var reply = ParseOutbound(write);
+            Assert.AreEqual(MessageCommand.Verack, reply.Command);
+
+            Assert.IsTrue(remote.UnderlyingActor.IsFullNode);
+            Assert.AreEqual(42u, remote.UnderlyingActor.LastBlockIndex);
+            Assert.AreEqual(10333, remote.UnderlyingActor.ListenerTcpPort);
+        }
+
+        [TestMethod]
+        public void AfterHandshake_Ping_RepliesWithPong_AndUpdatesLastBlockIndex()
+        {
+            var (remote, connection) = SpawnRemoteNode();
+            var sender = CreateTestProbe();
+            CompleteHandshake(remote, connection, sender: sender);
+
+            const uint peerHeight = 99;
+            const uint nonce = 0xC0FFEE;
+            sender.Send(remote, AsReceived(Message.Create(
+                MessageCommand.Ping,
+                PingPayload.Create(peerHeight, nonce))));
+
+            var pong = ExpectOutboundCommand(remote, connection, sender, MessageCommand.Pong);
+            var payload = (PingPayload)pong.Payload;
+            Assert.AreEqual(nonce, payload.Nonce);
+            Assert.AreEqual(peerHeight, remote.UnderlyingActor.LastBlockIndex);
+        }
+
+        [TestMethod]
+        public void AfterHandshake_Pong_UpdatesLastBlockIndex_WithoutWrite()
+        {
+            var (remote, connection) = SpawnRemoteNode();
+            var sender = CreateTestProbe();
+            CompleteHandshake(remote, connection, sender: sender);
+
+            sender.Send(remote, AsReceived(Message.Create(
+                MessageCommand.Pong,
+                PingPayload.Create(55, 1))));
+
+            connection.ExpectNoMsg(TimeSpan.FromMilliseconds(300), cancellationToken: CancellationToken.None);
+            Assert.AreEqual(55u, remote.UnderlyingActor.LastBlockIndex);
+        }
+
+        [TestMethod]
+        public void MessageReceived_ReturningFalse_StopsProtocolHandling()
+        {
+            var received = new List<MessageCommand>();
+            MessageReceivedHandler handler = (_, msg) =>
+            {
+                received.Add(msg.Command);
+                return false; // stop further OnMessage handling
+            };
+            RemoteNode.MessageReceived += handler;
+            try
+            {
+                var (remote, connection) = SpawnRemoteNode();
+                var sender = CreateTestProbe();
+                sender.Send(remote, AsReceived(Message.Create(MessageCommand.Version, MakeVersion())));
+
+                connection.ExpectNoMsg(TimeSpan.FromMilliseconds(400), cancellationToken: CancellationToken.None);
+                Assert.IsNull(remote.UnderlyingActor.Version);
+                Assert.HasCount(1, received);
+                Assert.AreEqual(MessageCommand.Version, received[0]);
+            }
+            finally
+            {
+                RemoteNode.MessageReceived -= handler;
+            }
+        }
+
+        [TestMethod]
+        public void MessageReceived_ReturningTrue_IsInvoked_AndAllowsHandshake()
+        {
+            var seen = new List<MessageCommand>();
+            MessageReceivedHandler handler = (system, msg) =>
+            {
+                Assert.AreSame(s_system, system);
+                seen.Add(msg.Command);
+                return true;
+            };
+            RemoteNode.MessageReceived += handler;
+            try
+            {
+                var (remote, connection) = SpawnRemoteNode();
+                CompleteHandshake(remote, connection);
+
+                Assert.IsTrue(seen.Contains(MessageCommand.Version));
+                Assert.IsTrue(seen.Contains(MessageCommand.Verack));
+            }
+            finally
+            {
+                RemoteNode.MessageReceived -= handler;
+            }
+        }
+
+        [TestMethod]
+        public void AfterHandshake_GetHeaders_FromGenesis_ReturnsHeaders()
+        {
+            var (remote, connection) = SpawnRemoteNode();
+            var sender = CreateTestProbe();
+            CompleteHandshake(remote, connection, sender: sender);
+
+            sender.Send(remote, AsReceived(Message.Create(
+                MessageCommand.GetHeaders,
+                GetBlockByIndexPayload.Create(0, 1))));
+
+            var msg = ExpectOutboundCommand(remote, connection, sender, MessageCommand.Headers);
+            var headers = (HeadersPayload)msg.Payload;
+            Assert.IsTrue(headers.Headers.Length >= 1);
+            Assert.AreEqual(0u, headers.Headers[0].Index);
+        }
+
+        [TestMethod]
+        public void AfterHandshake_GetData_MissingTx_SendsNotFound()
+        {
+            var (remote, connection) = SpawnRemoteNode();
+            var sender = CreateTestProbe();
+            CompleteHandshake(remote, connection, sender: sender);
+
+            var missing = new UInt256(Crypto.Hash256(new byte[] { 1, 2, 3, 4 }));
+            sender.Send(remote, AsReceived(Message.Create(
+                MessageCommand.GetData,
+                InvPayload.Create(InventoryType.TX, missing))));
+
+            var msg = ExpectOutboundCommand(remote, connection, sender, MessageCommand.NotFound);
+            var inv = (InvPayload)msg.Payload;
+            Assert.AreEqual(InventoryType.TX, inv.Type);
+            Assert.HasCount(1, inv.Hashes);
+            Assert.AreEqual(missing, inv.Hashes[0]);
+        }
+
+        [TestMethod]
+        public void AfterHandshake_Mempool_WithEmptyPool_SendsNoInv()
+        {
+            var (remote, connection) = SpawnRemoteNode();
+            var sender = CreateTestProbe();
+            CompleteHandshake(remote, connection, sender: sender);
+
+            // TaskManager may already have marked MempoolSent during drain; peer-initiated Mempool
+            // with an empty pool still produces no Inv writes.
+            sender.Send(remote, AsReceived(Message.Create(MessageCommand.Mempool)));
+            connection.ExpectNoMsg(TimeSpan.FromMilliseconds(400), cancellationToken: CancellationToken.None);
+        }
+
+        [TestMethod]
+        public void AfterHandshake_FilterLoad_And_FilterClear_DoNotThrow()
+        {
+            var (remote, connection) = SpawnRemoteNode();
+            var sender = CreateTestProbe();
+            CompleteHandshake(remote, connection, sender: sender);
+
+            var filter = new BloomFilter(256, 2, 0xDEADBEEF);
+            sender.Send(remote, AsReceived(Message.Create(
+                MessageCommand.FilterLoad,
+                FilterLoadPayload.Create(filter))));
+            sender.Send(remote, AsReceived(Message.Create(MessageCommand.FilterClear)));
+            sender.Send(remote, AsReceived(Message.Create(
+                MessageCommand.FilterAdd,
+                new FilterAddPayload { Data = new byte[] { 9, 9, 9 } })));
+
+            // Filter ops have no direct wire reply; ensure actor stays alive (no unexpected write).
+            connection.ExpectNoMsg(TimeSpan.FromMilliseconds(300), cancellationToken: CancellationToken.None);
+            Assert.IsNotNull(remote.UnderlyingActor.Version);
+        }
+
+        [TestMethod]
+        public void AfterHandshake_DuplicateVersion_IsProtocolViolation()
+        {
+            var (remote, connection) = SpawnRemoteNode();
+            var sender = CreateTestProbe();
+            CompleteHandshake(remote, connection, sender: sender);
+
+            // Second Version after handshake throws ProtocolViolationException inside OnMessage;
+            // Connection.OnReceived catches Exception and Disconnect(true) → Tcp.Abort.
+            sender.Send(remote, AsReceived(Message.Create(MessageCommand.Version, MakeVersion())));
+            connection.ExpectMsg<Tcp.Abort>(TimeSpan.FromSeconds(3), cancellationToken: CancellationToken.None);
+        }
+    }
+}

--- a/tests/Neo.UnitTests/Network/P2P/UT_RemoteNode_ProtocolHandler.cs
+++ b/tests/Neo.UnitTests/Network/P2P/UT_RemoteNode_ProtocolHandler.cs
@@ -125,15 +125,17 @@ namespace Neo.UnitTests.Network.P2P
 
         /// <summary>
         /// Consumes outbound Tcp.Write frames produced by TaskManager after Register, acking each.
+        /// Bounded loop + fixed idle wait (no <c>while (true)</c>).
         /// </summary>
         private static void DrainTaskManagerOutbound(
             TestActorRef<RemoteNode> remote,
             TestProbe connection,
             TestProbe sender,
-            TimeSpan? quiet = null)
+            TimeSpan? quiet = null,
+            int maxMessages = 32)
         {
             var idle = quiet ?? TimeSpan.FromMilliseconds(400);
-            while (true)
+            for (var i = 0; i < maxMessages; i++)
             {
                 var next = connection.ReceiveOne(idle);
                 if (next is null) return;
@@ -145,6 +147,7 @@ namespace Neo.UnitTests.Network.P2P
                 // Unexpected non-Write; put back is not supported — fail loudly.
                 Assert.Fail($"Unexpected message while draining TaskManager outbound: {next.GetType().Name}");
             }
+            Assert.Fail($"Drained {maxMessages} outbound messages without a quiet period; possible runaway TaskManager traffic.");
         }
 
         /// <summary>

--- a/tests/Neo.UnitTests/Network/P2P/UT_RemoteNode_ProtocolHandler.cs
+++ b/tests/Neo.UnitTests/Network/P2P/UT_RemoteNode_ProtocolHandler.cs
@@ -276,9 +276,10 @@ namespace Neo.UnitTests.Network.P2P
         public void MessageReceived_ReturningTrue_IsInvoked_AndAllowsHandshake()
         {
             // Scope observation to this handshake's UserAgent so static-event noise is ignored.
+            // Verack has no payload, so it cannot be attributed safely on the process-wide event;
+            // count only the uniquely marked Version, and prove handshake via actor state.
             const string marker = "UT-MessageReceived-Allow";
             var versionSeen = 0;
-            var verackSeen = 0;
             MessageReceivedHandler handler = (system, msg) =>
             {
                 if (!ReferenceEquals(system, s_system))
@@ -288,11 +289,6 @@ namespace Neo.UnitTests.Network.P2P
                     && vp.UserAgent == marker)
                 {
                     versionSeen++;
-                }
-                else if (msg.Command == MessageCommand.Verack && versionSeen > 0)
-                {
-                    // Verack has no payload; count only after our Version was observed.
-                    verackSeen++;
                 }
                 return true;
             };
@@ -310,8 +306,7 @@ namespace Neo.UnitTests.Network.P2P
 
                 Assert.IsNotNull(remote.UnderlyingActor.Version);
                 Assert.AreEqual(marker, remote.UnderlyingActor.Version.UserAgent);
-                Assert.IsTrue(versionSeen >= 1);
-                Assert.IsTrue(verackSeen >= 1);
+                Assert.AreEqual(1, versionSeen);
             }
             finally
             {

--- a/tests/Neo.UnitTests/Network/P2P/UT_TaskSession_Coverage.cs
+++ b/tests/Neo.UnitTests/Network/P2P/UT_TaskSession_Coverage.cs
@@ -1,0 +1,98 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// UT_TaskSession_Coverage.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.Network.P2P;
+using Neo.Network.P2P.Capabilities;
+using Neo.Network.P2P.Payloads;
+using System;
+
+namespace Neo.UnitTests.Network.P2P
+{
+    [TestClass]
+    public class UT_TaskSession_Coverage
+    {
+        private static TaskSession FullNodeSession(uint height = 10)
+        {
+            return new TaskSession(new VersionPayload
+            {
+                Capabilities = [new FullNodeCapability(height)],
+                UserAgent = "ut"
+            });
+        }
+
+        [TestMethod]
+        public void AvailableTasks_And_ReceivedBlock_AreIndependentCollections()
+        {
+            var session = FullNodeSession();
+            var hash = UInt256.Zero;
+            session.AvailableTasks.Add(hash);
+            Assert.IsTrue(session.AvailableTasks.Contains(hash));
+            Assert.IsEmpty(session.ReceivedBlock);
+            Assert.IsEmpty(session.InvTasks);
+        }
+
+        [TestMethod]
+        public void HasTooManyTasks_CountsInvAndIndexTogether()
+        {
+            var session = FullNodeSession();
+            for (uint i = 0; i < 60; i++)
+                session.IndexTasks[i] = DateTime.UtcNow;
+            for (var i = 0; i < 40; i++)
+            {
+                var bytes = new byte[32];
+                bytes[0] = (byte)i;
+                bytes[1] = (byte)(i >> 8);
+                session.InvTasks[new UInt256(bytes)] = DateTime.UtcNow;
+            }
+            Assert.IsTrue(session.HasTooManyTasks);
+        }
+
+        [TestMethod]
+        public void LastBlockIndex_CanBeUpdated()
+        {
+            var session = FullNodeSession(5);
+            Assert.AreEqual(5u, session.LastBlockIndex);
+            session.LastBlockIndex = 99;
+            Assert.AreEqual(99u, session.LastBlockIndex);
+        }
+
+        [TestMethod]
+        public void NonFullNode_HasZeroLastBlockIndex()
+        {
+            var session = new TaskSession(new VersionPayload
+            {
+                Capabilities = [new ServerCapability(NodeCapabilityType.TcpServer, 10333)],
+                UserAgent = "light"
+            });
+            Assert.IsFalse(session.IsFullNode);
+            Assert.AreEqual(0u, session.LastBlockIndex);
+        }
+
+        [TestMethod]
+        public void MempoolSent_DefaultsFalse_AndCanBeSet()
+        {
+            var session = FullNodeSession();
+            Assert.IsFalse(session.MempoolSent);
+            session.MempoolSent = true;
+            Assert.IsTrue(session.MempoolSent);
+        }
+
+        [TestMethod]
+        public void HasTooManyTasks_FalseWhenUnderLimit()
+        {
+            var session = FullNodeSession();
+            for (uint i = 0; i < 50; i++)
+                session.IndexTasks[i] = DateTime.UtcNow;
+            Assert.IsFalse(session.HasTooManyTasks);
+        }
+    }
+}


### PR DESCRIPTION
# Description

Adds behavioral P2P coverage using Akka.TestKit (same pattern as existing `UT_RemoteNode`):

- `TaskSession` task limits, full-node height, `MempoolSent`
- `RemoteNode` ProtocolHandler via framed `Tcp.Received` / outbound `Tcp.Write`: Version/Verack handshake, Ping/Pong, GetHeaders, GetData NotFound, FilterLoad/Clear/Add, `MessageReceived` short-circuit, duplicate Version → disconnect
- Drains TaskManager `Register` side-effects so protocol asserts stay deterministic

Part of the larger ~90% coverage track. Test-only; no product behavior changes.

Related: #4693

# Change Log

- Add File `tests/Neo.UnitTests/Network/P2P/UT_TaskSession_Coverage.cs`
- Add File `tests/Neo.UnitTests/Network/P2P/UT_RemoteNode_ProtocolHandler.cs`

Fixes #4693 (partial — P2P ProtocolHandler slice)

## Type of change

- [ ] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Unit Testing
- [ ] Run Application
- [ ] Local Computer Tests
- [ ] No Testing

`dotnet test tests/Neo.UnitTests --filter "FullyQualifiedName~UT_RemoteNode_ProtocolHandler|FullyQualifiedName~UT_TaskSession_Coverage"` (16 passed)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules