### PR TITLE
fix(BigDecimal): format negative ToString without signed remainder

### DIFF
--- a/src/Neo/BigDecimal.cs
+++ b/src/Neo/BigDecimal.cs
@@ -130,7 +130,12 @@ namespace Neo
             var divisor = BigInteger.Pow(10, _decimals);
             var result = BigInteger.DivRem(_value, divisor, out var remainder);
             if (remainder == 0) return result.ToString();
-            return $"{result}.{remainder.ToString("d" + _decimals)}".TrimEnd('0');
+            // DivRem remainder has the sign of the dividend, so format the
+            // fractional part from |remainder| and restore the sign for (-1, 0).
+            var fraction = BigInteger.Abs(remainder).ToString("d" + _decimals);
+            if (result.IsZero && _value.Sign < 0)
+                return $"-0.{fraction}".TrimEnd('0');
+            return $"{result}.{fraction}".TrimEnd('0');
         }
 
         /// <summary>

--- a/tests/Neo.UnitTests/UT_BigDecimal.cs
+++ b/tests/Neo.UnitTests/UT_BigDecimal.cs
@@ -151,6 +151,21 @@ namespace Neo.UnitTests
             Assert.AreEqual("1", value.ToString());
             value = new BigDecimal(new BigInteger(123456), 5);
             Assert.AreEqual("1.23456", value.ToString());
+
+            value = new BigDecimal(new BigInteger(-1234), 2);
+            Assert.AreEqual("-12.34", value.ToString());
+            value = new BigDecimal(new BigInteger(-1200), 2);
+            Assert.AreEqual("-12", value.ToString());
+            value = new BigDecimal(new BigInteger(-1010), 2);
+            Assert.AreEqual("-10.1", value.ToString());
+            value = new BigDecimal(new BigInteger(-34), 2);
+            Assert.AreEqual("-0.34", value.ToString());
+            value = new BigDecimal(new BigInteger(-10), 2);
+            Assert.AreEqual("-0.1", value.ToString());
+            value = new BigDecimal(new BigInteger(-10), 0);
+            Assert.AreEqual("-10", value.ToString());
+            value = new BigDecimal(BigInteger.Zero, 2);
+            Assert.AreEqual("0", value.ToString());
         }
 
         [TestMethod]


### PR DESCRIPTION
# Description

`BigDecimal.ToString()` used `BigInteger.DivRem` remainder as-is. For a negative value the remainder keeps the dividend's sign, so `-12.34` printed as `"-12.-34"`. Values in `(-1, 0)` would also drop the leading minus if only `Abs(remainder)` were used.

Fixes #4731

# Change Log

- Update `BigDecimal.ToString()` to format `|remainder|` and restore the sign for `(-1, 0)`
- Extend `UT_BigDecimal.TestToString` with negative, fractional, and zero cases

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Unit Testing (`UT_BigDecimal`)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
