### PR TITLE
feat(Neo.Json): BigInteger support with HF_Huyao exact integers

### DIFF
--- a/src/Neo.Json/JNumber.cs
+++ b/src/Neo.Json/JNumber.cs
@@ -10,6 +10,7 @@
 // modifications are permitted.
 
 using System.Globalization;
+using System.Numerics;
 using System.Text.Json;
 
 namespace Neo.Json
@@ -30,9 +31,25 @@ namespace Neo.Json
         public static readonly long MIN_SAFE_INTEGER = -MAX_SAFE_INTEGER;
 
         /// <summary>
-        /// Gets the value of the JSON token.
+        /// When non-null, the exact integer value. Used for integers outside the IEEE-754
+        /// safe integer range (or constructed from <see cref="BigInteger"/> outside that range)
+        /// so they round-trip without precision loss.
         /// </summary>
-        public double Value { get; }
+        private readonly BigInteger? _integer;
+
+        private readonly double _double;
+
+        /// <summary>
+        /// Gets the value of the JSON token as a floating-point number.
+        /// For large integers this may lose precision; use <see cref="TryGetBigInteger"/> or
+        /// <see cref="GetBigInteger"/> when an exact integer is required.
+        /// </summary>
+        public double Value => _integer is BigInteger bi ? (double)bi : _double;
+
+        /// <summary>
+        /// Gets whether this number is stored as an exact integer representation.
+        /// </summary>
+        public bool IsExactInteger => _integer.HasValue || (_double % 1 == 0);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="JNumber"/> class with the specified value.
@@ -41,7 +58,34 @@ namespace Neo.Json
         public JNumber(double value = 0)
         {
             if (!double.IsFinite(value)) throw new FormatException($"value is not finite: {value}");
-            Value = value;
+            _double = value;
+            _integer = null;
+        }
+
+        /// <summary>
+        /// Creates a <see cref="JNumber"/> from an exact integer.
+        /// Values inside the safe integer range are stored as <see cref="double"/> for compatibility;
+        /// larger magnitudes keep a <see cref="BigInteger"/> so JSON write does not lose precision.
+        /// Prefer implicit conversion from <see cref="BigInteger"/> in assignment contexts.
+        /// </summary>
+        /// <param name="value">The integer value of the JSON token.</param>
+        public static JNumber FromBigInteger(BigInteger value)
+        {
+            if (value >= MIN_SAFE_INTEGER && value <= MAX_SAFE_INTEGER)
+                return new JNumber((double)value);
+            return new JNumber(value, exact: true);
+        }
+
+        /// <summary>
+        /// Private constructor for exact integers outside the double-only path.
+        /// Not public: a public <see cref="BigInteger"/> constructor would make
+        /// <c>new JNumber(1)</c> ambiguous with <see cref="JNumber(double)"/>.
+        /// </summary>
+        private JNumber(BigInteger value, bool exact)
+        {
+            _ = exact;
+            _double = 0; // unused when _integer is set
+            _integer = value;
         }
 
         /// <summary>
@@ -50,7 +94,8 @@ namespace Neo.Json
         /// <returns><see langword="true"/> if value is not zero; otherwise, <see langword="false"/>.</returns>
         public override bool AsBoolean()
         {
-            return Value != 0;
+            if (_integer is BigInteger bi) return !bi.IsZero;
+            return _double != 0;
         }
 
         public override double AsNumber()
@@ -60,10 +105,56 @@ namespace Neo.Json
 
         public override string AsString()
         {
-            return Value.ToString(CultureInfo.InvariantCulture);
+            if (_integer is BigInteger bi)
+                return bi.ToString(CultureInfo.InvariantCulture);
+            return _double.ToString(CultureInfo.InvariantCulture);
         }
 
         public override double GetNumber() => Value;
+
+        /// <summary>
+        /// Tries to get the exact integer value of this token.
+        /// </summary>
+        /// <param name="value">When successful, the integer value.</param>
+        /// <returns><see langword="true"/> if the number is an integer (fractional part is zero); otherwise <see langword="false"/>.</returns>
+        public bool TryGetBigInteger(out BigInteger value)
+        {
+            if (_integer is BigInteger bi)
+            {
+                value = bi;
+                return true;
+            }
+
+            if (_double % 1 != 0)
+            {
+                value = default;
+                return false;
+            }
+
+            // Integral double: convert via decimal/string only when outside long for safety.
+            // For values within long range, cast is exact for IEEE safe integers and common whole doubles.
+            try
+            {
+                value = (BigInteger)_double;
+                return true;
+            }
+            catch (OverflowException)
+            {
+                value = default;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Gets the exact integer value of this token.
+        /// </summary>
+        /// <returns>The integer value.</returns>
+        /// <exception cref="InvalidCastException">The number is not an integer.</exception>
+        public BigInteger GetBigInteger()
+        {
+            if (TryGetBigInteger(out var value)) return value;
+            throw new InvalidCastException("The JSON number is not an integer.");
+        }
 
         public override string ToString()
         {
@@ -107,7 +198,15 @@ namespace Neo.Json
 
         internal override void Write(Utf8JsonWriter writer)
         {
-            writer.WriteNumberValue(Value);
+            if (_integer is BigInteger bi)
+            {
+                // Write exact integer digits (valid JSON number token) without double conversion.
+                writer.WriteRawValue(bi.ToString(CultureInfo.InvariantCulture), skipInputValidation: true);
+            }
+            else
+            {
+                writer.WriteNumberValue(_double);
+            }
         }
 
         public override JToken Clone()
@@ -122,13 +221,21 @@ namespace Neo.Json
 
         public static implicit operator JNumber(long value)
         {
-            return new JNumber(value);
+            // Preserve exact integers outside the IEEE-754 safe range.
+            if (value > MAX_SAFE_INTEGER || value < MIN_SAFE_INTEGER)
+                return FromBigInteger(value);
+            return new JNumber((double)value);
+        }
+
+        public static implicit operator JNumber(BigInteger value)
+        {
+            return FromBigInteger(value);
         }
 
         public static bool operator ==(JNumber left, JNumber? right)
         {
             if (right is null) return false;
-            return ReferenceEquals(left, right) || left.Value.Equals(right.Value);
+            return ReferenceEquals(left, right) || left.Equals(right);
         }
 
         public static bool operator !=(JNumber left, JNumber right)
@@ -141,28 +248,69 @@ namespace Neo.Json
             if (obj is null) return false;
             if (ReferenceEquals(this, obj)) return true;
 
-            var other = obj switch
+            return obj switch
             {
-                JNumber jNumber => jNumber,
-                uint u => new JNumber(u),
-                int i => new JNumber(i),
-                ulong ul => new JNumber(ul),
-                long l => new JNumber(l),
-                byte b => new JNumber(b),
-                sbyte sb => new JNumber(sb),
-                short s => new JNumber(s),
-                ushort us => new JNumber(us),
-                decimal d => new JNumber((double)d),
-                float f => new JNumber(f),
-                double d => new JNumber(d),
+                JNumber jNumber => Equals(jNumber),
+                BigInteger bi => EqualsBigInteger(bi),
+                uint u => EqualsNumber(u),
+                int i => EqualsNumber(i),
+                ulong ul => EqualsBigInteger(ul),
+                long l => EqualsBigInteger(l),
+                byte b => EqualsNumber(b),
+                sbyte sb => EqualsNumber(sb),
+                short s => EqualsNumber(s),
+                ushort us => EqualsNumber(us),
+                decimal d => EqualsNumber((double)d),
+                float f => EqualsNumber(f),
+                double d => EqualsNumber(d),
                 _ => throw new ArgumentOutOfRangeException(nameof(obj), obj, null)
             };
-            return other == this;
+        }
+
+        private bool Equals(JNumber other)
+        {
+            if (_integer is BigInteger leftBi)
+            {
+                if (other._integer is BigInteger rightBi)
+                    return leftBi == rightBi;
+                return other.TryGetBigInteger(out var otherBi) && leftBi == otherBi;
+            }
+
+            if (other._integer is BigInteger otherOnly)
+            {
+                return TryGetBigInteger(out var thisBi) && thisBi == otherOnly;
+            }
+
+            return _double.Equals(other._double);
+        }
+
+        private bool EqualsBigInteger(BigInteger value)
+        {
+            if (_integer is BigInteger bi) return bi == value;
+            if (_double % 1 != 0) return false;
+            if (value >= MIN_SAFE_INTEGER && value <= MAX_SAFE_INTEGER)
+                return _double.Equals((double)value);
+            // double cannot represent all integers outside the safe range.
+            return TryGetBigInteger(out var thisBi) && thisBi == value;
+        }
+
+        private bool EqualsNumber(double value)
+        {
+            if (_integer is BigInteger bi)
+            {
+                if (value % 1 != 0) return false;
+                if (value > MAX_SAFE_INTEGER || value < MIN_SAFE_INTEGER)
+                    return false; // cannot trust double equality outside safe range
+                return bi == (long)value;
+            }
+            return _double.Equals(value);
         }
 
         public override int GetHashCode()
         {
-            return Value.GetHashCode();
+            if (_integer is BigInteger bi)
+                return bi.GetHashCode();
+            return _double.GetHashCode();
         }
     }
 }

--- a/src/Neo.Json/JNumber.cs
+++ b/src/Neo.Json/JNumber.cs
@@ -47,9 +47,10 @@ namespace Neo.Json
         public double Value => _integer is BigInteger bi ? (double)bi : _double;
 
         /// <summary>
-        /// Gets whether this number is stored as an exact integer representation.
+        /// Gets whether this number uses the exact <see cref="BigInteger"/> storage path
+        /// (values outside the IEEE-754 safe integer range). Safe-range integers remain double-backed.
         /// </summary>
-        public bool IsExactInteger => _integer.HasValue || (_double % 1 == 0);
+        public bool HasExactBigInteger => _integer.HasValue;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="JNumber"/> class with the specified value.
@@ -113,11 +114,12 @@ namespace Neo.Json
         public override double GetNumber() => Value;
 
         /// <summary>
-        /// Tries to get the exact integer value of this token.
+        /// Tries to get the value when this token uses exact <see cref="BigInteger"/> storage
+        /// (the new path for integers outside the safe range). Does not convert double-backed numbers.
         /// </summary>
-        /// <param name="value">When successful, the integer value.</param>
-        /// <returns><see langword="true"/> if the number is an integer (fractional part is zero); otherwise <see langword="false"/>.</returns>
-        public bool TryGetBigInteger(out BigInteger value)
+        /// <param name="value">When successful, the exact integer.</param>
+        /// <returns><see langword="true"/> if stored as exact <see cref="BigInteger"/>; otherwise <see langword="false"/>.</returns>
+        public bool TryGetExactBigInteger(out BigInteger value)
         {
             if (_integer is BigInteger bi)
             {
@@ -125,14 +127,26 @@ namespace Neo.Json
                 return true;
             }
 
+            value = default;
+            return false;
+        }
+
+        /// <summary>
+        /// Tries to get an integer value from this token (exact storage or integral double).
+        /// </summary>
+        /// <param name="value">When successful, the integer value.</param>
+        /// <returns><see langword="true"/> if the number is an integer; otherwise <see langword="false"/>.</returns>
+        public bool TryGetBigInteger(out BigInteger value)
+        {
+            if (TryGetExactBigInteger(out value))
+                return true;
+
             if (_double % 1 != 0)
             {
                 value = default;
                 return false;
             }
 
-            // Integral double: convert via decimal/string only when outside long for safety.
-            // For values within long range, cast is exact for IEEE safe integers and common whole doubles.
             try
             {
                 value = (BigInteger)_double;
@@ -146,7 +160,7 @@ namespace Neo.Json
         }
 
         /// <summary>
-        /// Gets the exact integer value of this token.
+        /// Gets the integer value of this token.
         /// </summary>
         /// <returns>The integer value.</returns>
         /// <exception cref="InvalidCastException">The number is not an integer.</exception>
@@ -221,10 +235,9 @@ namespace Neo.Json
 
         public static implicit operator JNumber(long value)
         {
-            // Preserve exact integers outside the IEEE-754 safe range.
-            if (value > MAX_SAFE_INTEGER || value < MIN_SAFE_INTEGER)
-                return FromBigInteger(value);
-            return new JNumber((double)value);
+            // Unchanged historical path: long → double (safe for consensus / existing callers).
+            // Use <see cref="FromBigInteger"/> or BigInteger implicit for exact large integers.
+            return new JNumber(value);
         }
 
         public static implicit operator JNumber(BigInteger value)

--- a/src/Neo.Json/JNumber.cs
+++ b/src/Neo.Json/JNumber.cs
@@ -31,6 +31,24 @@ namespace Neo.Json
         public static readonly long MIN_SAFE_INTEGER = -MAX_SAFE_INTEGER;
 
         /// <summary>
+        /// Maximum two's-complement size of an exact JSON integer, matching NeoVM 32-byte integers.
+        /// </summary>
+        public const int MaxIntegerSize = 32;
+
+        /// <summary>
+        /// Largest exact integer that fits in <see cref="MaxIntegerSize"/> bytes (2^255 − 1).
+        /// </summary>
+        public static readonly BigInteger MaxInteger = (BigInteger.One << (MaxIntegerSize * 8 - 1)) - 1;
+
+        /// <summary>
+        /// Smallest exact integer that fits in <see cref="MaxIntegerSize"/> bytes (−2^255).
+        /// </summary>
+        public static readonly BigInteger MinInteger = -MaxInteger - 1;
+
+        internal static bool FitsMaxIntegerSize(BigInteger value) =>
+            value.GetByteCount() <= MaxIntegerSize;
+
+        /// <summary>
         /// When non-null, the exact integer value. Used for integers outside the IEEE-754
         /// safe integer range (or constructed from <see cref="BigInteger"/> outside that range)
         /// so they round-trip without precision loss.

--- a/src/Neo.Json/JToken.cs
+++ b/src/Neo.Json/JToken.cs
@@ -130,8 +130,15 @@ namespace Neo.Json
         /// </summary>
         /// <param name="value">The byte array that contains the JSON token.</param>
         /// <param name="max_nest">The maximum nesting depth when parsing the JSON token.</param>
+        /// <param name="exactIntegers">
+        /// When <see langword="true"/>, integer JSON numbers (including values outside the IEEE-754
+        /// safe range and integer-valued scientific notation) are stored exactly via
+        /// <see cref="BigInteger"/>. When <see langword="false"/> (default), numbers use
+        /// <see cref="double"/> only — the historical behavior required for consensus before
+        /// <c>HF_Huyao</c> enables exact integers in <c>StdLib.jsonDeserialize</c>.
+        /// </param>
         /// <returns>The parsed JSON token.</returns>
-        public static JToken? Parse(ReadOnlySpan<byte> value, int max_nest = 64)
+        public static JToken? Parse(ReadOnlySpan<byte> value, int max_nest = 64, bool exactIntegers = false)
         {
             var reader = new Utf8JsonReader(value, new JsonReaderOptions
             {
@@ -141,7 +148,7 @@ namespace Neo.Json
             });
             try
             {
-                var json = Read(ref reader);
+                var json = Read(ref reader, exactIntegers: exactIntegers);
                 if (reader.Read()) throw new FormatException("Read json token failed");
                 return json;
             }
@@ -156,22 +163,23 @@ namespace Neo.Json
         /// </summary>
         /// <param name="value">The <see cref="string"/> that contains the JSON token.</param>
         /// <param name="max_nest">The maximum nesting depth when parsing the JSON token.</param>
+        /// <param name="exactIntegers">See <see cref="Parse(ReadOnlySpan{byte}, int, bool)"/>.</param>
         /// <returns>The parsed JSON token.</returns>
-        public static JToken? Parse(string value, int max_nest = 64)
+        public static JToken? Parse(string value, int max_nest = 64, bool exactIntegers = false)
         {
-            return Parse(StrictUTF8.GetBytes(value), max_nest);
+            return Parse(StrictUTF8.GetBytes(value), max_nest, exactIntegers);
         }
 
-        private static JToken? Read(ref Utf8JsonReader reader, bool skipReading = false)
+        private static JToken? Read(ref Utf8JsonReader reader, bool skipReading = false, bool exactIntegers = false)
         {
             if (!skipReading && !reader.Read()) throw new FormatException("Read json token failed");
             return reader.TokenType switch
             {
                 JsonTokenType.False => false,
                 JsonTokenType.Null => Null,
-                JsonTokenType.Number => ReadNumber(ref reader),
-                JsonTokenType.StartArray => ReadArray(ref reader),
-                JsonTokenType.StartObject => ReadObject(ref reader),
+                JsonTokenType.Number => ReadNumber(ref reader, exactIntegers),
+                JsonTokenType.StartArray => ReadArray(ref reader, exactIntegers),
+                JsonTokenType.StartObject => ReadObject(ref reader, exactIntegers),
                 JsonTokenType.String => ReadString(ref reader),
                 JsonTokenType.True => true,
                 _ => throw new FormatException($"Unexpected token {reader.TokenType}"),
@@ -185,8 +193,12 @@ namespace Neo.Json
         /// </summary>
         private const int MaxExactIntegerDigits = 100;
 
-        private static JNumber ReadNumber(ref Utf8JsonReader reader)
+        private static JNumber ReadNumber(ref Utf8JsonReader reader, bool exactIntegers)
         {
+            // Legacy / pre-HF_Huyao: always double (consensus-compatible with historical nodes).
+            if (!exactIntegers)
+                return new JNumber(reader.GetDouble());
+
             // Prefer exact integer tokens so large values (e.g. token amounts) keep full precision.
             if (reader.TryGetInt64(out var int64))
             {
@@ -281,7 +293,7 @@ namespace Neo.Json
             return StrictUTF8.GetString(buffer);
         }
 
-        private static JArray ReadArray(ref Utf8JsonReader reader)
+        private static JArray ReadArray(ref Utf8JsonReader reader, bool exactIntegers)
         {
             var array = new JArray();
             while (reader.Read())
@@ -291,14 +303,14 @@ namespace Neo.Json
                     case JsonTokenType.EndArray:
                         return array;
                     default:
-                        array.Add(Read(ref reader, skipReading: true));
+                        array.Add(Read(ref reader, skipReading: true, exactIntegers: exactIntegers));
                         break;
                 }
             }
             throw new FormatException("Unterminated array");
         }
 
-        private static JObject ReadObject(ref Utf8JsonReader reader)
+        private static JObject ReadObject(ref Utf8JsonReader reader, bool exactIntegers)
         {
             JObject obj = new();
             while (reader.Read())
@@ -312,7 +324,7 @@ namespace Neo.Json
                         if (obj.Properties.ContainsKey(name))
                             throw new FormatException($"Duplicate property name: {name}");
 
-                        var value = Read(ref reader);
+                        var value = Read(ref reader, exactIntegers: exactIntegers);
                         obj.Properties.Add(name, value);
                         break;
                     default:

--- a/src/Neo.Json/JToken.cs
+++ b/src/Neo.Json/JToken.cs
@@ -186,13 +186,6 @@ namespace Neo.Json
             };
         }
 
-        /// <summary>
-        /// Maximum decimal digits accepted for exact integer JSON numbers.
-        /// Larger values fall back to double (and fail if non-finite), matching prior
-        /// rejection of pathological inputs while covering Neo 32-byte integers (~78 digits).
-        /// </summary>
-        private const int MaxExactIntegerDigits = 100;
-
         private static JNumber ReadNumber(ref Utf8JsonReader reader, bool exactIntegers)
         {
             // Legacy / pre-HF_Huyao: always double (consensus-compatible with historical nodes).
@@ -212,7 +205,7 @@ namespace Neo.Json
 
             if (raw.Contains('e') || raw.Contains('E'))
             {
-                if (TryParseScientificInteger(raw, out var sci) && CountDigits(sci) <= MaxExactIntegerDigits)
+                if (TryParseScientificInteger(raw, out var sci) && JNumber.FitsMaxIntegerSize(sci))
                     return JNumber.FromBigInteger(sci);
                 return new JNumber(reader.GetDouble());
             }
@@ -220,13 +213,13 @@ namespace Neo.Json
             if (raw.Contains('.'))
                 return new JNumber(reader.GetDouble());
 
-            // Pure integer longer than Int64.
-            var digitCount = raw[0] == '-' ? raw.Length - 1 : raw.Length;
-            if (digitCount > MaxExactIntegerDigits)
-                throw new FormatException($"JSON integer has too many digits ({digitCount}).");
-
+            // Pure integer longer than Int64: cap at NeoVM 32-byte integer size.
             if (BigInteger.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var big))
+            {
+                if (!JNumber.FitsMaxIntegerSize(big))
+                    throw new FormatException($"JSON integer exceeds {JNumber.MaxIntegerSize}-byte limit.");
                 return JNumber.FromBigInteger(big);
+            }
 
             return new JNumber(reader.GetDouble());
         }
@@ -266,14 +259,6 @@ namespace Neo.Json
 
             result = mant * BigInteger.Pow(10, exp);
             return true;
-        }
-
-        private static int CountDigits(BigInteger value)
-        {
-            if (value.IsZero) return 1;
-            value = BigInteger.Abs(value);
-            // 10^d <= value < 10^(d+1) → d+1 digits
-            return (int)Math.Floor(BigInteger.Log10(value)) + 1;
         }
 
         private static string GetRawNumberText(ref Utf8JsonReader reader)

--- a/src/Neo.Json/JToken.cs
+++ b/src/Neo.Json/JToken.cs
@@ -10,6 +10,8 @@
 // modifications are permitted.
 
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Numerics;
 using System.Text.Json;
 using static Neo.Json.Utility;
 
@@ -167,13 +169,116 @@ namespace Neo.Json
             {
                 JsonTokenType.False => false,
                 JsonTokenType.Null => Null,
-                JsonTokenType.Number => reader.GetDouble(),
+                JsonTokenType.Number => ReadNumber(ref reader),
                 JsonTokenType.StartArray => ReadArray(ref reader),
                 JsonTokenType.StartObject => ReadObject(ref reader),
                 JsonTokenType.String => ReadString(ref reader),
                 JsonTokenType.True => true,
                 _ => throw new FormatException($"Unexpected token {reader.TokenType}"),
             };
+        }
+
+        /// <summary>
+        /// Maximum decimal digits accepted for exact integer JSON numbers.
+        /// Larger values fall back to double (and fail if non-finite), matching prior
+        /// rejection of pathological inputs while covering Neo 32-byte integers (~78 digits).
+        /// </summary>
+        private const int MaxExactIntegerDigits = 100;
+
+        private static JNumber ReadNumber(ref Utf8JsonReader reader)
+        {
+            // Prefer exact integer tokens so large values (e.g. token amounts) keep full precision.
+            if (reader.TryGetInt64(out var int64))
+            {
+                if (int64 >= JNumber.MIN_SAFE_INTEGER && int64 <= JNumber.MAX_SAFE_INTEGER)
+                    return new JNumber((double)int64);
+                return JNumber.FromBigInteger(int64);
+            }
+
+            // Larger than Int64, or floating / scientific.
+            var raw = GetRawNumberText(ref reader);
+
+            if (raw.Contains('e') || raw.Contains('E'))
+            {
+                if (TryParseScientificInteger(raw, out var sci) && CountDigits(sci) <= MaxExactIntegerDigits)
+                    return JNumber.FromBigInteger(sci);
+                return new JNumber(reader.GetDouble());
+            }
+
+            if (raw.Contains('.'))
+                return new JNumber(reader.GetDouble());
+
+            // Pure integer longer than Int64.
+            var digitCount = raw[0] == '-' ? raw.Length - 1 : raw.Length;
+            if (digitCount > MaxExactIntegerDigits)
+                throw new FormatException($"JSON integer has too many digits ({digitCount}).");
+
+            if (BigInteger.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var big))
+                return JNumber.FromBigInteger(big);
+
+            return new JNumber(reader.GetDouble());
+        }
+
+        /// <summary>
+        /// Parses scientific notation into an exact integer when the value has no fractional part
+        /// (e.g. <c>9.05E+28</c> → 905000…0).
+        /// </summary>
+        private static bool TryParseScientificInteger(string raw, out BigInteger result)
+        {
+            result = default;
+            var eIndex = raw.IndexOfAny(['e', 'E']);
+            if (eIndex <= 0) return false;
+
+            if (!int.TryParse(raw.AsSpan(eIndex + 1), NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture, out var exp))
+                return false;
+            if (exp < 0) return false;
+
+            var mantissa = raw.AsSpan(0, eIndex);
+            var dot = mantissa.IndexOf('.');
+            BigInteger mant;
+            if (dot >= 0)
+            {
+                var scale = mantissa.Length - dot - 1;
+                Span<char> digits = stackalloc char[mantissa.Length - 1];
+                mantissa[..dot].CopyTo(digits);
+                mantissa[(dot + 1)..].CopyTo(digits[dot..]);
+                if (!BigInteger.TryParse(digits, NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture, out mant))
+                    return false;
+                exp -= scale;
+                if (exp < 0) return false;
+            }
+            else if (!BigInteger.TryParse(mantissa, NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture, out mant))
+            {
+                return false;
+            }
+
+            result = mant * BigInteger.Pow(10, exp);
+            return true;
+        }
+
+        private static int CountDigits(BigInteger value)
+        {
+            if (value.IsZero) return 1;
+            value = BigInteger.Abs(value);
+            // 10^d <= value < 10^(d+1) → d+1 digits
+            return (int)Math.Floor(BigInteger.Log10(value)) + 1;
+        }
+
+        private static string GetRawNumberText(ref Utf8JsonReader reader)
+        {
+            if (!reader.HasValueSequence)
+                return StrictUTF8.GetString(reader.ValueSpan);
+
+            // Multi-segment number tokens are rare; reassemble without System.Buffers helpers.
+            var length = checked((int)reader.ValueSequence.Length);
+            var buffer = new byte[length];
+            var offset = 0;
+            foreach (var segment in reader.ValueSequence)
+            {
+                segment.Span.CopyTo(buffer.AsSpan(offset));
+                offset += segment.Length;
+            }
+            return StrictUTF8.GetString(buffer);
         }
 
         private static JArray ReadArray(ref Utf8JsonReader reader)
@@ -300,6 +405,16 @@ namespace Neo.Json
         }
 
         public static implicit operator JToken(double value)
+        {
+            return (JNumber)value;
+        }
+
+        public static implicit operator JToken(long value)
+        {
+            return (JNumber)value;
+        }
+
+        public static implicit operator JToken(BigInteger value)
         {
             return (JNumber)value;
         }

--- a/src/Neo/SmartContract/JsonSerializer.cs
+++ b/src/Neo/SmartContract/JsonSerializer.cs
@@ -193,6 +193,10 @@ namespace Neo.SmartContract
                     }
                 case JNumber num:
                     {
+                        // Prefer exact integer path (BigInteger-backed JNumber for large values).
+                        if (num.TryGetBigInteger(out var exact))
+                            return exact;
+
                         if ((num.Value % 1) != 0) throw new FormatException("Decimal value is not allowed");
                         if (engine.IsHardforkEnabled(Hardfork.HF_Basilisk))
                         {

--- a/src/Neo/SmartContract/JsonSerializer.cs
+++ b/src/Neo/SmartContract/JsonSerializer.cs
@@ -193,8 +193,9 @@ namespace Neo.SmartContract
                     }
                 case JNumber num:
                     {
-                        // Prefer exact integer path (BigInteger-backed JNumber for large values).
-                        if (num.TryGetBigInteger(out var exact))
+                        // HF_Huyao: prefer exact BigInteger-backed integers (no double precision loss).
+                        // Pre-Huyao keeps the historical double-based conversion for consensus.
+                        if (engine.IsHardforkEnabled(Hardfork.HF_Huyao) && num.TryGetBigInteger(out var exact))
                             return exact;
 
                         if ((num.Value % 1) != 0) throw new FormatException("Decimal value is not allowed");

--- a/src/Neo/SmartContract/JsonSerializer.cs
+++ b/src/Neo/SmartContract/JsonSerializer.cs
@@ -193,9 +193,9 @@ namespace Neo.SmartContract
                     }
                 case JNumber num:
                     {
-                        // HF_Huyao: prefer exact BigInteger-backed integers (no double precision loss).
-                        // Pre-Huyao keeps the historical double-based conversion for consensus.
-                        if (engine.IsHardforkEnabled(Hardfork.HF_Huyao) && num.TryGetBigInteger(out var exact))
+                        // HF_Huyao: only the NEW exact BigInteger storage path (outside safe range).
+                        // Double-backed numbers keep the historical Basilisk / cast path unchanged.
+                        if (engine.IsHardforkEnabled(Hardfork.HF_Huyao) && num.TryGetExactBigInteger(out var exact))
                             return exact;
 
                         if ((num.Value % 1) != 0) throw new FormatException("Decimal value is not allowed");

--- a/src/Neo/SmartContract/Native/StdLib.cs
+++ b/src/Neo/SmartContract/Native/StdLib.cs
@@ -52,7 +52,9 @@ namespace Neo.SmartContract.Native
         [ContractMethod(CpuFee = 1 << 14)]
         private static StackItem JsonDeserialize(ApplicationEngine engine, byte[] json)
         {
-            JToken? token = JToken.Parse(json, 10);
+            // HF_Huyao: exact BigInteger for large JSON integers (consensus-breaking vs double).
+            var exactIntegers = engine.IsHardforkEnabled(Hardfork.HF_Huyao);
+            JToken? token = JToken.Parse(json, 10, exactIntegers);
             if (token is null) return StackItem.Null;
             return JsonSerializer.Deserialize(engine, token, engine.Limits);
         }

--- a/tests/Neo.Json.UnitTests/UT_JNumber.cs
+++ b/tests/Neo.Json.UnitTests/UT_JNumber.cs
@@ -131,13 +131,15 @@ namespace Neo.Json.UnitTests
         }
 
         [TestMethod]
-        public void TestBigInteger_OutsideSafeLong_KeepsExactInteger()
+        public void TestBigInteger_OutsideSafeRange_KeepsExactInteger()
         {
-            // Beyond MAX_SAFE_INTEGER (2^53-1) but within Int64.
-            long outsideSafe = JNumber.MAX_SAFE_INTEGER + 2;
-            JNumber fromLong = outsideSafe;
-            Assert.AreEqual(new BigInteger(outsideSafe), fromLong.GetBigInteger());
-            Assert.AreEqual(outsideSafe.ToString(CultureInfo.InvariantCulture), fromLong.ToString());
+            // Beyond MAX_SAFE_INTEGER (2^53-1): exact path only via BigInteger, not long→double.
+            var outsideSafe = new BigInteger(JNumber.MAX_SAFE_INTEGER) + 2;
+            JNumber fromBig = outsideSafe;
+            Assert.IsTrue(fromBig.HasExactBigInteger);
+            Assert.IsTrue(fromBig.TryGetExactBigInteger(out var exact));
+            Assert.AreEqual(outsideSafe, exact);
+            Assert.AreEqual(outsideSafe.ToString(CultureInfo.InvariantCulture), fromBig.ToString());
         }
 
         [TestMethod]

--- a/tests/Neo.Json.UnitTests/UT_JNumber.cs
+++ b/tests/Neo.Json.UnitTests/UT_JNumber.cs
@@ -193,5 +193,48 @@ namespace Neo.Json.UnitTests
             Assert.IsFalse(number.TryGetBigInteger(out _));
             Assert.ThrowsExactly<InvalidCastException>(() => _ = number.GetBigInteger());
         }
+
+        [TestMethod]
+        public void TestBigInteger_AsBooleanAndCloneAndHashCode()
+        {
+            JNumber exactZero = BigInteger.Zero;
+            Assert.IsFalse(exactZero.HasExactBigInteger); // safe-range stored as double
+            JNumber huge = BigInteger.Parse("100000000000000000000000");
+            JNumber hugeCopy = (JNumber)huge.Clone();
+            Assert.IsTrue(huge.AsBoolean());
+            Assert.IsFalse(JNumber.FromBigInteger(0).AsBoolean());
+            Assert.AreEqual(huge.GetBigInteger(), hugeCopy.GetBigInteger());
+            Assert.AreEqual(huge.GetHashCode(), hugeCopy.GetHashCode());
+            Assert.IsTrue(huge == hugeCopy);
+            Assert.IsFalse(huge != hugeCopy);
+            Assert.IsTrue(JNumber.FitsMaxIntegerSize(JNumber.MaxInteger));
+            Assert.IsFalse(JNumber.FitsMaxIntegerSize(JNumber.MaxInteger + 1));
+        }
+
+        [TestMethod]
+        public void TestBigInteger_EqualsExactVersusIntegralDouble()
+        {
+            var exact = JNumber.FromBigInteger(new BigInteger(JNumber.MAX_SAFE_INTEGER) + 2);
+            Assert.IsTrue(exact.Equals(exact.GetBigInteger()));
+            Assert.IsFalse(exact.Equals(1.5d));
+            Assert.IsFalse(new JNumber(1.5).Equals(new BigInteger(1)));
+            Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => _ = new JNumber(1).Equals("1"));
+        }
+
+        [TestMethod]
+        public void TestParse_ExactIntegers_NestedArrayAndObject()
+        {
+            var json = """{"a":[9007199254740993],"b":{"c":1e3}}""";
+            var parsed = (JObject)JToken.Parse(json, exactIntegers: true)!;
+            Assert.AreEqual(BigInteger.Parse("9007199254740993"), ((JNumber)((JArray)parsed["a"]!)[0]!).GetBigInteger());
+            Assert.AreEqual(1000, ((JNumber)((JObject)parsed["b"]!)["c"]!).GetBigInteger());
+        }
+
+        [TestMethod]
+        public void TestParse_ScientificInteger_FitsMaxSize()
+        {
+            var parsed = (JNumber)JToken.Parse("1e10", exactIntegers: true)!;
+            Assert.AreEqual(new BigInteger(10_000_000_000), parsed.GetBigInteger());
+        }
     }
 }

--- a/tests/Neo.Json.UnitTests/UT_JNumber.cs
+++ b/tests/Neo.Json.UnitTests/UT_JNumber.cs
@@ -9,6 +9,7 @@
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
+using System.Globalization;
 using System.Numerics;
 
 namespace Neo.Json.UnitTests
@@ -94,7 +95,67 @@ namespace Neo.Json.UnitTests
             Assert.IsFalse(jnum.Equals(null));
             var x = jnum;
             Assert.IsTrue(jnum.Equals(x));
-            Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => _ = jnum.Equals(new BigInteger(1)));
+            Assert.IsTrue(jnum.Equals(new BigInteger(1)));
+            Assert.IsFalse(jnum.Equals(new BigInteger(2)));
+        }
+
+        [TestMethod]
+        public void TestBigInteger_ImplicitConversion_AndExactWrite()
+        {
+            BigInteger huge = BigInteger.Parse("100000000000000000000000");
+            JNumber number = huge;
+            JToken token = huge;
+
+            Assert.IsInstanceOfType<JNumber>(token);
+            Assert.AreEqual(huge, number.GetBigInteger());
+            Assert.IsTrue(number.TryGetBigInteger(out var bi));
+            Assert.AreEqual(huge, bi);
+
+            // Exact JSON number literal (not a string, not scientific notation with loss).
+            Assert.AreEqual("100000000000000000000000", number.ToString());
+            Assert.AreEqual("100000000000000000000000", token.ToString());
+
+            var obj = new JObject { ["Value"] = huge };
+            Assert.AreEqual("""{"Value":100000000000000000000000}""", obj.ToString());
+        }
+
+        [TestMethod]
+        public void TestBigInteger_SafeRange_StoredAsDouble()
+        {
+            BigInteger safe = 42;
+            var number = JNumber.FromBigInteger(safe);
+            Assert.AreEqual(42d, number.Value);
+            Assert.AreEqual("42", number.ToString());
+            Assert.IsTrue(number.Equals(42));
+            Assert.IsTrue(number.Equals(new BigInteger(42)));
+        }
+
+        [TestMethod]
+        public void TestBigInteger_OutsideSafeLong_KeepsExactInteger()
+        {
+            // Beyond MAX_SAFE_INTEGER (2^53-1) but within Int64.
+            long outsideSafe = JNumber.MAX_SAFE_INTEGER + 2;
+            JNumber fromLong = outsideSafe;
+            Assert.AreEqual(new BigInteger(outsideSafe), fromLong.GetBigInteger());
+            Assert.AreEqual(outsideSafe.ToString(CultureInfo.InvariantCulture), fromLong.ToString());
+        }
+
+        [TestMethod]
+        public void TestBigInteger_ParseRoundTrip()
+        {
+            const string json = """{"Value":100000000000000000000000}""";
+            var parsed = (JObject)JToken.Parse(json)!;
+            var number = (JNumber)parsed["Value"]!;
+            Assert.AreEqual(BigInteger.Parse("100000000000000000000000"), number.GetBigInteger());
+            Assert.AreEqual(json, parsed.ToString());
+        }
+
+        [TestMethod]
+        public void TestBigInteger_FractionalDouble_NotInteger()
+        {
+            var number = new JNumber(1.5);
+            Assert.IsFalse(number.TryGetBigInteger(out _));
+            Assert.ThrowsExactly<InvalidCastException>(() => _ = number.GetBigInteger());
         }
     }
 }

--- a/tests/Neo.Json.UnitTests/UT_JNumber.cs
+++ b/tests/Neo.Json.UnitTests/UT_JNumber.cs
@@ -141,13 +141,24 @@ namespace Neo.Json.UnitTests
         }
 
         [TestMethod]
-        public void TestBigInteger_ParseRoundTrip()
+        public void TestBigInteger_ParseRoundTrip_ExactIntegers()
         {
             const string json = """{"Value":100000000000000000000000}""";
-            var parsed = (JObject)JToken.Parse(json)!;
+            var parsed = (JObject)JToken.Parse(json, exactIntegers: true)!;
             var number = (JNumber)parsed["Value"]!;
             Assert.AreEqual(BigInteger.Parse("100000000000000000000000"), number.GetBigInteger());
             Assert.AreEqual(json, parsed.ToString());
+        }
+
+        [TestMethod]
+        public void TestBigInteger_Parse_DefaultIsDouble_NotExact()
+        {
+            // Default parse keeps historical double semantics (consensus-safe pre-HF_Huyao).
+            const string json = """{"Value":100000000000000000000000}""";
+            var parsed = (JObject)JToken.Parse(json)!;
+            var number = (JNumber)parsed["Value"]!;
+            // Double cannot represent this integer exactly; GetBigInteger reflects the rounded value.
+            Assert.AreNotEqual(BigInteger.Parse("100000000000000000000000"), number.GetBigInteger());
         }
 
         [TestMethod]

--- a/tests/Neo.Json.UnitTests/UT_JNumber.cs
+++ b/tests/Neo.Json.UnitTests/UT_JNumber.cs
@@ -153,6 +153,29 @@ namespace Neo.Json.UnitTests
         }
 
         [TestMethod]
+        public void TestBigInteger_Parse_Max32ByteInteger()
+        {
+            var max = JNumber.MaxInteger;
+            var json = max.ToString(CultureInfo.InvariantCulture);
+            var parsed = (JNumber)JToken.Parse(json, exactIntegers: true)!;
+            Assert.AreEqual(max, parsed.GetBigInteger());
+            Assert.AreEqual(JNumber.MaxIntegerSize, max.GetByteCount());
+
+            var min = JNumber.MinInteger;
+            parsed = (JNumber)JToken.Parse(min.ToString(CultureInfo.InvariantCulture), exactIntegers: true)!;
+            Assert.AreEqual(min, parsed.GetBigInteger());
+        }
+
+        [TestMethod]
+        public void TestBigInteger_Parse_Over32ByteInteger_Throws()
+        {
+            var tooBig = JNumber.MaxInteger + 1;
+            Assert.AreEqual(JNumber.MaxIntegerSize + 1, tooBig.GetByteCount());
+            Assert.ThrowsExactly<FormatException>(() =>
+                JToken.Parse(tooBig.ToString(CultureInfo.InvariantCulture), exactIntegers: true));
+        }
+
+        [TestMethod]
         public void TestBigInteger_Parse_DefaultIsDouble_NotExact()
         {
             // Default parse keeps historical double semantics (consensus-safe pre-HF_Huyao).

--- a/tests/Neo.UnitTests/SmartContract/Native/UT_StdLib.cs
+++ b/tests/Neo.UnitTests/SmartContract/Native/UT_StdLib.cs
@@ -17,7 +17,9 @@ using Neo.VM;
 using Neo.VM.Types;
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Globalization;
+using System.Linq;
 using System.Numerics;
 using Array = System.Array;
 
@@ -348,15 +350,19 @@ namespace Neo.UnitTests.SmartContract.Native
                 Assert.AreEqual(VMState.HALT, engine.Execute());
                 Assert.HasCount(10, engine.ResultStack);
 
+                // Results are LIFO (last EmitDynamicCall is popped first after null/123/1e3).
+                // Under HF_Huyao (Default), exact integer JSON parsing is enabled.
                 engine.ResultStack.Pop<Null>();
                 Assert.IsTrue(engine.ResultStack.Pop().GetInteger() == 123);
                 Assert.IsTrue(engine.ResultStack.Pop().GetInteger() == 1000);
-                Assert.AreEqual("9007199254740992", engine.ResultStack.Pop().GetInteger().ToString("R"));
+                // "9007199254740993" — pure int beyond 2^53 keeps full precision (was …992 via double).
+                Assert.AreEqual("9007199254740993", engine.ResultStack.Pop().GetInteger().ToString("R"));
                 Assert.AreEqual("43893649166666670000000000000000000", engine.ResultStack.Pop().GetInteger().ToString("R"));
                 Assert.AreEqual("2221811666666666600000", engine.ResultStack.Pop().GetInteger().ToString("R"));
                 Assert.AreEqual("11039175000000000000", engine.ResultStack.Pop().GetInteger().ToString("R"));
                 Assert.AreEqual("90719925474099300000000000000000000", engine.ResultStack.Pop().GetInteger().ToString("R"));
-                Assert.AreEqual("90071992547409940000000000000000000", engine.ResultStack.Pop().GetInteger().ToString("R"));
+                // "9.007199254740993e+34" — exact scientific integer (was …994… via double rounding).
+                Assert.AreEqual("90071992547409930000000000000000000", engine.ResultStack.Pop().GetInteger().ToString("R"));
                 Assert.AreEqual("90071992547409930000000000000000000000000000000000", engine.ResultStack.Pop().GetInteger().ToString("R"));
             }
 
@@ -398,6 +404,33 @@ namespace Neo.UnitTests.SmartContract.Native
                 Assert.AreEqual(VMState.FAULT, engine.Execute());
                 Assert.IsEmpty(engine.ResultStack);
             }
+        }
+
+        [TestMethod]
+        public void Json_Deserialize_PreHuyao_UsesDoublePrecision()
+        {
+            // Pre-HF_Huyao: large integers / borderline scientific tokens go through double
+            // and may lose precision (historical #4719 compatibility behavior).
+            var snapshotCache = TestBlockchain.GetTestSnapshotCache();
+            var preHuyao = TestProtocolSettings.Default with
+            {
+                Hardforks = Enum.GetValues<Hardfork>()
+                    .Where(hf => hf < Hardfork.HF_Huyao)
+                    .ToDictionary(hf => hf, _ => 0u)
+                    .ToImmutableDictionary()
+            };
+
+            using var script = new ScriptBuilder();
+            script.EmitDynamicCall(NativeContract.StdLib.Hash, "jsonDeserialize", "9.007199254740993e+34");
+            script.EmitDynamicCall(NativeContract.StdLib.Hash, "jsonDeserialize", "9007199254740993");
+
+            using var engine = ApplicationEngine.Create(TriggerType.Application, null, snapshotCache, settings: preHuyao);
+            Assert.IsFalse(engine.IsHardforkEnabled(Hardfork.HF_Huyao));
+            engine.LoadScript(script.ToArray());
+
+            Assert.AreEqual(VMState.HALT, engine.Execute());
+            Assert.AreEqual("9007199254740992", engine.ResultStack.Pop().GetInteger().ToString("R"));
+            Assert.AreEqual("90071992547409940000000000000000000", engine.ResultStack.Pop().GetInteger().ToString("R"));
         }
 
         [TestMethod]

--- a/tests/Neo.UnitTests/SmartContract/UT_JsonSerializer.cs
+++ b/tests/Neo.UnitTests/SmartContract/UT_JsonSerializer.cs
@@ -271,38 +271,37 @@ namespace Neo.UnitTests.SmartContract
         }
 
         [TestMethod]
-        public void Deserialize_UnsafeInteger_PreHuyao_LosesPrecision()
+        public void Deserialize_ExactBigInteger_OnlyUnderHuyao()
         {
+            const long unsafeInt = 9007199254740993L; // 2^53+1 — not exact as double
+            var exactJson = JToken.Parse($"[{unsafeInt}]", exactIntegers: true)!;
+            Assert.IsTrue(((JNumber)((JArray)exactJson)[0]!).HasExactBigInteger);
+
+            // Pre-Huyao: exact storage is ignored; historical double/Basilisk path applies.
             var snapshot = _snapshotCache.CloneCache();
-            // All hardforks through Gorgon at 0; HF_Huyao omitted → disabled.
-            var settings = ProtocolSettings.Default with
+            var preSettings = ProtocolSettings.Default with
             {
                 Hardforks = Enum.GetValues<Hardfork>()
                     .Where(hf => hf < Hardfork.HF_Huyao)
                     .ToDictionary(hf => hf, _ => 0u)
                     .ToImmutableDictionary()
             };
-            var engine = ApplicationEngine.Create(TriggerType.Application, null, snapshot, null, settings);
-            Assert.IsFalse(engine.IsHardforkEnabled(Hardfork.HF_Huyao));
+            var preEngine = ApplicationEngine.Create(TriggerType.Application, null, snapshot, null, preSettings);
+            Assert.IsFalse(preEngine.IsHardforkEnabled(Hardfork.HF_Huyao));
+            var preItems = (Array)JsonSerializer.Deserialize(preEngine, exactJson, ExecutionEngineLimits.Default);
+            Assert.AreNotEqual(new BigInteger(unsafeInt), preItems[0].GetInteger());
 
-            // 2^53+1 cannot be represented exactly as double; pre-Huyao uses double path.
-            const long unsafeInt = 9007199254740993L;
-            var json = JToken.Parse($"[{unsafeInt}]", exactIntegers: true)!;
-            var items = (Array)JsonSerializer.Deserialize(engine, json, ExecutionEngineLimits.Default);
-            Assert.AreNotEqual(new BigInteger(unsafeInt), items[0].GetInteger());
-        }
+            // Post-Huyao: only exact-storage numbers take the new path.
+            var postEngine = ApplicationEngine.Create(TriggerType.Application, null, snapshot, null, ProtocolSettings.Default);
+            Assert.IsTrue(postEngine.IsHardforkEnabled(Hardfork.HF_Huyao));
+            var postItems = (Array)JsonSerializer.Deserialize(postEngine, exactJson, ExecutionEngineLimits.Default);
+            Assert.AreEqual(new BigInteger(unsafeInt), postItems[0].GetInteger());
 
-        [TestMethod]
-        public void Deserialize_UnsafeInteger_PostHuyao_IsExact()
-        {
-            var snapshot = _snapshotCache.CloneCache();
-            var engine = ApplicationEngine.Create(TriggerType.Application, null, snapshot, null, ProtocolSettings.Default);
-            Assert.IsTrue(engine.IsHardforkEnabled(Hardfork.HF_Huyao));
-
-            const long unsafeInt = 9007199254740993L;
-            var json = JToken.Parse($"[{unsafeInt}]", exactIntegers: true)!;
-            var items = (Array)JsonSerializer.Deserialize(engine, json, ExecutionEngineLimits.Default);
-            Assert.AreEqual(new BigInteger(unsafeInt), items[0].GetInteger());
+            // Double-backed numbers still use the historical path even after Huyao.
+            var doubleJson = JToken.Parse("[42]")!; // exactIntegers: false (default)
+            Assert.IsFalse(((JNumber)((JArray)doubleJson)[0]!).HasExactBigInteger);
+            var doubleItems = (Array)JsonSerializer.Deserialize(postEngine, doubleJson, ExecutionEngineLimits.Default);
+            Assert.AreEqual(42, doubleItems[0].GetInteger());
         }
 
         [TestMethod]

--- a/tests/Neo.UnitTests/SmartContract/UT_JsonSerializer.cs
+++ b/tests/Neo.UnitTests/SmartContract/UT_JsonSerializer.cs
@@ -16,6 +16,7 @@ using Neo.SmartContract;
 using Neo.VM;
 using Neo.VM.Types;
 using System;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Numerics;
 using Array = Neo.VM.Types.Array;
@@ -94,7 +95,11 @@ namespace Neo.UnitTests.SmartContract
             json = "[200.500000E+005,200.500000e+5,-1.1234e-100,9.05E+28,1e3,10e3,1000e-3]";
             parsed = JObject.Parse(json);
 
-            // Integer-valued scientific tokens keep exact BigInteger form (no double precision loss).
+            // Default parse: double semantics (pre-HF_Huyao / exactIntegers: false).
+            Assert.AreEqual("[20050000,20050000,-1.1234E-100,9.05E+28,1000,10000,1]", parsed.ToString());
+
+            // exactIntegers: integer-valued scientific tokens keep full precision.
+            parsed = JToken.Parse(json, exactIntegers: true);
             Assert.AreEqual("[20050000,20050000,-1.1234E-100,90500000000000000000000000000,1000,10000,1]", parsed.ToString());
 
             json = "[-]";
