### PR TITLE
KeepAlive pooled Buffers that leave the VM (depends on neo-vm#595)

### DIFF
--- a/src/Neo/Ledger/Blockchain.ApplicationExecuted.cs
+++ b/src/Neo/Ledger/Blockchain.ApplicationExecuted.cs
@@ -65,6 +65,9 @@ namespace Neo.Ledger
                 Exception = engine.FaultException;
                 Stack = [.. engine.ResultStack];
                 Notifications = [.. engine.Notifications];
+                StackItemKeepAlive.KeepAll(Stack);
+                foreach (var notification in Notifications)
+                    StackItemKeepAlive.Keep(notification.State);
             }
         }
     }

--- a/src/Neo/SmartContract/BinarySerializer.cs
+++ b/src/Neo/SmartContract/BinarySerializer.cs
@@ -100,7 +100,9 @@ namespace Neo.SmartContract
                         break;
                     case StackItemType.Buffer:
                         var memory = reader.ReadVarMemory((int)maxSize);
-                        deserialized.Push(new Buffer(memory.Span));
+                        var buffer = new Buffer(memory.Span);
+                        buffer.KeepAlive();
+                        deserialized.Push(buffer);
                         break;
                     case StackItemType.Array:
                     case StackItemType.Struct:

--- a/src/Neo/SmartContract/StackItemKeepAlive.cs
+++ b/src/Neo/SmartContract/StackItemKeepAlive.cs
@@ -1,0 +1,45 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// StackItemKeepAlive.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Neo.VM.Types;
+using System.Collections.Generic;
+using Buffer = Neo.VM.Types.Buffer;
+
+namespace Neo.SmartContract
+{
+    /// <summary>
+    /// Pins pooled <see cref="Buffer"/> memory that leaves the VM
+    /// (neo-vm#595 <c>IMemoryOwner</c>). Call before the engine disposes
+    /// items back to <see cref="System.Buffers.MemoryPool{T}"/>.
+    /// </summary>
+    internal static class StackItemKeepAlive
+    {
+        public static void Keep(StackItem? item)
+        {
+            switch (item)
+            {
+                case Buffer buffer:
+                    buffer.KeepAlive();
+                    break;
+                case CompoundType compound:
+                    foreach (var child in compound.SubItems)
+                        Keep(child);
+                    break;
+            }
+        }
+
+        public static void KeepAll(IEnumerable<StackItem> items)
+        {
+            foreach (var item in items)
+                Keep(item);
+        }
+    }
+}

--- a/tests/Neo.UnitTests/Ledger/UT_ApplicationExecuted.cs
+++ b/tests/Neo.UnitTests/Ledger/UT_ApplicationExecuted.cs
@@ -15,6 +15,7 @@ using Neo.Network.P2P.Payloads;
 using Neo.SmartContract;
 using Neo.VM;
 using System;
+using Buffer = Neo.VM.Types.Buffer;
 
 namespace Neo.UnitTests.Ledger
 {
@@ -36,6 +37,22 @@ namespace Neo.UnitTests.Ledger
             Assert.IsTrue(executed.GasConsumed >= 0);
             Assert.HasCount(1, executed.Stack);
             Assert.IsEmpty(executed.Notifications);
+        }
+
+        [TestMethod]
+        public void FromEngine_NewBuffer_PinsPooledMemory()
+        {
+            var snapshot = TestBlockchain.GetTestSnapshotCache();
+            using var sb = new ScriptBuilder();
+            sb.EmitPush(1);
+            sb.Emit(OpCode.NEWBUFFER);
+            using var engine = ApplicationEngine.Run(sb.ToArray(), snapshot);
+            Assert.AreEqual(VMState.HALT, engine.State);
+
+            var executed = new Blockchain.ApplicationExecuted(engine);
+            Assert.HasCount(1, executed.Stack);
+            Assert.IsInstanceOfType<Buffer>(executed.Stack[0]);
+            Assert.AreEqual(1, executed.Stack[0].GetSpan().Length);
         }
 
         [TestMethod]


### PR DESCRIPTION
# Description

Companion to https://github.com/neo-project/neo-vm/pull/595.

neo-vm#595 backs `Buffer` / `ByteString` with `IMemoryOwner` from `MemoryPool.Shared`. When those items are copied out of the engine (result stack, notifications, `BinarySerializer`), the host must pin them with `KeepAlive()` so later `Cleanup()` does not return the pool memory while neo still holds the item.

# Change Log

- Add `StackItemKeepAlive` to walk `Buffer` and nested compounds
- Pin `ApplicationExecuted.Stack` and notification `State`
- Pin buffers created by `BinarySerializer`
- Test: `NEWBUFFER` result on `ApplicationExecuted` still has a readable span

Fixes # (issue)

## Type of change

- [ ] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Unit Testing
- [ ] Run Application
- [ ] Local Computer Tests
- [ ] No Testing

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Status

**Draft.** CI cannot compile `Buffer.KeepAlive` until neo-vm#595 is in a published `Neo.VM` package.