### PR TITLE
[Coverage] TaskManager, ProtocolHandler depth, and LocalNode tests

### DIFF
--- a/tests/Neo.UnitTests/Network/P2P/UT_LocalNode_Coverage.cs
+++ b/tests/Neo.UnitTests/Network/P2P/UT_LocalNode_Coverage.cs
@@ -1,0 +1,73 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// UT_LocalNode_Coverage.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Akka.TestKit.MsTest;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.Network.P2P;
+using Neo.Network.P2P.Payloads;
+using System;
+using System.Net;
+using System.Threading;
+
+namespace Neo.UnitTests.Network.P2P
+{
+    [TestClass]
+    public class UT_LocalNode_Coverage : TestKit
+    {
+        private static NeoSystem s_system;
+
+        [ClassInitialize]
+        public static void ClassSetup(TestContext _)
+        {
+            s_system = TestBlockchain.GetSystem();
+        }
+
+        [TestMethod]
+        public void Peers_Message_AddsUnconnectedPeers()
+        {
+            var sender = CreateTestProbe();
+            sender.Send(s_system.LocalNode, new ChannelsConfig
+            {
+                Tcp = new IPEndPoint(IPAddress.Loopback, 0),
+                MinDesiredConnections = 1,
+                MaxConnections = 10,
+                MaxConnectionsPerAddress = 3
+            });
+
+            var ep = new IPEndPoint(IPAddress.Parse("203.0.113.10"), 20333);
+            sender.Send(s_system.LocalNode, new Peer.Peers([ep]));
+
+            sender.Send(s_system.LocalNode, new LocalNode.GetInstance());
+            var local = sender.ExpectMsg<LocalNode>(TimeSpan.FromSeconds(3), cancellationToken: CancellationToken.None);
+            Assert.IsTrue(local.UnconnectedCount >= 0);
+        }
+
+        [TestMethod]
+        public void Relay_Directly_Message_DoesNotFault()
+        {
+            var sender = CreateTestProbe();
+            var inv = InvPayload.Create(InventoryType.TX,
+                UInt256.Parse("0x3333333333333333333333333333333333333333333333333333333333333333"));
+            sender.Send(s_system.LocalNode, Message.Create(MessageCommand.Inv, inv));
+            sender.ExpectNoMsg(TimeSpan.FromMilliseconds(300), cancellationToken: CancellationToken.None);
+        }
+
+        [TestMethod]
+        public void GetInstance_ReturnsLocalNode()
+        {
+            var sender = CreateTestProbe();
+            sender.Send(s_system.LocalNode, new LocalNode.GetInstance());
+            var local = sender.ExpectMsg<LocalNode>(TimeSpan.FromSeconds(3), cancellationToken: CancellationToken.None);
+            Assert.IsNotNull(local);
+            Assert.IsNotNull(local.Config);
+        }
+    }
+}

--- a/tests/Neo.UnitTests/Network/P2P/UT_LocalNode_Coverage.cs
+++ b/tests/Neo.UnitTests/Network/P2P/UT_LocalNode_Coverage.cs
@@ -14,6 +14,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Neo.Network.P2P;
 using Neo.Network.P2P.Payloads;
 using System;
+using System.Linq;
 using System.Net;
 using System.Threading;
 
@@ -22,49 +23,53 @@ namespace Neo.UnitTests.Network.P2P
     [TestClass]
     public class UT_LocalNode_Coverage : TestKit
     {
-        private static NeoSystem s_system;
-
-        [ClassInitialize]
-        public static void ClassSetup(TestContext _)
-        {
-            s_system = TestBlockchain.GetSystem();
-        }
-
         [TestMethod]
         public void Peers_Message_AddsUnconnectedPeers()
         {
+            // Isolated actor so we do not reconfigure the shared NeoSystem.LocalNode.
+            var system = TestBlockchain.GetSystem();
+            var localNode = ActorOf(LocalNode.Props(system));
             var sender = CreateTestProbe();
-            sender.Send(s_system.LocalNode, new ChannelsConfig
+
+            // MinDesiredConnections = 0 keeps OnTimer from draining UnconnectedPeers.
+            sender.Send(localNode, new ChannelsConfig
             {
                 Tcp = new IPEndPoint(IPAddress.Loopback, 0),
-                MinDesiredConnections = 1,
+                MinDesiredConnections = 0,
                 MaxConnections = 10,
                 MaxConnectionsPerAddress = 3
             });
 
             var ep = new IPEndPoint(IPAddress.Parse("203.0.113.10"), 20333);
-            sender.Send(s_system.LocalNode, new Peer.Peers([ep]));
+            sender.Send(localNode, new Peer.Peers([ep]));
 
-            sender.Send(s_system.LocalNode, new LocalNode.GetInstance());
+            sender.Send(localNode, new LocalNode.GetInstance());
             var local = sender.ExpectMsg<LocalNode>(TimeSpan.FromSeconds(3), cancellationToken: CancellationToken.None);
-            Assert.IsTrue(local.UnconnectedCount >= 0);
+            Assert.IsTrue(local.GetUnconnectedPeers().Any(p => p.Equals(ep)));
         }
 
         [TestMethod]
         public void Relay_Directly_Message_DoesNotFault()
         {
+            var system = TestBlockchain.GetSystem();
+            var localNode = ActorOf(LocalNode.Props(system));
             var sender = CreateTestProbe();
+            sender.Send(localNode, new ChannelsConfig());
+
             var inv = InvPayload.Create(InventoryType.TX,
                 UInt256.Parse("0x3333333333333333333333333333333333333333333333333333333333333333"));
-            sender.Send(s_system.LocalNode, Message.Create(MessageCommand.Inv, inv));
+            sender.Send(localNode, Message.Create(MessageCommand.Inv, inv));
             sender.ExpectNoMsg(TimeSpan.FromMilliseconds(300), cancellationToken: CancellationToken.None);
         }
 
         [TestMethod]
         public void GetInstance_ReturnsLocalNode()
         {
+            var system = TestBlockchain.GetSystem();
+            var localNode = ActorOf(LocalNode.Props(system));
             var sender = CreateTestProbe();
-            sender.Send(s_system.LocalNode, new LocalNode.GetInstance());
+            sender.Send(localNode, new ChannelsConfig());
+            sender.Send(localNode, new LocalNode.GetInstance());
             var local = sender.ExpectMsg<LocalNode>(TimeSpan.FromSeconds(3), cancellationToken: CancellationToken.None);
             Assert.IsNotNull(local);
             Assert.IsNotNull(local.Config);

--- a/tests/Neo.UnitTests/Network/P2P/UT_RemoteNode_ProtocolHandler_Depth.cs
+++ b/tests/Neo.UnitTests/Network/P2P/UT_RemoteNode_ProtocolHandler_Depth.cs
@@ -1,0 +1,273 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// UT_RemoteNode_ProtocolHandler_Depth.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Akka.Actor;
+using Akka.IO;
+using Akka.TestKit;
+using Akka.TestKit.MsTest;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.Cryptography;
+using Neo.Extensions;
+using Neo.Network.P2P;
+using Neo.Network.P2P.Capabilities;
+using Neo.Network.P2P.Payloads;
+using Neo.SmartContract.Native;
+using System;
+using System.Net;
+using System.Threading;
+
+namespace Neo.UnitTests.Network.P2P
+{
+    /// <summary>
+    /// Additional ProtocolHandler coverage beyond UT_RemoteNode_ProtocolHandler (handshake/ping/filters).
+    /// </summary>
+    [TestClass]
+    public class UT_RemoteNode_ProtocolHandler_Depth : TestKit
+    {
+        private static NeoSystem s_system;
+        private static uint s_nextNonce = 0xD00D;
+
+        public UT_RemoteNode_ProtocolHandler_Depth()
+            : base($"remote-node-mailbox {{ mailbox-type: \"{typeof(RemoteNodeMailbox).AssemblyQualifiedName}\" }}")
+        {
+        }
+
+        [ClassInitialize]
+        public static void TestSetup(TestContext ctx)
+        {
+            s_system = TestBlockchain.GetSystem();
+        }
+
+        private static VersionPayload MakeVersion(uint startHeight = 0)
+        {
+            var nonce = s_nextNonce++;
+            if (nonce == LocalNode.Nonce)
+                nonce = s_nextNonce++;
+
+            return new VersionPayload
+            {
+                UserAgent = "ProtocolHandlerDepthUT",
+                Nonce = nonce,
+                Network = TestProtocolSettings.Default.Network,
+                Timestamp = 1,
+                Version = LocalNode.ProtocolVersion,
+                Capabilities =
+                [
+                    new FullNodeCapability(startHeight),
+                    new ServerCapability(NodeCapabilityType.TcpServer, 20333)
+                ]
+            };
+        }
+
+        private static Tcp.Received AsReceived(Message message) =>
+            new((ByteString)message.ToArray());
+
+        private (TestActorRef<RemoteNode> remote, TestProbe connection) SpawnRemoteNode()
+        {
+            var connection = CreateTestProbe("conn-depth");
+            var remoteEp = new IPEndPoint(IPAddress.Parse("192.0.2.20"), 20333);
+            var localEp = new IPEndPoint(IPAddress.Loopback, 20335);
+            var remote = ActorOfAsTestActorRef(() =>
+                new RemoteNode(
+                    s_system,
+                    new LocalNode(s_system),
+                    connection,
+                    remoteEp,
+                    localEp,
+                    new ChannelsConfig()));
+            return (remote, connection);
+        }
+
+        private void CompleteHandshake(TestActorRef<RemoteNode> remote, TestProbe connection, TestProbe sender = null)
+        {
+            sender ??= CreateTestProbe();
+            sender.Send(remote, AsReceived(Message.Create(MessageCommand.Version, MakeVersion(0))));
+            connection.ExpectMsg<Tcp.Write>(TimeSpan.FromSeconds(3), cancellationToken: CancellationToken.None);
+            sender.Send(remote, Connection.Ack.Instance);
+            sender.Send(remote, AsReceived(Message.Create(MessageCommand.Verack)));
+            DrainOutbound(remote, connection, sender);
+        }
+
+        private static void DrainOutbound(TestActorRef<RemoteNode> remote, TestProbe connection, TestProbe sender, TimeSpan? quiet = null)
+        {
+            var idle = quiet ?? TimeSpan.FromMilliseconds(400);
+            while (true)
+            {
+                var next = connection.ReceiveOne(idle, cancellationToken: CancellationToken.None);
+                if (next is null) return;
+                if (next is Tcp.Write)
+                {
+                    sender.Send(remote, Connection.Ack.Instance);
+                    continue;
+                }
+                Assert.Fail($"Unexpected message while draining: {next.GetType().Name}");
+            }
+        }
+
+        private static Message ExpectOutboundCommand(
+            TestActorRef<RemoteNode> remote,
+            TestProbe connection,
+            TestProbe sender,
+            MessageCommand command,
+            TimeSpan? timeout = null)
+        {
+            var deadline = DateTime.UtcNow + (timeout ?? TimeSpan.FromSeconds(3));
+            while (DateTime.UtcNow < deadline)
+            {
+                var remaining = deadline - DateTime.UtcNow;
+                if (remaining < TimeSpan.Zero) remaining = TimeSpan.Zero;
+                var next = connection.ReceiveOne(remaining, cancellationToken: CancellationToken.None);
+                Assert.IsNotNull(next, $"Timed out waiting for outbound {command}");
+                Assert.IsInstanceOfType<Tcp.Write>(next);
+                sender.Send(remote, Connection.Ack.Instance);
+                var length = Message.TryDeserialize(((Tcp.Write)next).Data, out var msg);
+                Assert.IsTrue(length > 0);
+                if (msg.Command == command)
+                    return msg;
+            }
+            Assert.Fail($"Timed out waiting for outbound {command}");
+            return null;
+        }
+
+        [TestMethod]
+        public void AfterHandshake_GetBlocks_FromGenesis_SendsInvOrNothing()
+        {
+            var (remote, connection) = SpawnRemoteNode();
+            var sender = CreateTestProbe();
+            CompleteHandshake(remote, connection, sender);
+
+            var genesis = NativeContract.Ledger.GetBlockHash(s_system.StoreView, 0);
+            Assert.IsNotNull(genesis);
+
+            sender.Send(remote, AsReceived(Message.Create(
+                MessageCommand.GetBlocks,
+                GetBlocksPayload.Create(genesis, 10))));
+
+            // Only genesis exists: either no hashes after start, or empty → no Inv.
+            // If more blocks exist in the test chain, Inv is acceptable.
+            var next = connection.ReceiveOne(TimeSpan.FromMilliseconds(500), cancellationToken: CancellationToken.None);
+            if (next is Tcp.Write write)
+            {
+                sender.Send(remote, Connection.Ack.Instance);
+                Message.TryDeserialize(write.Data, out var msg);
+                Assert.IsTrue(msg.Command is MessageCommand.Inv or MessageCommand.NotFound);
+            }
+        }
+
+        [TestMethod]
+        public void AfterHandshake_GetBlockByIndex_Genesis_SendsBlock()
+        {
+            var (remote, connection) = SpawnRemoteNode();
+            var sender = CreateTestProbe();
+            CompleteHandshake(remote, connection, sender);
+
+            sender.Send(remote, AsReceived(Message.Create(
+                MessageCommand.GetBlockByIndex,
+                GetBlockByIndexPayload.Create(0, 1))));
+
+            var msg = ExpectOutboundCommand(remote, connection, sender, MessageCommand.Block);
+            Assert.IsInstanceOfType<Block>(msg.Payload);
+            Assert.AreEqual(0u, ((Block)msg.Payload).Index);
+        }
+
+        [TestMethod]
+        public void AfterHandshake_GetData_MissingBlock_SendsNotFound()
+        {
+            var (remote, connection) = SpawnRemoteNode();
+            var sender = CreateTestProbe();
+            CompleteHandshake(remote, connection, sender);
+
+            var missing = new UInt256(Crypto.Hash256([9, 8, 7, 6]));
+            sender.Send(remote, AsReceived(Message.Create(
+                MessageCommand.GetData,
+                InvPayload.Create(InventoryType.Block, missing))));
+
+            var msg = ExpectOutboundCommand(remote, connection, sender, MessageCommand.NotFound);
+            var inv = (InvPayload)msg.Payload;
+            Assert.AreEqual(InventoryType.Block, inv.Type);
+            Assert.AreEqual(missing, inv.Hashes[0]);
+        }
+
+        [TestMethod]
+        public void AfterHandshake_GetData_GenesisBlock_SendsBlock()
+        {
+            var (remote, connection) = SpawnRemoteNode();
+            var sender = CreateTestProbe();
+            CompleteHandshake(remote, connection, sender);
+
+            var genesisHash = NativeContract.Ledger.GetBlockHash(s_system.StoreView, 0);
+            sender.Send(remote, AsReceived(Message.Create(
+                MessageCommand.GetData,
+                InvPayload.Create(InventoryType.Block, genesisHash))));
+
+            var msg = ExpectOutboundCommand(remote, connection, sender, MessageCommand.Block);
+            Assert.AreEqual(genesisHash, ((Block)msg.Payload).Hash);
+        }
+
+        [TestMethod]
+        public void AfterHandshake_Inv_Tx_DoesNotFault()
+        {
+            var (remote, connection) = SpawnRemoteNode();
+            var sender = CreateTestProbe();
+            CompleteHandshake(remote, connection, sender);
+
+            var hash = new UInt256(Crypto.Hash256([1, 1, 1, 1]));
+            sender.Send(remote, AsReceived(Message.Create(
+                MessageCommand.Inv,
+                InvPayload.Create(InventoryType.TX, hash))));
+
+            // Inv is forwarded to TaskManager; may produce delayed outbound frames — drain, stay alive.
+            DrainOutbound(remote, connection, sender, TimeSpan.FromMilliseconds(300));
+            Assert.IsNotNull(remote.UnderlyingActor.Version);
+        }
+
+        [TestMethod]
+        public void AfterHandshake_GetAddr_WithNoPeers_DoesNotFault()
+        {
+            var (remote, connection) = SpawnRemoteNode();
+            var sender = CreateTestProbe();
+            CompleteHandshake(remote, connection, sender);
+
+            sender.Send(remote, AsReceived(Message.Create(MessageCommand.GetAddr)));
+            // With no peers, GetAddr should not produce Addr; ignore residual TaskManager frames.
+            DrainOutbound(remote, connection, sender, TimeSpan.FromMilliseconds(300));
+            Assert.IsNotNull(remote.UnderlyingActor.Version);
+        }
+
+        [TestMethod]
+        public void AfterHandshake_Headers_UpdatesLastBlockIndex()
+        {
+            var (remote, connection) = SpawnRemoteNode();
+            var sender = CreateTestProbe();
+            CompleteHandshake(remote, connection, sender);
+
+            var header = NativeContract.Ledger.GetHeader(s_system.StoreView, 0);
+            Assert.IsNotNull(header);
+
+            sender.Send(remote, AsReceived(Message.Create(
+                MessageCommand.Headers,
+                HeadersPayload.Create([header]))));
+
+            // Headers are forwarded to Blockchain; peer LastBlockIndex updates from last header.
+            Assert.AreEqual(header.Index, remote.UnderlyingActor.LastBlockIndex);
+        }
+
+        [TestMethod]
+        public void PreHandshake_NonVersion_Aborts()
+        {
+            var (remote, connection) = SpawnRemoteNode();
+            var sender = CreateTestProbe();
+
+            sender.Send(remote, AsReceived(Message.Create(MessageCommand.Ping, PingPayload.Create(0, 1))));
+            connection.ExpectMsg<Tcp.Abort>(TimeSpan.FromSeconds(3), cancellationToken: CancellationToken.None);
+        }
+    }
+}

--- a/tests/Neo.UnitTests/Network/P2P/UT_TaskManager.cs
+++ b/tests/Neo.UnitTests/Network/P2P/UT_TaskManager.cs
@@ -1,0 +1,156 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// UT_TaskManager.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Akka.Actor;
+using Akka.TestKit.MsTest;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.Ledger;
+using Neo.Network.P2P;
+using Neo.Network.P2P.Capabilities;
+using Neo.Network.P2P.Payloads;
+using Neo.SmartContract.Native;
+using System;
+using System.Threading;
+
+namespace Neo.UnitTests.Network.P2P
+{
+    [TestClass]
+    public class UT_TaskManager : TestKit
+    {
+        private static NeoSystem s_system;
+
+        [ClassInitialize]
+        public static void ClassSetup(TestContext _)
+        {
+            s_system = TestBlockchain.GetSystem();
+        }
+
+        private static VersionPayload MakeVersion(uint startHeight)
+        {
+            return new VersionPayload
+            {
+                UserAgent = "TaskManagerUT",
+                Nonce = 0xBEEF,
+                Network = TestProtocolSettings.Default.Network,
+                Timestamp = 1,
+                Version = LocalNode.ProtocolVersion,
+                Capabilities = [new FullNodeCapability(startHeight)]
+            };
+        }
+
+        [TestMethod]
+        public void Register_AtOrBelowLocalHeight_RequestsMempool()
+        {
+            var remote = CreateTestProbe("remote-mempool");
+            var height = NativeContract.Ledger.CurrentIndex(s_system.StoreView);
+            remote.Send(s_system.TaskManager, new TaskManager.Register(MakeVersion(height)));
+
+            var msg = remote.FishForMessage<Message>(
+                m => m.Command == MessageCommand.Mempool,
+                TimeSpan.FromSeconds(3),
+                cancellationToken: CancellationToken.None);
+            Assert.IsNotNull(msg);
+            Assert.AreEqual(MessageCommand.Mempool, msg.Command);
+        }
+
+        [TestMethod]
+        public void Register_HigherPeer_RequestsWork()
+        {
+            var remote = CreateTestProbe("remote-headers");
+            var height = NativeContract.Ledger.CurrentIndex(s_system.StoreView);
+            remote.Send(s_system.TaskManager, new TaskManager.Register(MakeVersion(height + 50)));
+
+            var msg = remote.FishForMessage<Message>(
+                m => m.Command is MessageCommand.GetHeaders or MessageCommand.GetBlockByIndex or MessageCommand.Mempool,
+                TimeSpan.FromSeconds(3),
+                cancellationToken: CancellationToken.None);
+            Assert.IsNotNull(msg);
+        }
+
+        [TestMethod]
+        public void Update_WithoutSession_IsIgnored()
+        {
+            var remote = CreateTestProbe("remote-orphan-update");
+            remote.Send(s_system.TaskManager, new TaskManager.Update(123));
+            remote.ExpectNoMsg(TimeSpan.FromMilliseconds(300), cancellationToken: CancellationToken.None);
+        }
+
+        [TestMethod]
+        public void Update_AfterRegister_DoesNotThrow()
+        {
+            var remote = CreateTestProbe("remote-update");
+            var height = NativeContract.Ledger.CurrentIndex(s_system.StoreView);
+            remote.Send(s_system.TaskManager, new TaskManager.Register(MakeVersion(height)));
+            remote.ReceiveOne(TimeSpan.FromSeconds(2), cancellationToken: CancellationToken.None);
+
+            remote.Send(s_system.TaskManager, new TaskManager.Update(height + 10));
+            remote.ReceiveOne(TimeSpan.FromMilliseconds(500), cancellationToken: CancellationToken.None);
+        }
+
+        [TestMethod]
+        public void NewTasks_TxInventory_DoesNotFaultActor()
+        {
+            var remote = CreateTestProbe("remote-newtasks");
+            var height = NativeContract.Ledger.CurrentIndex(s_system.StoreView);
+            remote.Send(s_system.TaskManager, new TaskManager.Register(MakeVersion(height)));
+            remote.ReceiveOne(TimeSpan.FromSeconds(2), cancellationToken: CancellationToken.None);
+
+            var hash = UInt256.Parse("0x1111111111111111111111111111111111111111111111111111111111111111");
+            remote.Send(s_system.TaskManager, new TaskManager.NewTasks(
+                InvPayload.Create(InventoryType.TX, hash)));
+
+            // TX NewTasks may produce GetData (or nothing); either is fine — actor must stay healthy.
+            _ = remote.ReceiveOne(TimeSpan.FromMilliseconds(400), cancellationToken: CancellationToken.None);
+        }
+
+        [TestMethod]
+        public void RestartTasks_DoesNotFaultActor()
+        {
+            var remote = CreateTestProbe("remote-restart");
+            var height = NativeContract.Ledger.CurrentIndex(s_system.StoreView);
+            remote.Send(s_system.TaskManager, new TaskManager.Register(MakeVersion(height)));
+            remote.ReceiveOne(TimeSpan.FromSeconds(2), cancellationToken: CancellationToken.None);
+
+            var hash = UInt256.Parse("0x2222222222222222222222222222222222222222222222222222222222222222");
+            remote.Send(s_system.TaskManager, new TaskManager.RestartTasks(
+                InvPayload.Create(InventoryType.Block, hash)));
+
+            remote.ExpectNoMsg(TimeSpan.FromMilliseconds(200), cancellationToken: CancellationToken.None);
+        }
+
+        [TestMethod]
+        public void PersistCompleted_IsAccepted()
+        {
+            var remote = CreateTestProbe("remote-persist");
+            var height = NativeContract.Ledger.CurrentIndex(s_system.StoreView);
+            remote.Send(s_system.TaskManager, new TaskManager.Register(MakeVersion(height + 5)));
+            remote.ReceiveOne(TimeSpan.FromSeconds(2), cancellationToken: CancellationToken.None);
+
+            var block = NativeContract.Ledger.GetBlock(s_system.StoreView, 0);
+            Assert.IsNotNull(block);
+            s_system.TaskManager.Tell(new Blockchain.PersistCompleted(block), remote);
+            remote.ReceiveOne(TimeSpan.FromMilliseconds(500), cancellationToken: CancellationToken.None);
+        }
+
+        [TestMethod]
+        public void InventoryCompleted_IsAccepted()
+        {
+            var remote = CreateTestProbe("remote-inv-done");
+            var height = NativeContract.Ledger.CurrentIndex(s_system.StoreView);
+            remote.Send(s_system.TaskManager, new TaskManager.Register(MakeVersion(height)));
+            remote.ReceiveOne(TimeSpan.FromSeconds(2), cancellationToken: CancellationToken.None);
+
+            var block = NativeContract.Ledger.GetBlock(s_system.StoreView, 0);
+            remote.Send(s_system.TaskManager, block);
+            remote.ReceiveOne(TimeSpan.FromMilliseconds(500), cancellationToken: CancellationToken.None);
+        }
+    }
+}


### PR DESCRIPTION
# Description

Adds behavioral P2P coverage for TaskManager session/register/update/new-tasks paths, additional RemoteNode ProtocolHandler commands (GetBlocks, GetBlockByIndex, GetData, Inv, Headers, pre-handshake abort), and LocalNode peer/relay helpers. Complements existing ProtocolHandler handshake work. Test-only; no product behavior changes.

# Change Log

- Add File `tests/Neo.UnitTests/Network/P2P/UT_TaskManager.cs`
- Add File `tests/Neo.UnitTests/Network/P2P/UT_RemoteNode_ProtocolHandler_Depth.cs`
- Add File `tests/Neo.UnitTests/Network/P2P/UT_LocalNode_Coverage.cs`

Fixes # (issue)

## Type of change

- [x] Style (the change is only a code style for better maintenance or standard purpose)

# How Has This Been Tested?

- [x] Unit Testing

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules