### PR TITLE
Make contract formatting culture-independent under Huyao

### DIFF
--- a/src/Neo/SmartContract/ApplicationEngine.Culture.cs
+++ b/src/Neo/SmartContract/ApplicationEngine.Culture.cs
@@ -1,0 +1,41 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// ApplicationEngine.Culture.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Neo.SmartContract.Native;
+using Neo.VM;
+using System.Globalization;
+
+namespace Neo.SmartContract
+{
+    partial class ApplicationEngine
+    {
+        /// <summary>
+        /// Executes contracts with culture-independent formatting after <see cref="Hardfork.HF_Huyao"/>.
+        /// </summary>
+        public override VMState Execute()
+        {
+            var index = PersistingBlock?.Index ?? NativeContract.Ledger.CurrentIndex(SnapshotCache);
+            if (!ProtocolSettings.IsHardforkEnabled(Hardfork.HF_Huyao, index))
+                return base.Execute();
+
+            var previousCulture = CultureInfo.CurrentCulture;
+            try
+            {
+                CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
+                return base.Execute();
+            }
+            finally
+            {
+                CultureInfo.CurrentCulture = previousCulture;
+            }
+        }
+    }
+}

--- a/tests/Neo.UnitTests/SmartContract/UT_ApplicationEngine.Culture.cs
+++ b/tests/Neo.UnitTests/SmartContract/UT_ApplicationEngine.Culture.cs
@@ -1,0 +1,136 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// UT_ApplicationEngine.Culture.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.VM;
+using System;
+using System.Globalization;
+using System.Numerics;
+using System.Text;
+
+namespace Neo.UnitTests.SmartContract
+{
+    public partial class UT_ApplicationEngine
+    {
+        [TestMethod]
+        public void TestPickItemCatchMessageWithHuyao()
+        {
+            const uint GorgonEnable = 10u;
+            const uint HuyaoEnable = 20u;
+            var settings = ProtocolSettings.Default with
+            {
+                Hardforks = ProtocolSettings.Default.Hardforks
+                    .SetItem(Hardfork.HF_Gorgon, GorgonEnable)
+                    .SetItem(Hardfork.HF_Huyao, HuyaoEnable)
+            };
+            var negativeKeyScript = BuildMissingMapKeyCatchScript(BigInteger.MinusOne * 5);
+            var positiveKeyScript = BuildMissingMapKeyCatchScript(new BigInteger(5));
+
+            Assert.AreEqual(
+                "Key \u22125 not found in Map.",
+                ExecuteCaughtMessage(negativeKeyScript, settings, HuyaoEnable - 1, "sv-SE"));
+
+            foreach (var culture in new[] { "en-US", "sv-SE", "nb-NO", "lt-LT" })
+            {
+                Assert.AreEqual(
+                    "Key -5 not found in Map.",
+                    ExecuteCaughtMessage(negativeKeyScript, settings, HuyaoEnable, culture));
+            }
+
+            var positiveEnUs = ExecuteCaughtMessage(positiveKeyScript, settings, HuyaoEnable, "en-US");
+            var positiveSvSe = ExecuteCaughtMessage(positiveKeyScript, settings, HuyaoEnable, "sv-SE");
+            Assert.AreEqual("Key 5 not found in Map.", positiveEnUs);
+            Assert.AreEqual(positiveEnUs, positiveSvSe);
+        }
+
+        [TestMethod]
+        public void TestSetItemCatchMessageWithHuyao()
+        {
+            const uint GorgonEnable = 10u;
+            const uint HuyaoEnable = 20u;
+            var settings = ProtocolSettings.Default with
+            {
+                Hardforks = ProtocolSettings.Default.Hardforks
+                    .SetItem(Hardfork.HF_Gorgon, GorgonEnable)
+                    .SetItem(Hardfork.HF_Huyao, HuyaoEnable)
+            };
+            var script = BuildOutOfRangeSetItemCatchScript(BigInteger.MinusOne * 5);
+
+            Assert.AreEqual(
+                "The index of VMArray is out of range, \u22125/[0, 0).",
+                ExecuteCaughtMessage(script, settings, HuyaoEnable - 1, "sv-SE"));
+
+            var enUs = ExecuteCaughtMessage(script, settings, HuyaoEnable, "en-US");
+            var svSe = ExecuteCaughtMessage(script, settings, HuyaoEnable, "sv-SE");
+            Assert.AreEqual("The index of VMArray is out of range, -5/[0, 0).", enUs);
+            Assert.AreEqual(enUs, svSe);
+        }
+
+        private static byte[] BuildMissingMapKeyCatchScript(BigInteger key)
+        {
+            return BuildCatchScript(script =>
+            {
+                script.Emit(OpCode.NEWMAP);
+                script.EmitPush(key);
+                script.Emit(OpCode.PICKITEM);
+            });
+        }
+
+        private static byte[] BuildOutOfRangeSetItemCatchScript(BigInteger key)
+        {
+            return BuildCatchScript(script =>
+            {
+                script.Emit(OpCode.NEWARRAY0);
+                script.EmitPush(key);
+                script.EmitPush(1);
+                script.Emit(OpCode.SETITEM);
+            });
+        }
+
+        private static byte[] BuildCatchScript(Action<ScriptBuilder> emitBody)
+        {
+            using var body = new ScriptBuilder();
+            emitBody(body);
+            var bodyLength = body.ToArray().Length;
+            var catchOffset = 3 + bodyLength + 2;
+            var endAddress = catchOffset + 2;
+            var firstEndTryOffset = endAddress - (3 + bodyLength);
+            var secondEndTryOffset = endAddress - catchOffset;
+
+            using var script = new ScriptBuilder();
+            script.Emit(OpCode.TRY, [(byte)(sbyte)catchOffset, 0]);
+            emitBody(script);
+            script.Emit(OpCode.ENDTRY, [(byte)(sbyte)firstEndTryOffset]);
+            script.Emit(OpCode.ENDTRY, [(byte)(sbyte)secondEndTryOffset]);
+            script.Emit(OpCode.RET);
+            return script.ToArray();
+        }
+
+        private static string ExecuteCaughtMessage(byte[] script, ProtocolSettings settings, uint index, string culture)
+        {
+            var previousCulture = CultureInfo.CurrentCulture;
+            try
+            {
+                CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo(culture);
+                using var engine = Execute(script, settings, index);
+
+                Assert.AreEqual(VMState.HALT, engine.State);
+                Assert.AreEqual(1, engine.ResultStack.Count);
+                Assert.AreEqual(culture, CultureInfo.CurrentCulture.Name);
+                return Encoding.UTF8.GetString(engine.ResultStack.Peek().GetSpan());
+            }
+            finally
+            {
+                CultureInfo.CurrentCulture = previousCulture;
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Description

Make contract execution culture-independent after `HF_Huyao`.

Some cultures render negative values with a non-ASCII minus sign. Because catchable exception messages are exposed to the VM as bytes, the same script can observe different values under different process cultures.

This change preserves historical behavior before Huyao and executes `ApplicationEngine` with `InvariantCulture` after activation. The previous process culture is restored when execution finishes.

# Change Log

- Add an `HF_Huyao`-gated invariant-culture execution boundary.
- Add cross-culture regression tests for contract-catchable `PICKITEM` and `SETITEM` messages.
- Preserve and test the existing pre-Huyao message bytes.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

- [x] Unit Testing
- [x] Local Computer Tests

The following validation was completed:

- Focused Huyao regression tests: 2 passed
- ApplicationEngine tests: 67 passed
- Full solution tests: 1465 passed
- Release solution build: 0 warnings and 0 errors
- Formatting verification: passed

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes