### PR TITLE
fix(BigDecimal): reject leftover remainder when reducing decimals

### DIFF
--- a/src/Neo/BigDecimal.cs
+++ b/src/Neo/BigDecimal.cs
@@ -101,7 +101,9 @@ namespace Neo
             {
                 var divisor = BigInteger.Pow(10, _decimals - decimals);
                 value = BigInteger.DivRem(_value, divisor, out var remainder);
-                if (remainder > BigInteger.Zero)
+                // DivRem remainder has the sign of the dividend, so a negative
+                // value with a leftover fraction would otherwise be truncated.
+                if (!remainder.IsZero)
                     throw new ArgumentOutOfRangeException(nameof(decimals));
             }
             return new BigDecimal(value, decimals);

--- a/tests/Neo.UnitTests/UT_BigDecimal_Edges.cs
+++ b/tests/Neo.UnitTests/UT_BigDecimal_Edges.cs
@@ -52,6 +52,22 @@ namespace Neo.UnitTests
         }
 
         [TestMethod]
+        public void ChangeDecimals_NegativeWithRemainder_Throws()
+        {
+            var value = new BigDecimal(new BigInteger(-12300), 5);
+            Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => value.ChangeDecimals(2));
+        }
+
+        [TestMethod]
+        public void ChangeDecimals_NegativeExact_Succeeds()
+        {
+            var value = new BigDecimal(new BigInteger(-12300), 5);
+            var result = value.ChangeDecimals(3);
+            Assert.AreEqual(new BigInteger(-123), result.Value);
+            Assert.AreEqual(3, result.Decimals);
+        }
+
+        [TestMethod]
         public void ToString_IncludesDecimals()
         {
             var value = new BigDecimal(new BigInteger(12345), 3);


### PR DESCRIPTION
Same remainder-sign issue as the `ToString` fix in #4733.

`BigInteger.DivRem` keeps the remainder's sign. `ChangeDecimals` used `remainder > 0`, so a negative leftover was treated as exact and truncated. Example: `-0.12300` reduced to 2 decimal places silently became `-0.12` instead of throwing.

## Change
Treat any non-zero remainder as inexact (`!remainder.IsZero`). Cover negative exact and inexact reductions.

Independent of other PRs. Off-chain numeric helper; not consensus-critical.