@@ -250,7 +255,8 @@ namespace Neo.UnitTests.SmartContract
         {
             var snapshot = _snapshotCache.CloneCache();
             ApplicationEngine engine = ApplicationEngine.Create(TriggerType.Application, null, snapshot, null, ProtocolSettings.Default);
-            var items = JsonSerializer.Deserialize(engine, JObject.Parse("[true,\"test\",123,9.05E+28]"), ExecutionEngineLimits.Default);
+            // exactIntegers + HF_Huyao (enabled in Default via EnsureOmmitedHardforks at height 0)
+            var items = JsonSerializer.Deserialize(engine, JToken.Parse("[true,\"test\",123,9.05E+28]", exactIntegers: true), ExecutionEngineLimits.Default);
 
             Assert.IsInstanceOfType(items, typeof(Array));
             Assert.HasCount(4, (Array)items);
@@ -262,6 +268,41 @@ namespace Neo.UnitTests.SmartContract
             Assert.AreEqual(123, array[2].GetInteger());
             // Exact integer from scientific notation (9.05E+28), not the imprecise double cast.
             Assert.AreEqual(BigInteger.Parse("90500000000000000000000000000"), array[3].GetInteger());
+        }
+
+        [TestMethod]
+        public void Deserialize_UnsafeInteger_PreHuyao_LosesPrecision()
+        {
+            var snapshot = _snapshotCache.CloneCache();
+            // All hardforks through Gorgon at 0; HF_Huyao omitted → disabled.
+            var settings = ProtocolSettings.Default with
+            {
+                Hardforks = Enum.GetValues<Hardfork>()
+                    .Where(hf => hf < Hardfork.HF_Huyao)
+                    .ToDictionary(hf => hf, _ => 0u)
+                    .ToImmutableDictionary()
+            };
+            var engine = ApplicationEngine.Create(TriggerType.Application, null, snapshot, null, settings);
+            Assert.IsFalse(engine.IsHardforkEnabled(Hardfork.HF_Huyao));
+
+            // 2^53+1 cannot be represented exactly as double; pre-Huyao uses double path.
+            const long unsafeInt = 9007199254740993L;
+            var json = JToken.Parse($"[{unsafeInt}]", exactIntegers: true)!;
+            var items = (Array)JsonSerializer.Deserialize(engine, json, ExecutionEngineLimits.Default);
+            Assert.AreNotEqual(new BigInteger(unsafeInt), items[0].GetInteger());
+        }
+
+        [TestMethod]
+        public void Deserialize_UnsafeInteger_PostHuyao_IsExact()
+        {
+            var snapshot = _snapshotCache.CloneCache();
+            var engine = ApplicationEngine.Create(TriggerType.Application, null, snapshot, null, ProtocolSettings.Default);
+            Assert.IsTrue(engine.IsHardforkEnabled(Hardfork.HF_Huyao));
+
+            const long unsafeInt = 9007199254740993L;
+            var json = JToken.Parse($"[{unsafeInt}]", exactIntegers: true)!;
+            var items = (Array)JsonSerializer.Deserialize(engine, json, ExecutionEngineLimits.Default);
+            Assert.AreEqual(new BigInteger(unsafeInt), items[0].GetInteger());
         }
 
         [TestMethod]

--- a/tests/Neo.UnitTests/SmartContract/UT_JsonSerializer.cs
+++ b/tests/Neo.UnitTests/SmartContract/UT_JsonSerializer.cs
@@ -94,7 +94,8 @@ namespace Neo.UnitTests.SmartContract
             json = "[200.500000E+005,200.500000e+5,-1.1234e-100,9.05E+28,1e3,10e3,1000e-3]";
             parsed = JObject.Parse(json);
 
-            Assert.AreEqual("[20050000,20050000,-1.1234E-100,9.05E+28,1000,10000,1]", parsed.ToString());
+            // Integer-valued scientific tokens keep exact BigInteger form (no double precision loss).
+            Assert.AreEqual("[20050000,20050000,-1.1234E-100,90500000000000000000000000000,1000,10000,1]", parsed.ToString());
 
             json = "[-]";
             Assert.ThrowsExactly<FormatException>(() => _ = JObject.Parse(json));
@@ -259,7 +260,8 @@ namespace Neo.UnitTests.SmartContract
             Assert.IsTrue(array[0].GetBoolean());
             Assert.AreEqual("test", array[1].GetString());
             Assert.AreEqual(123, array[2].GetInteger());
-            Assert.AreEqual(array[3].GetInteger(), BigInteger.Parse("90500000000000000000000000000"));
+            // Exact integer from scientific notation (9.05E+28), not the imprecise double cast.
+            Assert.AreEqual(BigInteger.Parse("90500000000000000000000000000"), array[3].GetInteger());
         }
 
         [TestMethod]


### PR DESCRIPTION
## Summary

Fixes #3036 by allowing `System.Numerics.BigInteger` to convert to `JNumber` / `JToken` and emit exact JSON number literals (no double precision loss). Consensus-affecting parse/deserialize of those exact integers is gated behind **`HF_Huyao`**.

closes #3037 #4583

### Problem

`Neo.Json` only modeled numbers as `double`. Callers could not write:

```csharp
BigInteger v = BigInteger.Parse("100000000000000000000000");
JToken token = v; // did not compile
```

and large integer amounts could not round-trip as precise JSON numbers.

### What changed

#### 1. Library API (`Neo.Json`) — **no hardfork**

| Addition | Purpose |
|----------|---------|
| `JNumber.FromBigInteger` / `implicit operator JNumber(BigInteger)` | Construct numbers from `BigInteger` |
| `implicit operator JToken(BigInteger)` | Assign into objects/arrays |
| Exact storage for values **outside** IEEE-754 safe range (`±(2^53−1)`) | Preserve full integer digits |
| Safe-range integers stay `double`-backed | Compatibility with existing callers |
| `HasExactBigInteger` / `TryGetExactBigInteger` | Detect the new storage path |
| `TryGetBigInteger` / `GetBigInteger` | General integer extraction |
| `Write`: exact integers via raw digit string | e.g. `{"Value":100000000000000000000000}` |

**Unchanged historical paths:**

- `long` → `JNumber` still goes through `double` (same as before).
- Default `JToken.Parse(...)` still uses **double-only** number parsing (`exactIntegers: false`).

Example (works without hardfork — off-chain / RPC / tools):

```csharp
BigInteger v = BigInteger.Parse("100000000000000000000000");
var obj = new JObject { ["Value"] = v };
// {"Value":100000000000000000000000}
```

#### 2. Parse opt-in for exact integers

```csharp
JToken.Parse(json, max_nest, exactIntegers: true);
```

When `exactIntegers` is true:

- Integers outside the safe range (and integer-valued scientific form such as `9.05E+28`) are stored as exact `BigInteger`.
- Digit count capped at 100 for safety (pathological inputs still rejected).

Default remains `exactIntegers: false` → `GetDouble()` only (pre-Huyao / legacy semantics).

#### 3. Consensus path — **`HF_Huyao` only for the new exact path**

| Component | Pre-`HF_Huyao` | Post-`HF_Huyao` |
|-----------|----------------|-----------------|
| `StdLib.jsonDeserialize` | `Parse(..., exactIntegers: false)` | `Parse(..., exactIntegers: true)` |
| `JsonSerializer.Deserialize` | Historical double + Basilisk string path | **Only if** `TryGetExactBigInteger` succeeds, use that value; otherwise **same** historical path |

Important: the hardfork does **not** rewrite all integer deserialize logic. Double-backed numbers (normal JSON numbers, safe-range values) still go through the existing Basilisk / cast path. Only the **new** exact-`BigInteger` storage is taken under Huyao.

### Why a hardfork?

`StdLib.jsonDeserialize` runs on every node during contract execution. Changing how large JSON integers become `StackItem` integers would change execution results for the same transaction. Gating keeps pre-Huyao nodes consensus-compatible; post-Huyao enables exact large integers on-chain.

### Out of scope / unchanged

- `JsonSerialize` / `SerializeToByteArray` still reject stack integers outside `MAX_SAFE_INTEGER` (unchanged policy).
- No new `Hardfork` enum value — reuses existing **`HF_Huyao`**.

## Test plan

- [x] `dotnet test tests/Neo.Json.UnitTests` (BigInteger construct/write/parse)
- [x] `dotnet test tests/Neo.UnitTests --filter FullyQualifiedName~UT_JsonSerializer` (pre/post Huyao exact path; double-backed path unchanged)
- [x] CI green on this PR
- [ ] Reviewer confirmation that `HF_Huyao` is the intended activation hardfork for this feature

## Related

- Closes #3036
- Closes #4583