### PR TITLE
fix: leave '+' unescaped in JSON (neo#2612), HF_Huyao for StdLib

### DIFF
--- a/src/Neo.Json/JToken.cs
+++ b/src/Neo.Json/JToken.cs
@@ -10,6 +10,7 @@
 // modifications are permitted.
 
 using System.Diagnostics.CodeAnalysis;
+using System.Text.Encodings.Web;
 using System.Text.Json;
 using static Neo.Json.Utility;
 
@@ -20,6 +21,12 @@ namespace Neo.Json
     /// </summary>
     public abstract class JToken
     {
+        /// <summary>
+        /// Encoder used when writing JSON: same as <see cref="JavaScriptEncoder.Default"/>
+        /// but leaves <c>+</c> unescaped (neo-project/neo#2612).
+        /// </summary>
+        public static JavaScriptEncoder Encoder { get; } = JsonPlusEncoder.Instance;
+
         /// <summary>
         /// Represents a <see langword="null"/> token.
         /// </summary>
@@ -240,6 +247,7 @@ namespace Neo.Json
             using Utf8JsonWriter writer = new(ms, new JsonWriterOptions
             {
                 Indented = indented,
+                Encoder = Encoder,
                 SkipValidation = true
             });
             Write(writer);

--- a/src/Neo.Json/JsonPlusEncoder.cs
+++ b/src/Neo.Json/JsonPlusEncoder.cs
@@ -1,0 +1,96 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// JsonPlusEncoder.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using System.Text.Encodings.Web;
+
+namespace Neo.Json
+{
+    /// <summary>
+    /// <see cref="JavaScriptEncoder"/> matching <see cref="JavaScriptEncoder.Default"/>
+    /// except that <c>+</c> is not escaped to <c>\u002B</c>.
+    /// </summary>
+    /// <remarks>
+    /// System.Text.Json's default encoder rewrites <c>+</c> as <c>\u002B</c>, which inflates
+    /// base64 payloads in storage (see neo-project/neo#2612). Other escaping (quotes, controls,
+    /// non-ASCII BMP as <c>\uXXXX</c>, HTML-sensitive chars) is unchanged.
+    /// </remarks>
+    public sealed class JsonPlusEncoder : JavaScriptEncoder
+    {
+        /// <summary>
+        /// Shared instance.
+        /// </summary>
+        public static JsonPlusEncoder Instance { get; } = new();
+
+        private static readonly JavaScriptEncoder Inner = JavaScriptEncoder.Default;
+
+        private JsonPlusEncoder() { }
+
+        /// <inheritdoc />
+        public override int MaxOutputCharactersPerInputCharacter =>
+            Inner.MaxOutputCharactersPerInputCharacter;
+
+        /// <inheritdoc />
+        public override unsafe int FindFirstCharacterToEncode(char* text, int textLength)
+        {
+            for (var i = 0; i < textLength; i++)
+            {
+                var ch = text[i];
+                if (ch == '+')
+                    continue;
+
+                if (char.IsHighSurrogate(ch))
+                {
+                    if (i + 1 < textLength && char.IsLowSurrogate(text[i + 1]))
+                    {
+                        var scalar = char.ConvertToUtf32(ch, text[i + 1]);
+                        if (WillEncode(scalar))
+                            return i;
+                        i++;
+                        continue;
+                    }
+                }
+
+                if (WillEncode(ch))
+                    return i;
+            }
+
+            return -1;
+        }
+
+        /// <inheritdoc />
+        public override bool WillEncode(int unicodeScalar)
+        {
+            if (unicodeScalar == '+')
+                return false;
+            return Inner.WillEncode(unicodeScalar);
+        }
+
+        /// <inheritdoc />
+        public override unsafe bool TryEncodeUnicodeScalar(
+            int unicodeScalar, char* buffer, int bufferLength, out int numberOfCharactersWritten)
+        {
+            if (unicodeScalar == '+')
+            {
+                if (bufferLength < 1)
+                {
+                    numberOfCharactersWritten = 0;
+                    return false;
+                }
+
+                buffer[0] = '+';
+                numberOfCharactersWritten = 1;
+                return true;
+            }
+
+            return Inner.TryEncodeUnicodeScalar(unicodeScalar, buffer, bufferLength, out numberOfCharactersWritten);
+        }
+    }
+}

--- a/src/Neo.Json/Neo.Json.csproj
+++ b/src/Neo.Json/Neo.Json.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackageTags>NEO;JSON</PackageTags>
   </PropertyGroup>
 

--- a/src/Neo/SmartContract/JsonSerializer.cs
+++ b/src/Neo/SmartContract/JsonSerializer.cs
@@ -93,10 +93,26 @@ namespace Neo.SmartContract
         /// <returns>A byte array containing the JSON output.</returns>
         public static byte[] SerializeToByteArray(StackItem item, uint maxSize)
         {
+            return SerializeToByteArray(item, maxSize, preservePlus: false);
+        }
+
+        /// <summary>
+        /// Serializes a <see cref="StackItem"/> to JSON.
+        /// </summary>
+        /// <param name="item">The <see cref="StackItem"/> to convert.</param>
+        /// <param name="maxSize">The maximum size of the JSON output.</param>
+        /// <param name="preservePlus">
+        /// When <see langword="true"/>, <c>+</c> is left unescaped (HF_Huyao / neo#2612).
+        /// When <see langword="false"/>, historical <c>\u002B</c> escaping is used.
+        /// </param>
+        /// <returns>A byte array containing the JSON output.</returns>
+        public static byte[] SerializeToByteArray(StackItem item, uint maxSize, bool preservePlus)
+        {
             using MemoryStream ms = new();
             using Utf8JsonWriter writer = new(ms, new JsonWriterOptions
             {
                 Indented = false,
+                Encoder = preservePlus ? JToken.Encoder : null,
                 SkipValidation = false
             });
             Stack stack = new();

--- a/src/Neo/SmartContract/Native/StdLib.cs
+++ b/src/Neo/SmartContract/Native/StdLib.cs
@@ -46,7 +46,9 @@ namespace Neo.SmartContract.Native
         [ContractMethod(CpuFee = 1 << 12)]
         private static byte[] JsonSerialize(ApplicationEngine engine, StackItem item)
         {
-            return JsonSerializer.SerializeToByteArray(item, engine.Limits.MaxItemSize);
+            // HF_Huyao: leave '+' unescaped in JSON strings (neo#2612). Pre-Huyao keeps \u002B.
+            var preservePlus = engine.IsHardforkEnabled(Hardfork.HF_Huyao);
+            return JsonSerializer.SerializeToByteArray(item, engine.Limits.MaxItemSize, preservePlus);
         }
 
         [ContractMethod(CpuFee = 1 << 14)]

--- a/tests/Neo.Json.UnitTests/UT_JString.cs
+++ b/tests/Neo.Json.UnitTests/UT_JString.cs
@@ -426,6 +426,25 @@ namespace Neo.Json.UnitTests
 
             Assert.ThrowsExactly<ArgumentException>(() => _ = invalidEnum.GetEnum<Woo>());
         }
+
+        [TestMethod]
+        public void TestPlusNotEscapedAsUnicode()
+        {
+            // neo#2612: '+' must not become \u002B (base64-friendly, smaller storage)
+            JString plus = "a+b/c=";
+            Assert.AreEqual(@"""a+b/c=""", plus.ToString());
+            Assert.IsFalse(plus.ToString().Contains("\\u002B", StringComparison.Ordinal));
+
+            var obj = new JObject { ["k+ey"] = "val+ue" };
+            Assert.AreEqual(@"{""k+ey"":""val+ue""}", obj.ToString());
+
+            // Other escaping stays default-like (quotes, controls, non-ASCII BMP)
+            JString quoted = "say \"hi\"";
+            Assert.AreEqual(@"""say \u0022hi\u0022""", quoted.ToString());
+
+            JString nonAscii = "\uAAAA";
+            Assert.AreEqual(@"""\uAAAA""", nonAscii.ToString());
+        }
     }
     public enum EnumExample
     {

--- a/tests/Neo.UnitTests/SmartContract/UT_JsonSerializer.cs
+++ b/tests/Neo.UnitTests/SmartContract/UT_JsonSerializer.cs
@@ -18,6 +18,7 @@ using Neo.VM.Types;
 using System;
 using System.Linq;
 using System.Numerics;
+using System.Text;
 using Array = Neo.VM.Types.Array;
 
 namespace Neo.UnitTests.SmartContract
@@ -180,6 +181,11 @@ namespace Neo.UnitTests.SmartContract
 
             Assert.AreEqual(@"{""\uAAAA"":true}", parsed.ToString());
 
+            // neo#2612: '+' preserved in Neo.Json write path
+            json = @" {""test"":""+""} ";
+            parsed = JObject.Parse(json);
+            Assert.AreEqual(@"{""test"":""+""}", parsed.ToString());
+
             json = @"{""a"":}";
             Assert.ThrowsExactly<FormatException>(() => _ = JObject.Parse(json));
 
@@ -291,6 +297,29 @@ namespace Neo.UnitTests.SmartContract
             Assert.IsTrue(array[0].GetBoolean());
             Assert.AreEqual("test2", array[1].GetString());
             Assert.AreEqual(321, array[2].GetInteger());
+        }
+
+        [TestMethod]
+        public void SerializeToByteArray_Plus_HardforkGated()
+        {
+            // Base64-like payload with '+' (issue #2612).
+            StackItem item = "a+b/c=";
+
+            var legacy = Encoding.UTF8.GetString(JsonSerializer.SerializeToByteArray(item, 1024, preservePlus: false));
+            Assert.AreEqual(@"""a\u002Bb/c=""", legacy);
+
+            var fixedJson = Encoding.UTF8.GetString(JsonSerializer.SerializeToByteArray(item, 1024, preservePlus: true));
+            Assert.AreEqual(@"""a+b/c=""", fixedJson);
+            Assert.IsTrue(fixedJson.Length < legacy.Length);
+        }
+
+        [TestMethod]
+        public void SerializeToByteArray_Default_IsLegacyEscaping()
+        {
+            // Two-arg overload stays pre-Huyao / legacy (used when caller does not pass HF flag).
+            StackItem item = "x+y";
+            var json = Encoding.UTF8.GetString(JsonSerializer.SerializeToByteArray(item, 1024));
+            Assert.AreEqual(@"""x\u002By""", json);
         }
     }
 }


### PR DESCRIPTION
## Summary

Closes **#2612**. Stops `System.Text.Json` from rewriting `+` as `\u002B` when writing JSON strings, which unnecessarily inflates base64 payloads (storage size and GAS).

- **`Neo.Json`**: always write with a default-compatible encoder that leaves `+` unescaped.
- **`StdLib.jsonSerialize`**: same behavior only after **`HF_Huyao`** so consensus stays compatible until activation.

### Problem

Default `Utf8JsonWriter` / `JavaScriptEncoder.Default` escapes `+` to `\u002B`. That is valid JSON but harmful for Neo:

| Input string | Default write | Desired |
|--------------|---------------|---------|
| `a+b/c=` (base64-like) | "a\u002Bb/c="` | "a+b/c="` |

`+` is a normal base64 alphabet character. Escaping it grows every stored JSON string that contains base64 and raises user cost. Reported on testnet (e.g. block **398890**) with neo-cli 3.0.3.

---

## History of prior attempts (related PRs)

This bug has been rediscovered and “fixed” several times without landing on the long-lived N3 line:

| PR | Title | Outcome | Notes |
|----|--------|---------|--------|
| **#2050** | Fix encoder | **Closed** (Nov 2020) without merge into the path that stayed open | Targeted neo-modules related work / closed without the fix remaining in core |
| **#2307** | Fix json encoder | **Closed** as duplicate of #2050 (Feb 2021) | Would have fixed encoder usage; closed because #2050 was considered the “real” PR — but #2050 also never delivered a lasting core fix |
| **#2612** | `'+' still replaced by \u002B` | **Open** (Oct 2021–) | Documents that after the above closures the bug remained; shargon confirmed still open (2025) |
| **#3663** | Fix `+` in json | **Open**, **CONFLICTING**, base was `master` | shargon’s revival based on #2050; later commits (incl. from @cschuchardt88) tried `UnsafeRelaxed` / replace hacks; never merged, conflicted, not on `master-n3` |

**Net result:** the community has known the fix shape for years, but no clean, consensus-safe, `master-n3` PR shipped. This PR is a **fresh implementation on `master-n3`** that supersedes the intent of #2050 / #2307 / #3663 while addressing hardfork safety that older patches did not fully nail.

If #3663 is still desired as history, it can be closed in favor of this PR once reviewed.

---

## What this PR changes

### 1. `JsonPlusEncoder` (`Neo.Json`)

Custom `JavaScriptEncoder` that **delegates to `JavaScriptEncoder.Default`** except:

- `+` is **not** encoded as `\u002B`
- Everything else stays default-like (quotes, controls, non-ASCII as `\uXXXX`, HTML-sensitive chars, etc.)

Why not the approaches from #3663?

| Approach in #3663 | Issue |
|-------------------|--------|
| `JavaScriptEncoder.Create(BasicLatin, CJK)` | Still escapes `+` (verified); required a hacky `.Replace("\\u002B", "+")` |
| `UnsafeRelaxedJsonEscaping` | Also leaves `+`, but **also** changes many other escapes (e.g. raw UTF-8 for CJK, different quote escaping) — larger consensus surface than needed |
| Post-hoc string replace of `\u002B` | Easy to get wrong for edge cases involving backslashes |

`JsonPlusEncoder` is the minimal delta from Default: **only `+`**.

### 2. `JToken` write path (library — **no hardfork**)

`ToByteArray` / `ToString` set:

```csharp
Encoder = JToken.Encoder  // JsonPlusEncoder.Instance
```

Off-chain tools, RPC-facing JSON, wallets, tests get correct `+` immediately.

### 3. `JsonSerializer.SerializeToByteArray` + `StdLib.jsonSerialize` (**hardfork**)

| API | Behavior |
|-----|----------|
| `SerializeToByteArray(item, maxSize)` | **Legacy** (`\u002B`) — default overload |
| `SerializeToByteArray(item, maxSize, preservePlus: true)` | New encoder |
| `StdLib.jsonSerialize` | `preservePlus = engine.IsHardforkEnabled(HF_Huyao)` |

**Why hardfork?**  
`jsonSerialize` is consensus-critical. Output bytes (and thus length) change when `+` is present → fee/storage limits and stored data can diverge across nodes if not activated together.

Pre-Huyao nodes keep historical escaping. Post-Huyao nodes write bare `+`.

---

## Examples

```text
// Neo.Json (always)
new JString("a+b/c=").ToString()  →  "a+b/c="

// StdLib / SerializeToByteArray
preservePlus: false  →  "a\u002Bb/c="   // pre-HF_Huyao
preservePlus: true   →  "a+b/c="        // HF_Huyao+
```

Non-ASCII / controls still match default style, e.g. "\uAAAA"` and `\u0022` for quotes.

---

## Test plan

- [x] `dotnet test tests/Neo.Json.UnitTests` — includes `TestPlusNotEscapedAsUnicode`
- [x] `dotnet test tests/Neo.UnitTests --filter FullyQualifiedName~UT_JsonSerializer` — legacy vs `preservePlus`, object round-trip with "+"`
- [x] CI green on this PR
- [ ] Confirm **`HF_Huyao`** is the intended activation hardfork (same bucket as other pending N3 work)
- [ ] Optionally close **#3663** as superseded after merge

## Related

- Closes #2612
- Supersedes intent of #2050, #2307, #3663
- Related discussion: original report of testnet block 398890 base64/`+` cost