### PR TITLE
docs: add beginner guides for neo, neo-node, and neo-vm

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,8 @@ Neo is an open-source project and it depends on its contributors and constant co
 
 Read this document to understand how issues are organized and how you can start contributing.
 
+A beginner walkthrough (including **which of neo / neo-node / neo-vm to change**) is in [docs/how-to/contribute.md](docs/how-to/contribute.md). Start from [docs/getting-started.md](docs/getting-started.md).
+
 *This document covers this repository only and does not include community repositories or repositories managed by NGD Shanghai and NGD Seattle.*
 
 ### Questions and Support

--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@
 <p align="center">
    A modern distributed network for the Smart Economy.
   <br>
-  <a href="https://docs.neo.org/"><strong>Documentation »</strong></a>
+  <a href="docs/README.md"><strong>Documentation »</strong></a>
+  ·
+  <a href="https://developers.neo.org/"><strong>developers.neo.org</strong></a>
   <br>
   <br>
   <a href="https://github.com/neo-project/neo"><strong>Neo</strong></a>
@@ -99,16 +101,57 @@
 
 ## Table of Contents
 1. [Overview](#overview)
-2. [Project structure](#project-structure)
-3. [Related projects](#related-projects)
-4. [Opening a new issue](#opening-a-new-issue)
-5. [Contributing](#contributing)
-6. [Bounty program](#bounty-program)
-7. [License](#license)
+2. [Documentation](#documentation)
+    1. [Documentation hub](docs/README.md)
+    2. [Getting started](docs/getting-started.md)
+    3. [Architecture](docs/architecture.md)
+    4. [Neo core (`neo-project/neo`)](docs/neo-core.md)
+    5. [Neo node (`neo-project/neo-node`)](docs/neo-node.md)
+    6. [NeoVM (`neo-project/neo-vm`)](docs/neo-vm.md)
+    7. [How to: build and test](docs/how-to/build-and-test.md)
+    8. [How to: run a node](docs/how-to/run-a-node.md)
+    9. [How to: smart contracts](docs/how-to/smart-contracts.md)
+    10. [How to: contribute](docs/how-to/contribute.md)
+    11. [Glossary](docs/glossary.md)
+    12. [Persistence architecture](docs/persistence-architecture.md)
+    13. [Serialization format](docs/serialization-format.md)
+    14. [Official docs notes](docs/reference/official-docs.md)
+3. [Project structure](#project-structure)
+4. [Related projects](#related-projects)
+5. [Opening a new issue](#opening-a-new-issue)
+6. [Contributing](#contributing)
+7. [Bounty program](#bounty-program)
+8. [License](#license)
 
 ## Overview
-This repository is a csharp implementation of the [neo](https://neo.org) blockchain. It is jointly maintained by the neo core developers and neo global development community.
-Visit the [tutorials](https://docs.neo.org) to get started.
+This repository is a csharp implementation of the [neo](https://neo.org) blockchain protocol **library**. It is jointly maintained by the neo core developers and neo global development community.
+
+It is **not** the program that starts a node. Neo-CLI lives in [neo-project/neo-node](https://github.com/neo-project/neo-node). The virtual machine lives in [neo-project/neo-vm](https://github.com/neo-project/neo-vm).
+
+If you are new, start here: **[docs/getting-started.md](docs/getting-started.md)**.
+
+Official N3 developer hub: [developers.neo.org](https://developers.neo.org/). (The older [docs.neo.org](https://docs.neo.org/) tutorials still exist; prefer developers.neo.org for current N3 APIs.)
+
+## Documentation
+
+Beginner-friendly guides in this repository (covers **neo**, **neo-node**, and **neo-vm**):
+
+| Guide | Description |
+| --- | --- |
+| [Documentation hub](docs/README.md) | Index of all local docs |
+| [Getting started](docs/getting-started.md) | What this repo is, what to clone, common mix-ups |
+| [Architecture](docs/architecture.md) | How neo + neo-node + neo-vm fit together |
+| [Neo core](docs/neo-core.md) | This library (`neo-project/neo`) |
+| [Neo node](docs/neo-node.md) | Neo-CLI and plugins (`neo-project/neo-node`) |
+| [NeoVM](docs/neo-vm.md) | Virtual machine (`neo-project/neo-vm`) |
+| [How to: build and test](docs/how-to/build-and-test.md) | `dotnet test` / publish all three repos |
+| [How to: run a node](docs/how-to/run-a-node.md) | Start Neo-CLI, RPC ports, plugins |
+| [How to: smart contracts](docs/how-to/smart-contracts.md) | NEF, deploy, invoke |
+| [How to: contribute](docs/how-to/contribute.md) | Branches, which repo to PR |
+| [Glossary](docs/glossary.md) | GAS, dBFT, NEF, hardfork, … |
+| [Persistence architecture](docs/persistence-architecture.md) | Stores and `DataCache` |
+| [Serialization format](docs/serialization-format.md) | Binary layout |
+| [Official docs notes](docs/reference/official-docs.md) | What we verified vs stale links |
 
 
 ## Project structure
@@ -131,9 +174,9 @@ An overview of the project folders can be seen below.
 ## Related projects
 Code references are provided for all platform building blocks. That includes the base library, the VM, a command line application and the compiler.
 
-* [neo:](https://github.com/neo-project/neo/) The core libraries for NEO.
-* [neo-node:](https://github.com/neo-project/neo-node/) The `node-cli` implementation to start a NEO node, and Plugins(including DBFT, RpcServer, Oracle, ApplicationLogs, etc.).
-* [neo-vm:](https://github.com/neo-project/neo-vm/) The Neo Virtual Machine implementation.
+* [neo:](https://github.com/neo-project/neo/) The core libraries for NEO. Guide: [docs/neo-core.md](docs/neo-core.md).
+* [neo-node:](https://github.com/neo-project/neo-node/) Neo-CLI and plugins (DBFT, RpcServer, Oracle, ApplicationLogs, storage engines, etc.). Guide: [docs/neo-node.md](docs/neo-node.md). How to run: [docs/how-to/run-a-node.md](docs/how-to/run-a-node.md).
+* [neo-vm:](https://github.com/neo-project/neo-vm/) The Neo Virtual Machine. Guide: [docs/neo-vm.md](docs/neo-vm.md).
 * [neo-express:](https://github.com/neo-project/neo-express/) A private net optimized for development scenarios.
 * [neo-devpack-dotnet:](https://github.com/neo-project/neo-devpack-dotnet/) These are the official tools used to convert a C# smart-contract into a *neo executable file*.
 * [neo-proposals:](https://github.com/neo-project/proposals) NEO Enhancement Proposals (NEPs) describe standards for the NEO platform, including core protocol specifications, client APIs, and contract standards.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,57 @@
+# Neo documentation
+
+This folder is a **beginner-friendly guide** to the C# Neo stack: how the pieces fit together, how to build them, and how to run a node.
+
+Also listed from the repository root: [README.md — Table of Contents](../README.md#table-of-contents).
+
+You do **not** need to have read the protocol papers first. Start with [Getting started](getting-started.md), then pick a how-to.
+
+## Read in this order
+
+| If you want to… | Open this |
+| --- | --- |
+| Understand Neo in plain language | [Getting started](getting-started.md) |
+| Look up a word (GAS, dBFT, NEF, …) | [Glossary](glossary.md) |
+| See how the three GitHub repos fit together | [Architecture](architecture.md) |
+| Work on **this** repository (`neo-project/neo`) | [Neo core library](neo-core.md) |
+| Run or customize a full node (`neo-project/neo-node`) | [Neo node](neo-node.md) |
+| Understand the virtual machine (`neo-project/neo-vm`) | [NeoVM](neo-vm.md) |
+| Build the code and run tests | [How to: build and test](how-to/build-and-test.md) |
+| Start Neo-CLI and sync | [How to: run a node](how-to/run-a-node.md) |
+| Compile and deploy a contract | [How to: smart contracts](how-to/smart-contracts.md) |
+| Open a pull request | [How to: contribute](how-to/contribute.md) |
+
+## In-repo reference (advanced)
+
+These two files describe internals. They assume you already know what a block and a `StorageKey` are.
+
+- [Persistence architecture](persistence-architecture.md) — stores, snapshots, `DataCache`
+- [Serialization format](serialization-format.md) — `ISerializable`, VarInt, little-endian integers
+
+## Official sites (verified)
+
+| Site | Use it for | Watch out |
+| --- | --- | --- |
+| [developers.neo.org](https://developers.neo.org/) | Concepts, RPC, CLI commands, contract APIs | Some **download links still point at `neo-cli` as its own repo**. The CLI now lives in [neo-project/neo-node](https://github.com/neo-project/neo-node). |
+| [docs.neo.org](https://docs.neo.org/) | Older tutorials linked from the README | Prefer developers.neo.org for N3. |
+| [neo.org](https://neo.org/) | Product / community | Not a protocol spec. |
+
+Details of what we checked against the current source trees: [Official docs notes](reference/official-docs.md).
+
+## The three repositories this guide covers
+
+```
+┌─────────────────────┐     uses      ┌─────────────────────┐
+│  neo-project/neo    │◄──────────────│ neo-project/neo-node│
+│  Protocol library   │               │ Neo-CLI + plugins   │
+│  Ledger, P2P, GAS   │               │ RPC, DBFT, storage  │
+└─────────┬───────────┘               └─────────────────────┘
+          │ hosts
+          ▼
+┌─────────────────────┐
+│ neo-project/neo-vm  │
+│ Stack VM + opcodes  │
+└─────────────────────┘
+```
+
+All three currently target **.NET 10** and version **3.10.x** on the N3 line (`master-n3` for neo and neo-node; `master` for neo-vm).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,95 @@
+# Architecture
+
+How [neo](https://github.com/neo-project/neo), [neo-node](https://github.com/neo-project/neo-node), and [neo-vm](https://github.com/neo-project/neo-vm) work as one stack.
+
+## Mental model
+
+Think of three layers:
+
+1. **NeoVM** (`neo-vm`) — a calculator. It has stacks and opcodes. It does not know what a block is.
+2. **Neo core** (`neo`) — the blockchain: blocks, transactions, P2P messages, native contracts, and `ApplicationEngine` (the VM *plus* fees and syscalls).
+3. **Neo-CLI** (`neo-node`) — the process you run: config files, console, plugins that attach storage, RPC, and consensus to the core.
+
+```
+You  →  Neo-CLI (neo-node)
+            │  loads plugins (RpcServer, LevelDBStore, DBFTPlugin, …)
+            ▼
+        NeoSystem  (neo)
+            ├── Blockchain actor / MemoryPool / Ledger
+            ├── P2P LocalNode
+            ├── Native contracts
+            └── ApplicationEngine  ──executes──►  NeoVM (neo-vm)
+```
+
+## What happens when a contract is invoked
+
+1. A client calls RPC `invokescript` or `invokefunction` (RpcServer plugin in **neo-node**).
+2. The node builds an `ApplicationEngine` (**neo**) with a store snapshot.
+3. The engine loads the contract’s NEF script into NeoVM (**neo-vm**).
+4. Opcodes run on the evaluation stack. `SYSCALL` leaves the VM and runs C# interop in `ApplicationEngine`.
+5. Storage reads/writes go through `DataCache` → `IStore` (LevelDB/RocksDB plugin).
+6. If this was a real transaction (not a dry-run invoke), the tx sits in the mempool until dBFT includes it in a block.
+
+That split is why a VM PR and a native-contract PR land in different repositories.
+
+## Repository map
+
+### neo-project/neo (this repo)
+
+| Area | Path | Notes |
+| --- | --- | --- |
+| Protocol types | `src/Neo/` | `UInt160`, `Hardfork`, `ProtocolSettings` |
+| Ledger | `src/Neo/Ledger/` | `Blockchain`, `MemoryPool` |
+| P2P | `src/Neo/Network/` | messages, `RemoteNode`, `TaskManager` |
+| Persistence | `src/Neo/Persistence/` | `IStore`, `DataCache` — engines are plugins |
+| Smart contracts | `src/Neo/SmartContract/` | `ApplicationEngine`, native contracts |
+| Wallets | `src/Neo/Wallets/` | NEP-6 JSON wallets |
+| IO / JSON | `src/Neo.IO`, `src/Neo.Json` | serialization, RPC JSON |
+
+NuGet: packages named `Neo`, `Neo.IO`, `Neo.Json`, `Neo.Extensions`.
+
+### neo-project/neo-node
+
+| Area | Path | Notes |
+| --- | --- | --- |
+| CLI | `src/Neo.CLI/` | `dotnet Neo.CLI.dll` (or `neo-cli` binary) |
+| Console host | `src/Neo.ConsoleService/` | command loop |
+| Plugins | `plugins/` | RpcServer, DBFTPlugin, LevelDBStore, RocksDBStore, OracleService, ApplicationLogs, StateService, TokensTracker, … |
+
+Neo-CLI **references the `Neo` library**. On GitHub this is a package or project reference to `neo-project/neo`, not a copy of all protocol code.
+
+### neo-project/neo-vm
+
+| Area | Path | Notes |
+| --- | --- | --- |
+| VM | `src/Neo.VM/` | `ExecutionEngine`, `Instruction`, jump tables |
+| Tests | `tests/Neo.VM.Tests/` | opcode tests |
+
+NuGet: `Neo.VM` (`dotnet add package Neo.VM`).
+
+## Consensus vs library
+
+dBFT lives as **DBFTPlugin** in **neo-node**. The library still defines payloads and the ledger. You can run a node that only syncs (no `start consensus`) by omitting that plugin.
+
+## Networks and ports
+
+Verified against the current [node introduction](https://developers.neo.org/docs/n3/node/Introduction) (ports are still right; the *source* links on that page are stale — see [official docs notes](reference/official-docs.md)).
+
+| Service | MainNet | TestNet |
+| --- | --- | --- |
+| JSON-RPC HTTP | 10332 | 20332 |
+| JSON-RPC HTTPS | 10331 | 20331 |
+| P2P TCP | 10333 | 20333 |
+| P2P WebSocket | 10334 | 20334 |
+
+RPC must **not** be opened to the internet without a firewall or wallet isolation. Neo-CLI does not authenticate `open wallet`.
+
+## Where to change what
+
+| You want to change… | Open a PR on |
+| --- | --- |
+| GAS fees, native `StdLib`, hardfork behavior | [neo](https://github.com/neo-project/neo) |
+| Opcode pricing inside the VM itself | [neo-vm](https://github.com/neo-project/neo-vm) (and often neo together) |
+| `getblock` RPC shape, CLI `send` command | [neo-node](https://github.com/neo-project/neo-node) |
+| C# → NEF compiler | [neo-devpack-dotnet](https://github.com/neo-project/neo-devpack-dotnet) |
+| A standard (NEP-17, …) | [proposals](https://github.com/neo-project/proposals) |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,108 @@
+# Getting started
+
+This page is for people who have never worked on Neo internals. By the end you should know what this repository is, what it is *not*, and which guide to open next.
+
+## What is Neo?
+
+Neo is an open-source public blockchain. Applications (smart contracts) run on every full node and must produce the **same result** on every machine. That is why the virtual machine is deterministic: given the same script and the same chain state, every node must agree.
+
+Two native assets ship with the chain:
+
+| Token | What it is | Typical use |
+| --- | --- | --- |
+| **NEO** | Governance token | Voting for committee / consensus |
+| **GAS** | Utility token | Paying network and system fees |
+
+On N3, GAS is claimed automatically when the NEO balance of an account changes. You do not run a separate “claim GAS” ritual like Neo 2.
+
+Official concept pages (still accurate for N3):
+
+- [Introduction to Neo](https://developers.neo.org/docs/n3/foundation/introduction)
+- [Native tokens](https://developers.neo.org/docs/n3/foundation/Native%20tokens)
+- [Governance](https://developers.neo.org/docs/n3/foundation/governance)
+- [dBFT](https://developers.neo.org/docs/n3/foundation/consensus/consensus_algorithm)
+
+## Three GitHub repos, not one program
+
+Beginners often clone this repository and expect a running node. **This repo is the protocol library.** The program you start is **Neo-CLI**, which lives in a different repository.
+
+| Repository | What it contains | You clone it when… |
+| --- | --- | --- |
+| [neo-project/neo](https://github.com/neo-project/neo) (**this repo**) | Ledger, P2P messages, native contracts, `ApplicationEngine`, wallets, persistence interfaces | You change consensus rules, fees, storage keys, or native contracts |
+| [neo-project/neo-node](https://github.com/neo-project/neo-node) | `Neo.CLI` (the process), console commands, plugins (RPC, DBFT, LevelDB/RocksDB, Oracle, …) | You want to **run** a node, expose JSON-RPC, or change CLI/plugins |
+| [neo-project/neo-vm](https://github.com/neo-project/neo-vm) | Stack VM: opcodes, evaluation stack, execution engine **without** blockchain syscalls | You change instruction semantics or embed the VM in another host |
+
+A full node is: **neo-node process + neo library + neo-vm + a storage plugin**.
+
+See [Architecture](architecture.md) for a picture of the call path from “RPC invoke” down to an opcode.
+
+## What you need on your machine
+
+- **OS:** Windows, Linux, or macOS
+- **SDK:** [.NET 10](https://dotnet.microsoft.com/download) (this tree’s projects use `net10.0`; package version prefix is `3.10.2`)
+- **Git**
+- For a **persisted** node on Linux: LevelDB or RocksDB native libraries (see [Run a node](how-to/run-a-node.md))
+
+`dotnet --version` should report a 10.x SDK.
+
+## A 10-minute tour of *this* repo
+
+```bash
+git clone https://github.com/neo-project/neo.git
+cd neo
+git checkout master-n3          # N3 protocol line
+dotnet test tests/Neo.UnitTests/Neo.UnitTests.csproj
+```
+
+That builds the core library and runs unit tests. It does **not** start a P2P node.
+
+Useful folders:
+
+| Folder | Role |
+| --- | --- |
+| `src/Neo/` | Protocol: blockchain actor, mempool, native contracts, engine |
+| `src/Neo.IO/` | Serialization and caches |
+| `src/Neo.Json/` | JSON used by RPC and wallets |
+| `src/Neo.Extensions/` | Shared helpers |
+| `tests/` | Unit tests |
+
+N3 work happens on **`master-n3`**. The **`master`** branch is the next-generation (NEO-4) line. See [Contribute](how-to/contribute.md).
+
+## A 10-minute tour of the *node*
+
+The CLI is not in this repository on GitHub. Clone the node repo:
+
+```bash
+git clone https://github.com/neo-project/neo-node.git
+cd neo-node
+git checkout master-n3
+```
+
+Then follow [How to: run a node](how-to/run-a-node.md). After start you should see a `neo>` prompt. Type `help` and `show state`.
+
+## A 10-minute tour of the *VM*
+
+```bash
+git clone https://github.com/neo-project/neo-vm.git
+cd neo-vm
+git checkout master
+dotnet test tests/Neo.VM.Tests
+```
+
+The VM does not know about blocks. Blockchain features (storage, `System.Runtime.*` syscalls) are added by `ApplicationEngine` in **this** repo. Details: [NeoVM](neo-vm.md).
+
+## Common mix-ups
+
+| Mix-up | Reality |
+| --- | --- |
+| “I cloned `neo` but `dotnet neo-cli.dll` is missing” | CLI is in [neo-node](https://github.com/neo-project/neo-node). |
+| “Official page says download `neo-cli` from `neo-project/neo-cli`” | That extra repo is historical. Current source is **neo-node**. Releases are under [neo-node/releases](https://github.com/neo-project/neo-node/releases). |
+| “NameService is a native contract in the CLI dump I found online” | In current `neo` source, native contracts include ContractManagement, StdLib, CryptoLib, Ledger, NeoToken, GasToken, Policy, RoleManagement, Oracle, Notary, Treasury. Name service is a [non-native contract](https://github.com/neo-project/non-native-contracts). |
+| “I need Ubuntu 16 and .NET Core” | Current projects target **.NET 10**. The neo-node README still mentions old Ubuntu LTS numbers; any current Linux with the SDK works. |
+| “I will implement a dApp in this repo” | Application code is compiled with [neo-devpack-dotnet](https://github.com/neo-project/neo-devpack-dotnet) and deployed *to* the chain. This repo *is* the chain. |
+
+## Next step
+
+- New to blockchain terms → [Glossary](glossary.md)
+- Want the big picture → [Architecture](architecture.md)
+- Ready to type commands → [How to: build and test](how-to/build-and-test.md)

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,0 +1,33 @@
+# Glossary
+
+Short definitions used in these docs. Official longer pages are linked where they still match the source.
+
+| Term | Meaning |
+| --- | --- |
+| **N3** | Current Neo protocol generation. Developed on `master-n3` in `neo` and `neo-node`. |
+| **NEO-4 / `master`** | Next protocol line in `neo-project/neo` (`master` branch). Do not mix PRs between `master` and `master-n3`. |
+| **Full node** | A process that stores the chain, speaks P2P, and can verify every block. Neo-CLI is a full node. |
+| **Neo-CLI** | Command-line full node. Source: [neo-project/neo-node](https://github.com/neo-project/neo-node) (`src/Neo.CLI`). |
+| **Plugin** | DLL dropped into Neo-CLI’s `Plugins/` folder (RPC, storage engine, consensus, oracle, logs). |
+| **dBFT** | Delegated Byzantine Fault Tolerance — how N3 agrees on the next block. [Official page](https://developers.neo.org/docs/n3/foundation/consensus/consensus_algorithm). |
+| **Committee** | Elected accounts that vote on network parameters. |
+| **Validators / consensus nodes** | The subset that actually produce blocks (via DBFTPlugin). |
+| **Mempool** | In-memory list of unconfirmed transactions (`MemoryPool` in this repo). |
+| **GAS** | Fee token. Pays network fee (size / verification) and system fee (VM execution). |
+| **NEO** | Governance token; voting weight. |
+| **datoshi** | 10⁻⁸ GAS (smallest typical unit in APIs). |
+| **Script hash / UInt160** | 20-byte contract or account identifier. Addresses like `N…` are a Base58 form of a script hash. |
+| **UInt256** | 32-byte hash (block hash, tx hash). |
+| **NEF** | Neo Executable Format — compiled contract bytecode file (`.nef`). |
+| **Manifest** | `*.manifest.json` describing contract methods, permissions, events. |
+| **NeoVM** | Stack machine that runs NEF. Repo: [neo-project/neo-vm](https://github.com/neo-project/neo-vm). |
+| **Opcode** | One VM instruction (`PUSH1`, `SYSCALL`, `RET`, …). |
+| **Syscall / interop** | Call from the VM into the host (`System.Runtime.CheckWitness`, storage, …) implemented in `ApplicationEngine`. |
+| **ApplicationEngine** | Neo’s host around NeoVM: fees, syscalls, snapshots. Lives in **this** repo, not neo-vm. |
+| **Native contract** | Built-in contract (NEO, GAS, Policy, …) implemented in C# in `src/Neo/SmartContract/Native`. |
+| **Hardfork** | Named protocol upgrade (`HF_Huyao`, `HF_Gorgon`, …) activated at a block height. |
+| **Snapshot / `DataCache`** | Isolated view of storage for one execution or block persist. See [Persistence](persistence-architecture.md). |
+| **StorageKey** | `contract id + key bytes` used in the store. |
+| **RPC** | JSON-HTTP API (`getblock`, `invokescript`, …). Plugin: RpcServer. Ports: see [Neo node](neo-node.md). |
+| **Witness** | Signature (or contract) that authorizes a transaction. |
+| **NEP** | Neo Enhancement Proposal — [neo-project/proposals](https://github.com/neo-project/proposals). NEP-17 is the fungible token standard. |

--- a/docs/how-to/build-and-test.md
+++ b/docs/how-to/build-and-test.md
@@ -1,0 +1,94 @@
+# How to: build and test
+
+Covers all three official repositories. Use **.NET 10**.
+
+## Check the SDK
+
+```bash
+dotnet --version
+```
+
+You want a **10.x** SDK. The projects set `<TargetFramework>net10.0</TargetFramework>` (neo, neo-node, neo-vm).
+
+## 1. Protocol library — `neo-project/neo`
+
+```bash
+git clone https://github.com/neo-project/neo.git
+cd neo
+git checkout master-n3
+```
+
+Restore and test:
+
+```bash
+dotnet test tests/Neo.UnitTests/Neo.UnitTests.csproj
+```
+
+Useful filters:
+
+```bash
+dotnet test tests/Neo.UnitTests/Neo.UnitTests.csproj --filter "FullyQualifiedName~UT_StdLib"
+```
+
+Other test projects live under `tests/` (`Neo.Json.UnitTests`, `Neo.Extensions.Tests`, …).
+
+Open `neo.sln` in your IDE. TreatWarningsAsErrors is on; fix warnings, do not suppress them without a reason.
+
+### Which branch?
+
+| Work | Branch |
+| --- | --- |
+| N3 protocol, current mainnet rules | `master-n3` |
+| NEO-4 | `master` |
+
+Do not open an N3 bugfix against `master`.
+
+## 2. Node — `neo-project/neo-node`
+
+```bash
+git clone https://github.com/neo-project/neo-node.git
+cd neo-node
+git checkout master-n3
+dotnet test
+```
+
+Publish CLI:
+
+```bash
+dotnet publish src/Neo.CLI -c Release -o ./publish
+```
+
+Then [run a node](run-a-node.md) from `./publish`.
+
+The neo-node README still shows `cd neo-node/neo-cli`. The project path is **`src/Neo.CLI`**.
+
+## 3. VM — `neo-project/neo-vm`
+
+```bash
+git clone https://github.com/neo-project/neo-vm.git
+cd neo-vm
+git checkout master
+dotnet test tests/Neo.VM.Tests
+```
+
+## Working on a feature that spans repos
+
+Example: a new opcode that native contracts will use.
+
+1. Implement and test in **neo-vm**.
+2. Bump / ProjectReference the VM in **neo**, add host tests (fees, syscalls).
+3. If CLI must expose it, change **neo-node** last.
+
+Core-dev practice is to land VM then library then node, so binaries stay consistent.
+
+## If tests fail on your machine
+
+- Confirm `net10.0` is installed: `dotnet --list-sdks`
+- On this repo, tests are **not parallel** by default (`DoNotParallelize` unless a project opts in)
+- Native store tests need the right native DLL on Windows (LevelDB from neo-project)
+
+## Next
+
+- [Run a node](run-a-node.md)
+- [Contribute](contribute.md)
+- [Neo core](../neo-core.md)

--- a/docs/how-to/contribute.md
+++ b/docs/how-to/contribute.md
@@ -1,0 +1,56 @@
+# How to: contribute
+
+Rules below match [CONTRIBUTING.md](../../CONTRIBUTING.md) and the root [README](../../README.md#contributing).
+
+## Pick the right repository
+
+| Change | Open the PR on |
+| --- | --- |
+| Native contracts, ledger, P2P, `ApplicationEngine`, `DataCache` | **[neo-project/neo](https://github.com/neo-project/neo)** (this repo) |
+| Neo-CLI commands, plugins, `config.json` defaults | **[neo-project/neo-node](https://github.com/neo-project/neo-node)** |
+| Opcodes, `ExecutionEngine`, VM types | **[neo-project/neo-vm](https://github.com/neo-project/neo-vm)** |
+
+A feature that needs all three should be described in one issue and implemented as **stacked PRs** (VM → neo → neo-node).
+
+## Branch names
+
+On **neo** and **neo-node**:
+
+- `master-n3` — N3 (current public networks)
+- `master` — NEO-4 (neo only; neo-node also uses `master-n3` for N3)
+
+On **neo-vm**:
+
+- `master` — current VM
+
+## Workflow (this repo)
+
+```bash
+git clone https://github.com/<you>/neo.git
+cd neo
+git remote add neo https://github.com/neo-project/neo.git
+git fetch neo
+git checkout -b docs/your-topic neo/master-n3   # or feature/… from master-n3
+```
+
+1. Discuss non-trivial features in an issue first (`discussion` / `design` labels).
+2. Add unit tests (`tests/Neo.UnitTests`).
+3. Wait for **two** approvals on N3; leave **24 hours** after the last approval when you can.
+4. Do not merge your own PR unless you are a maintainer following those rules.
+
+Beginner-friendly issues: cosmetic and house-keeping labels (see CONTRIBUTING.md).
+
+## Coding habits
+
+- `TreatWarningsAsErrors` is on
+- Prefer existing test patterns (`TestProtocolSettings.Default`, `TestBlockchain.GetTestSnapshotCache()`)
+- Hardfork-gate consensus changes
+- Do not add secrets or real private keys to tests
+
+## Security
+
+Report vulnerabilities via the [security policy](https://github.com/neo-project/neo/security/policy), not a public issue. Bounty: [neo.org/bounty](https://neo.org/bounty).
+
+## Questions
+
+GitHub issues are for bugs and features. Chat: [Discord](https://discord.com/invite/rvZFQ5382k).

--- a/docs/how-to/run-a-node.md
+++ b/docs/how-to/run-a-node.md
@@ -1,0 +1,128 @@
+# How to: run a Neo node
+
+This is the practical path using **[neo-project/neo-node](https://github.com/neo-project/neo-node)**. You do not start a node from the `neo` protocol repo alone.
+
+## Option A — pre-built release
+
+1. Open [neo-node releases](https://github.com/neo-project/neo-node/releases) (not the old `neo-project/neo-cli` repo).
+2. Download the zip for your OS.
+3. Unzip. On Linux/macOS you may need `chmod +x` on the binary.
+4. Put at least one **storage plugin** in `Plugins/` if the zip does not already include it (LevelDBStore or RocksDBStore).
+5. Run:
+
+```bash
+./neo-cli          # Linux / macOS
+# or double-click neo-cli.exe on Windows
+```
+
+You should get a `neo>` prompt. Run `show state`. Height will climb as peers send blocks.
+
+## Option B — compile from source (verified against current tree)
+
+Prerequisites: Git, **.NET 10 SDK**.
+
+**Linux packages** (for LevelDB; names vary):
+
+```bash
+# Debian/Ubuntu (current, not only 14/16/18)
+sudo apt-get install libleveldb-dev sqlite3 libsqlite3-dev
+```
+
+**macOS:**
+
+```bash
+brew install leveldb
+```
+
+**Windows:** use the [Neo LevelDB build](https://github.com/neo-project/leveldb) and place `libleveldb.dll` next to the CLI if the plugin requires it.
+
+Clone and publish:
+
+```bash
+git clone https://github.com/neo-project/neo-node.git
+cd neo-node
+git checkout master-n3
+
+dotnet publish src/Neo.CLI -c Release -o ./publish
+cd publish
+```
+
+Copy plugin output into `./publish/Plugins/<PluginName>/` (each plugin’s `dotnet publish` output, including its `plugin.json` / `config.json`). Minimum for a syncing node:
+
+- `LevelDBStore` **or** `RocksDBStore`
+- optional: `RpcServer`, `ApplicationLogs`
+
+Start:
+
+```bash
+dotnet Neo.CLI.dll
+# or the published executable name on your OS
+```
+
+## First commands
+
+```text
+neo> help
+neo> show state
+neo> plugins
+```
+
+Create a wallet only if you need to send or deploy (not required just to sync):
+
+```text
+neo> create wallet wallet.json
+neo> open wallet wallet.json
+```
+
+## RPC
+
+Install/enable **RpcServer**, then from another terminal:
+
+```bash
+curl -X POST http://127.0.0.1:10332 \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"getblockcount","params":[],"id":1}'
+```
+
+TestNet uses **20332**. API catalog: [RPC methods](https://developers.neo.org/docs/n3/reference/rpc/latest-version/api).
+
+Do not expose 10332 to the world with an open wallet.
+
+## Consensus (private net)
+
+You need **DBFTPlugin**, a wallet that holds the consensus keys, matching `protocol.json` / `config.json`, and:
+
+```text
+neo> open wallet <cn-wallet.json>
+neo> start consensus
+```
+
+Public MainNet consensus is for elected CNs. For local experiments use [neo-express](https://github.com/neo-project/neo-express) unless you are testing the real CLI.
+
+## Docker
+
+From neo-node:
+
+```bash
+cd src/Neo.CLI/Docker
+docker build -t neo-cli .
+docker run -p 10332:10332 -p 10333:10333 --name=neo-cli-mainnet neo-cli
+```
+
+Attach with `docker exec -it …` as described in the neo-node README.
+
+## If it does not start
+
+| Symptom | Check |
+| --- | --- |
+| Immediate exit, no prompt | Missing `config.json`, or wrong working directory |
+| “no storage provider” | No LevelDB/RocksDB plugin in `Plugins/` |
+| Native DLL error | LevelDB not on PATH / not next to the binary |
+| RPC connection refused | RpcServer plugin not loaded; `plugins` command |
+| Height stuck at 0 | P2P port 10333 firewalled; seeds in config |
+
+## Next
+
+- [Neo node overview](../neo-node.md)
+- [Smart contracts](smart-contracts.md)
+- [CLI command reference](https://developers.neo.org/docs/n3/node/cli/cli)

--- a/docs/how-to/smart-contracts.md
+++ b/docs/how-to/smart-contracts.md
@@ -1,0 +1,72 @@
+# How to: smart contracts (C# stack)
+
+Contracts are **not** written inside `neo-project/neo`. You write C# (or another supported language), compile to **NEF + manifest**, then deploy with Neo-CLI or an SDK.
+
+## Pieces
+
+| Piece | Repository | Role |
+| --- | --- | --- |
+| Compiler / devpack | [neo-devpack-dotnet](https://github.com/neo-project/neo-devpack-dotnet) | C# → NeoVM bytecode (`.nef`) + `manifest.json` |
+| VM | [neo-vm](https://github.com/neo-project/neo-vm) | Runs opcodes |
+| Host | [neo](https://github.com/neo-project/neo) (`ApplicationEngine`) | Syscalls, storage, fees |
+| Node | [neo-node](https://github.com/neo-project/neo-node) | `deploy` / `invoke` commands, RPC |
+
+Official deploy guide: [Deploying smart contracts](https://developers.neo.org/docs/n3/develop/deploy/deploy). Interop list: [Smart contract API](https://developers.neo.org/docs/n3/reference/scapi/interop).
+
+## Mental model
+
+1. You write a class with methods the manifest will export.
+2. The compiler emits a **NEF** (bytecode) and a **manifest** (methods, permissions, events).
+3. `deploy` creates a transaction to `ContractManagement`.
+4. Later `invoke` builds a script that `CALLT`s your method.
+5. Every node runs the same script in NeoVM. If your code uses `DateTime.Now` or random without the chain’s `Runtime.GetRandom`, nodes would disagree — the compiler and runtime forbid that class of mistake.
+
+## Local loop (beginner)
+
+1. Install the SDK / Neo Blockchain Toolkit, or follow current neo-devpack docs.
+2. Compile → `YourContract.nef` + `YourContract.manifest.json`.
+3. Run [Neo-CLI](run-a-node.md) on TestNet or a private net.
+4. Open a wallet that has GAS (deployment costs system fee).
+5. Deploy:
+
+```text
+neo> open wallet wallet.json
+neo> deploy YourContract.nef YourContract.manifest.json
+```
+
+6. Invoke (example):
+
+```text
+neo> invoke 0x<scripthash> symbol
+```
+
+`VM State: HALT` means success. `FAULT` means the engine aborted (exception, missing witness, out of GAS).
+
+Dry-run RPC `invokefunction` does **not** persist storage; only a relayed transaction does.
+
+## Native contracts you can call
+
+You do not deploy these; they already exist. From CLI: `list nativecontract`.
+
+Typical hashes (N3, same on MainNet/TestNet for natives):
+
+| Name | Hash (from current CLI docs / source) |
+| --- | --- |
+| ContractManagement | `0xfffdc93764dbaddd97c48f252a53ea4643faa3fd` |
+| NeoToken | `0xef4073a0f2b305a38ec4050e4d3d28bc40ea63f5` |
+| GasToken | `0xd2a4cff31913016155e38e474a2c06d08be276cf` |
+| PolicyContract | `0xcc5e4edd9f5f8dba8bb65734541df7a1c081c67b` |
+| StdLib | `0xacce6fd80d44e1796aa0c2c625e9e4e0ce39efc0` |
+| OracleContract | `0xfe924b7cfe89ddd271abaf7210a80a7e11178758` |
+
+If a tutorial lists **NameService** as native, see [official docs notes](../reference/official-docs.md).
+
+## When you must change *this* repo
+
+Only if you are changing **protocol** behavior: a new syscall, a native method, a hardfork, or fee rules. Application logic stays in your contract project.
+
+## Next
+
+- [NeoVM](../neo-vm.md)
+- [Architecture](../architecture.md)
+- Examples: [developers.neo.org tutorials](https://developers.neo.org/tutorials)

--- a/docs/neo-core.md
+++ b/docs/neo-core.md
@@ -1,0 +1,99 @@
+# Neo core library (`neo-project/neo`)
+
+This is the repository you are in. It implements the **Neo N3 protocol in C#**: state, networking, native contracts, and the host that runs NeoVM.
+
+It is **not** the process that binds ports 10332/10333. That process is [Neo-CLI in neo-node](neo-node.md).
+
+- Source: [github.com/neo-project/neo](https://github.com/neo-project/neo)
+- Default N3 branch: **`master-n3`**
+- Next generation: **`master`** (NEO-4)
+- Current package prefix: **3.10.2**, target **net10.0** (`src/Directory.Build.props`)
+
+## What this library is responsible for
+
+- **Protocol settings** — magic, seed list, hardfork heights (`ProtocolSettings`)
+- **Blocks and transactions** — headers, witnesses, attributes
+- **Ledger** — persist blocks, apply native contract `OnPersist` / `PostPersist`
+- **Mempool** — unverified vs verified transactions
+- **P2P** — inventory, getdata, headers/blocks sync (`TaskManager`)
+- **Persistence API** — `IStore` / `DataCache` (the *engine* is a node plugin)
+- **Smart contract host** — `ApplicationEngine`, interop, native contracts
+- **Wallets** — NEP-6 JSON, accounts, signing (used by CLI)
+
+## Project layout (GitHub `master-n3`)
+
+On the official GitHub tree, `src/` contains:
+
+| Project | Purpose |
+| --- | --- |
+| `Neo` | Protocol implementation |
+| `Neo.Extensions` | helpers |
+| `Neo.IO` | `ISerializable`, caches |
+| `Neo.Json` | JSON tokens used by RPC/wallets |
+
+Some local checkouts (including developer forks) may also contain `Neo.CLI` or plugins. Treat those as **local extras**. The published split is neo / neo-node / neo-vm.
+
+A more detailed folder list is in the root [README](../README.md#project-structure).
+
+## Native contracts (from current source)
+
+Implemented under `src/Neo/SmartContract/Native/`:
+
+| Contract | Role |
+| --- | --- |
+| `ContractManagement` | Deploy / update / destroy contracts |
+| `StdLib` | `serialize`, `jsonDeserialize`, `stringSplit`, base58, … |
+| `CryptoLib` | hashes, signature verify, BLS12-381 |
+| `LedgerContract` | query blocks and transactions from contracts |
+| `NeoToken` | NEO asset, voting, GAS generation |
+| `GasToken` | GAS asset |
+| `PolicyContract` | fees, blocked accounts, exec fee factor |
+| `RoleManagement` | oracle / state validator / notary roles |
+| `OracleContract` | native oracle requests |
+| `Notary` | notary assistance |
+| `Treasury` | treasury |
+
+Name Service is **not** in this list. It lives in [non-native-contracts](https://github.com/neo-project/non-native-contracts). Older CLI dumps on developers.neo.org still show `NameService` next to natives — that is stale ([notes](reference/official-docs.md)).
+
+## Hardforks
+
+`Hardfork` in `src/Neo/Hardfork.cs` currently includes Aspidochelone through **Iara**. Heights are configured per network in protocol settings. A feature gated on `HF_Huyao` does nothing until that height.
+
+When you change VM or fee behavior, always ask: **is this a hardfork?** If yes, gate it and add tests with the fork disabled *and* enabled.
+
+## ApplicationEngine vs NeoVM
+
+```
+Contract NEF
+    → ApplicationEngine.Execute()     // neo: culture, fees, snapshot
+        → ExecutionEngine (NeoVM)     // neo-vm: opcodes
+            → SYSCALL
+                → interop in ApplicationEngine  // storage, CheckWitness, …
+```
+
+Changing `ADD` belongs in **neo-vm**. Changing `System.Storage.Put` or opcode *prices* in the host belongs in **neo**.
+
+## Persistence
+
+The library defines **interfaces**. LevelDB and RocksDB are **plugins in neo-node**. In-memory `MemoryStore` is used by unit tests.
+
+Read [Persistence architecture](persistence-architecture.md) after this page.
+
+## How to work in this repo
+
+```bash
+git clone https://github.com/neo-project/neo.git
+cd neo
+git checkout master-n3
+dotnet test tests/Neo.UnitTests/Neo.UnitTests.csproj
+```
+
+More: [How to: build and test](how-to/build-and-test.md).
+
+## Related reading
+
+- [Getting started](getting-started.md)
+- [Architecture](architecture.md)
+- [Serialization format](serialization-format.md)
+- [Contribute](how-to/contribute.md)
+- Unit tests as examples: `tests/Neo.UnitTests/SmartContract/Native/`

--- a/docs/neo-node.md
+++ b/docs/neo-node.md
@@ -1,0 +1,120 @@
+# Neo node (`neo-project/neo-node`)
+
+Neo-CLI is the full-node program: P2P, optional RPC, optional consensus, wallet commands.
+
+- Source: [github.com/neo-project/neo-node](https://github.com/neo-project/neo-node)
+- N3 branch: **`master-n3`**
+- Solution: `neo-node.sln`
+- Targets **net10.0**, version prefix **3.10.2** (same generation as this library)
+
+This documentation lives in **neo-project/neo** so beginners can see the whole stack in one place. Changes to CLI or plugins are still submitted on the **neo-node** repository.
+
+## What you get
+
+From the [official node introduction](https://developers.neo.org/docs/n3/node/Introduction) (feature table is still useful):
+
+| | Neo-CLI (this repo) | Neo-GUI |
+| --- | --- | --- |
+| Interface | Command line | Graphical |
+| Wallet / transfer / vote | Yes | Yes |
+| JSON-RPC | Yes (RpcServer plugin) | No |
+| Participate in consensus | Yes (DBFTPlugin) | No |
+
+GUI for N3 is maintained separately: [neo-ngd/Neo3-GUI](https://github.com/neo-ngd/Neo3-GUI). The historical **neo-gui** folder inside neo-node is not the app most users download.
+
+## Layout on GitHub
+
+```
+neo-node/
+  src/Neo.CLI/            # the executable project
+  src/Neo.ConsoleService/ # prompt, commands
+  plugins/                # optional DLLs
+    RpcServer/
+    DBFTPlugin/
+    LevelDBStore/
+    RocksDBStore/
+    ApplicationLogs/
+    OracleService/
+    StateService/
+    TokensTracker/
+    StorageDumper/
+    RestServer/
+    SQLiteWallet/
+    SignClient/
+    …
+  tests/
+```
+
+CLI **depends on** `neo-project/neo` (this library) and **neo-vm**.
+
+## Plugins you will actually use
+
+| Plugin | Why |
+| --- | --- |
+| **LevelDBStore** or **RocksDBStore** | Persist the chain. Without one, many setups cannot keep state on disk. |
+| **RpcServer** | `getblock`, `invokescript`, wallets over HTTP |
+| **ApplicationLogs** | Contract `notify` logs (needed for many indexers) |
+| **DBFTPlugin** | `start consensus` on a private net or as a CN |
+| **TokensTracker** | NEP-17 balance RPCs |
+| **OracleService** | If the node provides oracle |
+| **StateService** | MPT state root / proofs |
+
+Load plugins by putting their published output in `Plugins/<Name>/` next to the CLI, or use the `install <Name>` command (downloads a release zip; restart CLI).
+
+## Ports (still correct)
+
+| | MainNet | TestNet |
+| --- | --- | --- |
+| RPC HTTP | **10332** | **20332** |
+| RPC HTTPS | 10331 | 20331 |
+| P2P TCP | **10333** | **20333** |
+| P2P WS | 10334 | 20334 |
+
+**Security:** Neo-CLI does not require a password to call RPC after the wallet is open, and it does not remotely lock the wallet. Bind RPC to localhost or put it behind a firewall. This warning on developers.neo.org is still valid.
+
+## Commands worth knowing first
+
+Full tables: [CLI command reference](https://developers.neo.org/docs/n3/node/cli/cli) (command names match current CLI).
+
+After `neo>` appears:
+
+```text
+help
+show state
+plugins
+create wallet wallet.json
+open wallet wallet.json
+list nativecontract
+```
+
+Wallet must be open for `send`, `deploy`, `invoke`, `start consensus`.
+
+## Verified vs stale (neo-node README)
+
+The neo-node README on `master-n3` still says:
+
+- “Install .NET Core” and “Ubuntu LTS 14, 16 and 18”
+- `cd neo-node/neo-cli` then `dotnet neo-cli.dll`
+
+**Current source:**
+
+- SDK is **.NET 10**, project is `src/Neo.CLI`
+- Publish with `dotnet publish src/Neo.CLI -c Release`
+- Run the published `Neo.CLI` / `neo-cli` binary from the output directory, with `config.json` and `Plugins/`
+
+Step-by-step: [How to: run a node](how-to/run-a-node.md).
+
+## Docker
+
+neo-node ships a Docker context under `src/Neo.CLI/Docker` (see that README). Typical ports: `10332` (RPC) and `10333` (P2P).
+
+## Logging and fast sync
+
+- Logs: ApplicationLogs plugin
+- Faster catch-up: offline block files — [sync blocks](https://docs.neo.org/docs/en-us/node/syncblocks.html) (older docs URL; the idea is still “import a chain dump instead of P2P from genesis”)
+
+## Next
+
+- [How to: run a node](how-to/run-a-node.md)
+- [Architecture](architecture.md)
+- [Neo core](neo-core.md)

--- a/docs/neo-vm.md
+++ b/docs/neo-vm.md
@@ -1,0 +1,80 @@
+# NeoVM (`neo-project/neo-vm`)
+
+NeoVM is a small **stack machine** that runs contract bytecode. It is published as NuGet package **`Neo.VM`**.
+
+- Source: [github.com/neo-project/neo-vm](https://github.com/neo-project/neo-vm)
+- Default branch: **`master`** (there is no `master-n3` on this repo)
+- Target: **net10.0**, version prefix **3.10.2**
+- Official concept page (accurate): [NeoVM](https://developers.neo.org/docs/n3/foundation/neovm)
+
+This guide lives in **neo-project/neo** so VM, host, and node are documented together. Opcode PRs still go to **neo-vm**.
+
+## What NeoVM is *not*
+
+- It does **not** store blocks.
+- It does **not** implement `System.Storage.*` or `CheckWitness`.
+- It does **not** charge GAS by itself.
+
+Those belong to **`ApplicationEngine`** in [neo-core](neo-core.md). The VM calls out through an interop/syscall interface; the host decides what each syscall does and how much it costs.
+
+## Pieces (from the official page + source)
+
+| Piece | Role |
+| --- | --- |
+| **ExecutionEngine** | Fetches the next instruction and runs it |
+| **Invocation stack** | Nested call frames (`CALL`, `CALLT`, contract calls) |
+| **Evaluation stack** | Data the current instruction reads/writes |
+| **Result stack** | Values left when the script finishes (`HALT`) |
+| **Jump table** | Maps opcodes to C# handlers (hardforks can swap tables) |
+
+Execution:
+
+1. Compiler (for example [neo-devpack-dotnet](https://github.com/neo-project/neo-devpack-dotnet)) emits a **NEF** (NeoVM bytecode).
+2. Host creates an engine, loads the script, pushes a context.
+3. Loop: read opcode → handler → maybe syscall into the host.
+4. `RET`/`ABORT` or empty instruction pointer → `HALT` or `FAULT`.
+
+## Use it from another app
+
+```bash
+dotnet add package Neo.VM
+```
+
+You can embed the VM in tests or non-chain tools. For chain execution always use `ApplicationEngine` so fees and storage match consensus.
+
+## Layout
+
+```
+neo-vm/
+  src/Neo.VM/          # engine, instructions, types
+  tests/Neo.VM.Tests/  # opcode tests
+  benchmarks/
+  neo-vm.sln
+```
+
+## Build and test
+
+```bash
+git clone https://github.com/neo-project/neo-vm.git
+cd neo-vm
+git checkout master
+dotnet test tests/Neo.VM.Tests
+```
+
+When you change an opcode, add a test that runs a tiny script and checks the stack and `VMState` (`HALT` vs `FAULT`).
+
+## How this repo uses NeoVM
+
+In **neo**:
+
+- `ApplicationEngine` subclasses/hosts the VM
+- Opcode **prices** and some jump tables live next to the engine
+- Interop methods are registered as syscalls
+
+A hardfork that changes instruction *semantics* needs a **neo-vm** change. A hardfork that only changes *price* or which jump table the host selects may be **neo**-only.
+
+## Related
+
+- [Architecture](architecture.md)
+- [How to: smart contracts](how-to/smart-contracts.md)
+- [How to: build and test](how-to/build-and-test.md)

--- a/docs/persistence-architecture.md
+++ b/docs/persistence-architecture.md
@@ -1,5 +1,9 @@
 # Neo Persistence System - Class Relationships
 
+**Audience:** people changing stores, snapshots, or `DataCache`. If you are new to Neo, start with [Getting started](getting-started.md) and [Architecture](architecture.md). Persistence *engines* (LevelDB, RocksDB) are plugins in [neo-node](neo-node.md); this file describes the **interfaces in this library**.
+
+**Docs index:** [README](README.md)
+
 ## Interface Hierarchy
 
 ```

--- a/docs/reference/official-docs.md
+++ b/docs/reference/official-docs.md
@@ -1,0 +1,39 @@
+# Official docs notes
+
+We used [developers.neo.org](https://developers.neo.org/) while writing these guides and checked the **current GitHub trees**. This page records mismatches so you do not follow a dead link.
+
+## Still accurate
+
+| Topic | URL | Check |
+| --- | --- | --- |
+| Platform intro | [foundation/introduction](https://developers.neo.org/docs/n3/foundation/introduction) | Matches N3 product story |
+| NeoVM architecture | [foundation/neovm](https://developers.neo.org/docs/n3/foundation/neovm) | Matches neo-vm README + `ExecutionEngine` |
+| CLI commands | [node/cli/cli](https://developers.neo.org/docs/n3/node/cli/cli) | Command names (`show state`, `deploy`, `invoke`, …) still match Neo-CLI |
+| RPC catalog | [reference/rpc](https://developers.neo.org/docs/n3/reference/rpc/latest-version/api) | Use as API index |
+| Node ports | [node/Introduction](https://developers.neo.org/docs/n3/node/Introduction) | 10332/10333 MainNet, 20332/20333 TestNet |
+| CLI vs GUI feature table | same page | Still the right split (RPC + consensus = CLI) |
+| dBFT / governance | [consensus](https://developers.neo.org/docs/n3/foundation/consensus/consensus_algorithm), [governance](https://developers.neo.org/docs/n3/foundation/governance) | Concept pages |
+
+## Stale or easy to get wrong
+
+| What you might see | Current reality |
+| --- | --- |
+| Download / source **neo-project/neo-cli** | CLI source is **[neo-project/neo-node](https://github.com/neo-project/neo-node)** (`src/Neo.CLI`). Releases: [neo-node/releases](https://github.com/neo-project/neo-node/releases). |
+| neo-node README: `cd neo-node/neo-cli` | Path is `src/Neo.CLI` |
+| neo-node README: “.NET Core”, Ubuntu 14/16/18 | Projects target **.NET 10** (`net10.0`) |
+| `dotnet neo-cli.dll` | Published output may be `Neo.CLI.dll` / `neo-cli`; run from the publish folder |
+| `list nativecontract` sample includes **NameService** | Not a native contract in current `neo` source. See [non-native-contracts](https://github.com/neo-project/non-native-contracts). |
+| Root README “Documentation »” → docs.neo.org | N3 developer hub is [developers.neo.org](https://developers.neo.org/) |
+| This git workspace containing `src/Neo.CLI` | Official **neo-project/neo** `master-n3` `src/` is `Neo`, `Neo.IO`, `Neo.Json`, `Neo.Extensions` only. Extra folders in a fork are local. |
+
+## How we verified
+
+- `gh api repos/neo-project/neo/contents/src?ref=master-n3`
+- `gh api repos/neo-project/neo-node/contents/src?ref=master-n3` and `…/plugins`
+- `gh api repos/neo-project/neo-vm/contents/src?ref=master`
+- `src/Directory.Build.props` in this repo: `VersionPrefix` 3.10.2, tests `net10.0`
+- neo-node and neo-vm csproj / Directory.Build.props: `net10.0`, `3.10.2`
+- `src/Neo/SmartContract/Native/` file list for native contracts
+- `src/Neo/Hardfork.cs` for hardfork names
+
+When official pages and GitHub disagree, **these docs follow GitHub `master-n3` / neo-vm `master`**.

--- a/docs/serialization-format.md
+++ b/docs/serialization-format.md
@@ -1,5 +1,9 @@
 # Neo Serialization Format
 
+**Audience:** protocol and plugin developers. Beginners: [Getting started](getting-started.md). This format is implemented in `src/Neo.IO` in **this** repository (`neo-project/neo`).
+
+**Docs index:** [README](README.md)
+
 This document describes the binary serialization format used by the Neo blockchain platform. The format is designed for efficient serialization and deserialization of blockchain data structures.
 
 ## Overview


### PR DESCRIPTION
# Description

Add beginner-friendly documentation in `docs/` covering this repository (`neo-project/neo`) and the related **neo-node** and **neo-vm** repos, and link every guide from the root README table of contents.

Official N3 pages on [developers.neo.org](https://developers.neo.org/) were used for concepts, CLI commands, RPC, and ports, then checked against current GitHub trees. Stale items (CLI still documented as `neo-project/neo-cli`, `cd neo-cli`, .NET Core / Ubuntu 14–18, NameService listed as native) are called out in `docs/reference/official-docs.md`.

# Change Log

- Add `docs/README.md` hub and beginner guides (`getting-started`, `architecture`, `neo-core`, `neo-node`, `neo-vm`, glossary)
- Add how-tos: build and test, run a node, smart contracts, contribute
- Add `docs/reference/official-docs.md` (verified vs stale official links)
- Link the docs from the root README table of contents and the Documentation section
- Point existing persistence / serialization docs back to the hub
- Link `CONTRIBUTING.md` to the contribute how-to

## Type of change

- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] Local Computer Tests (links and repo layout checked against `neo-project/neo` `master-n3`, `neo-project/neo-node` `master-n3`, `neo-project/neo-vm` `master`)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
