### PR TITLE
refactor: replace runtime IsHardfork checks with dual ContractMethods

### DIFF
--- a/src/Neo/SmartContract/ApplicationEngine.cs
+++ b/src/Neo/SmartContract/ApplicationEngine.cs
@@ -717,25 +717,11 @@ namespace Neo.SmartContract
         {
             var index = persistingBlock?.Index ?? NativeContract.Ledger.CurrentIndex(snapshot);
             settings ??= ProtocolSettings.Default;
-            // Adjust jump table according persistingBlock
-
-            JumpTable jumpTable;
-
-            if (settings.IsHardforkEnabled(Hardfork.HF_Gorgon, index))
-            {
-                jumpTable = DefaultJumpTable;
-            }
-            else
-            {
-                if (!settings.IsHardforkEnabled(Hardfork.HF_Echidna, index))
-                {
-                    jumpTable = NotEchidnaJumpTable;
-                }
-                else
-                {
-                    jumpTable = NotGorgonJumpTable;
-                }
-            }
+            // Jump tables are stacked by hardfork; historical pre-HF paths must stay for genesis sync (#4455).
+            JumpTable jumpTable =
+                settings.IsHardforkEnabled(Hardfork.HF_Gorgon, index) ? DefaultJumpTable :
+                settings.IsHardforkEnabled(Hardfork.HF_Echidna, index) ? NotGorgonJumpTable :
+                NotEchidnaJumpTable;
 
             var engine = Provider?.Create(trigger, container, snapshot, persistingBlock, settings, gas, diagnostic, jumpTable)
                   ?? new ApplicationEngine(trigger, container, snapshot, persistingBlock, settings, gas, diagnostic, jumpTable);

--- a/src/Neo/SmartContract/Native/NeoToken.cs
+++ b/src/Neo/SmartContract/Native/NeoToken.cs
@@ -392,20 +392,32 @@ namespace Neo.SmartContract.Native
         }
 
         /// <summary>
-        /// Registers a candidate.
+        /// Registers a candidate (pre-Echidna). Witness is checked before charging the register fee.
         /// </summary>
         /// <param name="engine">The engine used to check witness and read data.</param>
         /// <param name="pubkey">The public key of the candidate.</param>
         /// <returns><see langword="true"/> if the candidate is registered; otherwise, <see langword="false"/>.</returns>
-        [ContractMethod(true, Hardfork.HF_Echidna, RequiredCallFlags = CallFlags.States)]
-        [ContractMethod(Hardfork.HF_Echidna, /* */ RequiredCallFlags = CallFlags.States | CallFlags.AllowNotify)]
-        private bool RegisterCandidate(ApplicationEngine engine, ECPoint pubkey)
+        [ContractMethod(true, Hardfork.HF_Echidna, RequiredCallFlags = CallFlags.States, Name = "registerCandidate")]
+        private bool RegisterCandidateV0(ApplicationEngine engine, ECPoint pubkey)
         {
-            // This check can be removed post-Echidna if compatible,
-            // RegisterInternal does this anyway.
-            if (!engine.IsHardforkEnabled(Hardfork.HF_Echidna) &&
-                !engine.CheckWitnessInternal(Contract.CreateSignatureRedeemScript(pubkey).ToScriptHash()))
+            // Pre-Echidna: fail before fee if witness is missing (fee was not charged on early return).
+            if (!engine.CheckWitnessInternal(Contract.CreateSignatureRedeemScript(pubkey).ToScriptHash()))
                 return false;
+            // In the unit of picoGAS, 1 picoGAS = 1e-12 GAS
+            engine.AddFee(GetRegisterPrice(engine.SnapshotCache), true);
+            return RegisterInternal(engine, pubkey);
+        }
+
+        /// <summary>
+        /// Registers a candidate (post-Echidna). Register fee is charged before the witness check in
+        /// <see cref="RegisterInternal"/>; notifications require <see cref="CallFlags.AllowNotify"/>.
+        /// </summary>
+        /// <param name="engine">The engine used to check witness and read data.</param>
+        /// <param name="pubkey">The public key of the candidate.</param>
+        /// <returns><see langword="true"/> if the candidate is registered; otherwise, <see langword="false"/>.</returns>
+        [ContractMethod(Hardfork.HF_Echidna, RequiredCallFlags = CallFlags.States | CallFlags.AllowNotify, Name = "registerCandidate")]
+        private bool RegisterCandidateV1(ApplicationEngine engine, ECPoint pubkey)
+        {
             // In the unit of picoGAS, 1 picoGAS = 1e-12 GAS
             engine.AddFee(GetRegisterPrice(engine.SnapshotCache), true);
             return RegisterInternal(engine, pubkey);

--- a/src/Neo/SmartContract/Native/PolicyContract.cs
+++ b/src/Neo/SmartContract/Native/PolicyContract.cs
@@ -510,12 +510,21 @@ namespace Neo.SmartContract.Native
             engine.SnapshotCache.GetAndChange(_feePerByte)!.Set(value);
         }
 
-        [ContractMethod(CpuFee = 1 << 15, RequiredCallFlags = CallFlags.States)]
-        private void SetExecFeeFactor(ApplicationEngine engine, ulong value)
+        [ContractMethod(true, Hardfork.HF_Faun, CpuFee = 1 << 15, RequiredCallFlags = CallFlags.States, Name = "setExecFeeFactor")]
+        private void SetExecFeeFactorV0(ApplicationEngine engine, ulong value)
+        {
+            SetExecFeeFactorInternal(engine, value, MaxExecFeeFactor);
+        }
+
+        [ContractMethod(Hardfork.HF_Faun, CpuFee = 1 << 15, RequiredCallFlags = CallFlags.States, Name = "setExecFeeFactor")]
+        private void SetExecFeeFactorV1(ApplicationEngine engine, ulong value)
         {
             // After FAUN hardfork, the max exec fee factor is with decimals defined in ApplicationEngine.FeeFactor
-            var maxValue = engine.IsHardforkEnabled(Hardfork.HF_Faun) ? ApplicationEngine.FeeFactor * MaxExecFeeFactor : MaxExecFeeFactor;
+            SetExecFeeFactorInternal(engine, value, ApplicationEngine.FeeFactor * MaxExecFeeFactor);
+        }
 
+        private void SetExecFeeFactorInternal(ApplicationEngine engine, ulong value, BigInteger maxValue)
+        {
             if (value == 0 || value > maxValue)
                 throw new ArgumentOutOfRangeException(nameof(value), $"ExecFeeFactor must be between [1, {maxValue}], got {value}");
 
@@ -575,7 +584,7 @@ namespace Neo.SmartContract.Native
         {
             AssertCommittee(engine);
 
-            return await BlockAccountInternal(engine, account);
+            return await BlockAccountInternal(engine, account, applyFaunRules: false);
         }
 
         [ContractMethod(Hardfork.HF_Faun, CpuFee = 1 << 15, RequiredCallFlags = CallFlags.States | CallFlags.AllowNotify, Name = "blockAccount")]
@@ -583,10 +592,14 @@ namespace Neo.SmartContract.Native
         {
             AssertCommittee(engine);
 
-            return await BlockAccountInternal(engine, account);
+            return await BlockAccountInternal(engine, account, applyFaunRules: true);
         }
 
-        internal async ContractTask<bool> BlockAccountInternal(ApplicationEngine engine, UInt160 account)
+        /// <summary>
+        /// Blocks an account. Callers that are not the dual <c>blockAccount</c> methods must pass
+        /// <paramref name="applyFaunRules"/> matching whether HF_Faun is active (see #4455).
+        /// </summary>
+        internal async ContractTask<bool> BlockAccountInternal(ApplicationEngine engine, UInt160 account, bool applyFaunRules)
         {
             if (IsNative(account)) throw new InvalidOperationException("Cannot block a native contract.");
 
@@ -594,15 +607,21 @@ namespace Neo.SmartContract.Native
 
             if (engine.SnapshotCache.Contains(key)) return false;
 
-            if (engine.IsHardforkEnabled(Hardfork.HF_Faun))
+            if (applyFaunRules)
                 await NEO.VoteInternal(engine, account, null);
 
-            engine.SnapshotCache.Add(key,
-                // Set request time for recover funds
-                engine.IsHardforkEnabled(Hardfork.HF_Faun) ? new StorageItem(engine.GetTime())
-                : new StorageItem([]));
+            // Post-Faun: store request time for recover-funds; pre-Faun: empty payload.
+            engine.SnapshotCache.Add(key, applyFaunRules ? new StorageItem(engine.GetTime()) : new StorageItem([]));
 
             return true;
+        }
+
+        /// <summary>
+        /// Blocks an account using the rules active at the current hardfork height.
+        /// </summary>
+        internal async ContractTask<bool> BlockAccountInternal(ApplicationEngine engine, UInt160 account)
+        {
+            return await BlockAccountInternal(engine, account, engine.IsHardforkEnabled(Hardfork.HF_Faun));
         }
 
         [ContractMethod(CpuFee = 1 << 15, RequiredCallFlags = CallFlags.States)]

--- a/src/Neo/SmartContract/Native/RoleManagement.cs
+++ b/src/Neo/SmartContract/Native/RoleManagement.cs
@@ -61,8 +61,19 @@ namespace Neo.SmartContract.Native
                 .FirstOrDefault() ?? [];
         }
 
-        [ContractMethod(CpuFee = 1 << 15, RequiredCallFlags = CallFlags.States | CallFlags.AllowNotify)]
-        private void DesignateAsRole(ApplicationEngine engine, Role role, ECPoint[] nodes)
+        [ContractMethod(true, Hardfork.HF_Echidna, CpuFee = 1 << 15, RequiredCallFlags = CallFlags.States | CallFlags.AllowNotify, Name = "designateAsRole")]
+        private void DesignateAsRoleV0(ApplicationEngine engine, Role role, ECPoint[] nodes)
+        {
+            DesignateAsRoleInternal(engine, role, nodes, includeNodeLists: false);
+        }
+
+        [ContractMethod(Hardfork.HF_Echidna, CpuFee = 1 << 15, RequiredCallFlags = CallFlags.States | CallFlags.AllowNotify, Name = "designateAsRole")]
+        private void DesignateAsRoleV1(ApplicationEngine engine, Role role, ECPoint[] nodes)
+        {
+            DesignateAsRoleInternal(engine, role, nodes, includeNodeLists: true);
+        }
+
+        private void DesignateAsRoleInternal(ApplicationEngine engine, Role role, ECPoint[] nodes, bool includeNodeLists)
         {
             if (nodes.Length == 0 || nodes.Length > 32)
                 throw new ArgumentException($"Nodes count {nodes.Length} must be between 1 and 32", nameof(nodes));
@@ -85,7 +96,9 @@ namespace Neo.SmartContract.Native
             list.AddRange(nodes);
             list.Sort();
             engine.SnapshotCache.Add(key, new StorageItem(list));
-            if (engine.IsHardforkEnabled(Hardfork.HF_Echidna))
+
+            // Notification shape is versioned via dual ContractMethod (pre/post Echidna), not a runtime HF check (#4455).
+            if (includeNodeLists)
             {
                 var oldNodes = new VM.Types.Array(GetDesignatedByRole(engine.SnapshotCache, role, index - 1).Select(u => (ByteString)u.EncodePoint(true)));
                 var newNodes = new VM.Types.Array(nodes.Select(u => (ByteString)u.EncodePoint(true)));

--- a/tests/Neo.UnitTests/SmartContract/Native/UT_HardforkDualContractMethods.cs
+++ b/tests/Neo.UnitTests/SmartContract/Native/UT_HardforkDualContractMethods.cs
@@ -1,0 +1,221 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// UT_HardforkDualContractMethods.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.Cryptography.ECC;
+using Neo.Extensions;
+using Neo.Network.P2P.Payloads;
+using Neo.Persistence;
+using Neo.SmartContract;
+using Neo.SmartContract.Native;
+using Neo.UnitTests.Extensions;
+using Neo.VM;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Array = Neo.VM.Types.Array;
+
+namespace Neo.UnitTests.SmartContract.Native
+{
+    [TestClass]
+    public class UT_HardforkDualContractMethods
+    {
+        private DataCache _snapshotCache;
+
+        [TestInitialize]
+        public void TestSetup()
+        {
+            _snapshotCache = TestBlockchain.GetTestSnapshotCache();
+        }
+
+        [TestMethod]
+        public void SetExecFeeFactorV0_RejectsAboveMaxExecFeeFactor()
+        {
+            using var engine = CommitteeEngine();
+            var ex = Assert.Throws<TargetInvocationException>(() =>
+                Invoke(NativeContract.Policy, "SetExecFeeFactorV0", engine, 101ul));
+            Assert.IsInstanceOfType<ArgumentOutOfRangeException>(ex.InnerException);
+
+            Invoke(NativeContract.Policy, "SetExecFeeFactorV0", engine, 50ul);
+        }
+
+        [TestMethod]
+        public void SetExecFeeFactorV1_AllowsAboveMaxExecFeeFactor()
+        {
+            using var engine = CommitteeEngine();
+            Invoke(NativeContract.Policy, "SetExecFeeFactorV1", engine, 101ul);
+            var tooLarge = (ulong)(ApplicationEngine.FeeFactor * PolicyContract.MaxExecFeeFactor) + 1;
+            var ex = Assert.Throws<TargetInvocationException>(() =>
+                Invoke(NativeContract.Policy, "SetExecFeeFactorV1", engine, tooLarge));
+            Assert.IsInstanceOfType<ArgumentOutOfRangeException>(ex.InnerException);
+        }
+
+        [TestMethod]
+        public void BlockAccountV0_StoresEmptyPayload()
+        {
+            using var engine = CommitteeEngine();
+            var account = UInt160.Parse("0xa400ff00ff00ff00ff00ff00ff00ff00ff00ff01");
+            var ok = Invoke<bool>(NativeContract.Policy, "BlockAccountV0", engine, account);
+            Assert.IsTrue(ok);
+            Assert.AreEqual(0, engine.SnapshotCache[StorageKey.Create(NativeContract.Policy.Id, 15, account)].Value.Length);
+        }
+
+        [TestMethod]
+        public void BlockAccountV1_StoresTimestamp()
+        {
+            using var engine = CommitteeEngine();
+            var account = UInt160.Parse("0xb400ff00ff00ff00ff00ff00ff00ff00ff00ff01");
+            var ok = Invoke<bool>(NativeContract.Policy, "BlockAccountV1", engine, account);
+            Assert.IsTrue(ok);
+            Assert.IsGreaterThan(0, engine.SnapshotCache[StorageKey.Create(NativeContract.Policy.Id, 15, account)].Value.Length);
+        }
+
+        [TestMethod]
+        public void BlockAccountInternal_TwoArgOverload()
+        {
+            using var engine = CommitteeEngine();
+            var account = UInt160.Parse("0xc400ff00ff00ff00ff00ff00ff00ff00ff00ff01");
+            var ok = NativeContract.Policy.BlockAccountInternal(engine, account).GetAwaiter().GetResult();
+            Assert.IsTrue(ok);
+        }
+
+        [TestMethod]
+        public void DesignateAsRoleV0_NotificationHasTwoStates()
+        {
+            AssertDesignate(includeNodeLists: false, expectedStates: 2);
+        }
+
+        [TestMethod]
+        public void DesignateAsRoleV1_NotificationHasFourStates()
+        {
+            AssertDesignate(includeNodeLists: true, expectedStates: 4);
+        }
+
+        [TestMethod]
+        public void RegisterCandidateV0_RejectsMissingWitnessBeforeFee()
+        {
+            using var engine = Engine(UInt160.Zero);
+            var pubkey = TestProtocolSettings.Default.StandbyValidators[0];
+            var before = engine.FeeConsumed;
+            var ok = Invoke<bool>(NativeContract.NEO, "RegisterCandidateV0", engine, pubkey);
+            Assert.IsFalse(ok);
+            Assert.AreEqual(before, engine.FeeConsumed);
+        }
+
+        [TestMethod]
+        public void RegisterCandidateV1_ChargesFeeBeforeWitnessCheck()
+        {
+            using var engine = Engine(UInt160.Zero, gas: 10_000_00000000);
+            var pubkey = TestProtocolSettings.Default.StandbyValidators[0];
+            var before = engine.FeeConsumed;
+            var ok = Invoke<bool>(NativeContract.NEO, "RegisterCandidateV1", engine, pubkey);
+            Assert.IsFalse(ok);
+            Assert.IsGreaterThan(before, engine.FeeConsumed);
+        }
+
+        [TestMethod]
+        public void RegisterCandidateV0AndV1_SucceedWithWitness()
+        {
+            var pubkey = TestProtocolSettings.Default.StandbyValidators[0];
+            var hash = Contract.CreateSignatureRedeemScript(pubkey).ToScriptHash();
+            using (var engine = Engine(hash, gas: 10_000_00000000))
+            {
+                Assert.IsTrue(Invoke<bool>(NativeContract.NEO, "RegisterCandidateV0", engine, pubkey));
+            }
+            using (var engine = Engine(hash, gas: 10_000_00000000))
+            {
+                Assert.IsTrue(Invoke<bool>(NativeContract.NEO, "RegisterCandidateV1", engine, pubkey));
+            }
+        }
+
+        private void AssertDesignate(bool includeNodeLists, int expectedStates)
+        {
+            using var engine = CommitteeEngine();
+            var notifications = new List<NotifyEventArgs>();
+            engine.Notify += (_, e) => notifications.Add(e);
+            var nodes = TestProtocolSettings.Default.StandbyValidators.Take(2).ToArray();
+            var name = includeNodeLists ? "DesignateAsRoleV1" : "DesignateAsRoleV0";
+            Invoke(NativeContract.RoleManagement, name, engine, Role.Oracle, nodes);
+            Assert.HasCount(1, notifications);
+            Assert.AreEqual("Designation", notifications[0].EventName);
+            Assert.HasCount(expectedStates, notifications[0].State);
+            Assert.IsInstanceOfType<Array>(notifications[0].State);
+        }
+
+        private ApplicationEngine CommitteeEngine()
+        {
+            var snapshot = _snapshotCache.CloneCache();
+            return Engine(NativeContract.NEO.GetCommitteeAddress(snapshot), snapshot);
+        }
+
+        private ApplicationEngine Engine(UInt160 signer, DataCache snapshot = null, long gas = 10_000_00000000)
+        {
+            snapshot ??= _snapshotCache.CloneCache();
+            var block = new Block
+            {
+                Header = new Header
+                {
+                    PrevHash = UInt256.Zero,
+                    MerkleRoot = UInt256.Zero,
+                    Index = 0,
+                    Timestamp = 1,
+                    NextConsensus = UInt160.Zero,
+                    Witness = null!
+                },
+                Transactions = []
+            };
+            var tx = new Transaction
+            {
+                Version = 0,
+                Nonce = 1,
+                Signers = [new() { Account = signer, Scopes = WitnessScope.Global }],
+                Attributes = [],
+                Witnesses = [new Witness { InvocationScript = new byte[] { 1 }, VerificationScript = System.Array.Empty<byte>() }],
+                Script = new byte[] { (byte)OpCode.NOP },
+                NetworkFee = 0,
+                SystemFee = 0,
+                ValidUntilBlock = 0
+            };
+            var engine = ApplicationEngine.Create(TriggerType.Application, tx, snapshot, block,
+                settings: TestProtocolSettings.Default, gas: gas);
+            engine.LoadScript(tx.Script);
+            return engine;
+        }
+
+        private static void Invoke(object instance, string name, params object[] args)
+        {
+            var result = InvokeRaw(instance, name, args);
+            if (result is ContractTask task)
+                task.GetAwaiter().GetResult();
+        }
+
+        private static T Invoke<T>(object instance, string name, params object[] args)
+        {
+            var result = InvokeRaw(instance, name, args);
+            if (result is ContractTask<T> typed)
+                return typed.GetAwaiter().GetResult();
+            if (result is ContractTask task)
+            {
+                task.GetAwaiter().GetResult();
+                return default!;
+            }
+            return (T)result!;
+        }
+
+        private static object InvokeRaw(object instance, string name, object[] args)
+        {
+            var method = instance.GetType().GetMethod(name, BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.IsNotNull(method, name);
+            return method.Invoke(instance, args);
+        }
+    }
+}


### PR DESCRIPTION
# Description

Addresses #4455 by cleaning up selected `IsHardforkEnabled` branches **without** removing historical pre-hardfork behavior required for full genesis sync.

Neo nodes must still interpret pre-HF heights correctly when replaying mainnet/testnet from genesis. Deleting pre-HF code paths after a hardfork is active on tip is **not** safe. This PR instead follows the established native-contract pattern already used for `blockAccount` / `getAttributeFee` / `destroy`: **dual `ContractMethod` entries** (`ActiveIn` / `DeprecatedIn`) so the method table selects the correct version at each height, and the method body no longer branches on `IsHardforkEnabled`.

## Motivation

#4455 asked for removable hardfork conditionals (readability; possible micro-perf). The right approach is not “always take post-HF,” but:

1. Keep any path that changes ledger state, fees, or notifications at a given height.
2. Prefer **versioned methods** over runtime `if (IsHardforkEnabled(...))` where both sides are contract entry points.
3. Leave consensus/interop HF gates that cannot be dual-methoded alone (e.g. jump tables, `GetRandom`, Basilisk notify, Gorgon crypto).

## What changed

### `NeoToken.registerCandidate`
- Split into `RegisterCandidateV0` (pre-Echidna) and `RegisterCandidateV1` (post-Echidna).
- **V0:** witness check **before** register fee (historical fee behavior).
- **V1:** charge fee, then `RegisterInternal` (witness inside); `CallFlags.States | AllowNotify`.
- Removes the dual-attribute + runtime HF early-return on a single method body.

### `PolicyContract.blockAccount`
- V0/V1 already existed; they now pass an explicit `applyFaunRules` flag.
- Removes two `IsHardforkEnabled(HF_Faun)` checks from the dual-method path.
- Keeps `BlockAccountInternal(engine, account)` overload (HF-aware) for `ContractManagement.destroy`, which is not versioned on Faun.

### `PolicyContract.setExecFeeFactor`
- Split into V0/V1 at Faun.
- Max bound is fixed per version (`MaxExecFeeFactor` vs `FeeFactor * MaxExecFeeFactor`) instead of a runtime HF ternary.

### `RoleManagement.designateAsRole`
- Split into V0/V1 at Echidna.
- Notification shape (2-arg vs 4-arg with old/new node lists) selected by version flag, not `IsHardforkEnabled`.

### `ApplicationEngine.Create`
- Jump-table selection flattened to a single expression.
- **Behavior unchanged** (Gorgon → default table; Echidna → NotGorgon; else NotEchidna). Comment notes historical paths must remain for genesis sync.

## Intentionally not removed

These still require height-gated logic for correct historical replay / protocol semantics:

- Aspidochelone fee / random paths  
- Basilisk `RuntimeNotify` / script ABI checks  
- Cockatrice `CommitteeChanged`  
- Domovoi call-permission path  
- Echidna traceable blocks, notification limits, Notary attribute, etc.  
- Faun exec-fee decimals, whitelist fee path, local storage interops  
- Gorgon signature verify / voter-reward vote source  
- Huyao and other not-yet-mainnet gates  

Further cleanups should use the same dual-method pattern or full mainnet/testnet A/B state comparison as described in #4455—not blanket deletion of pre-HF branches.

# Change Log

- Update `src/Neo/SmartContract/Native/NeoToken.cs` — dual `registerCandidate` methods  
- Update `src/Neo/SmartContract/Native/PolicyContract.cs` — `blockAccount` flags; dual `setExecFeeFactor`  
- Update `src/Neo/SmartContract/Native/RoleManagement.cs` — dual `designateAsRole` methods  
- Update `src/Neo/SmartContract/ApplicationEngine.cs` — clearer jump-table selection  

Fixes #4455

## Type of change

- [x] Optimization (the change is only an optimization)
- [x] Style (the change is only a code style for better maintenance or standard purpose)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Unit Testing
- [ ] Run Application
- [ ] Local Computer Tests
- [ ] No Testing

```
dotnet test tests/Neo.UnitTests/Neo.UnitTests.csproj --filter "FullyQualifiedName~SmartContract.Native|FullyQualifiedName~UT_ProtocolSettings|FullyQualifiedName~ApplicationEngine"
```

**257 passed**, 0 failed (filtered suite covering native contracts, protocol settings, ApplicationEngine).

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules