### PR TITLE
perf(MemoryPool): replace LINQ Intersect with direct signer loops

### DIFF
--- a/src/Neo/Ledger/MemoryPool.cs
+++ b/src/Neo/Ledger/MemoryPool.cs
@@ -410,7 +410,7 @@ namespace Neo.Ledger
                 foreach (var hash in conflicting)
                 {
                     var unsortedTx = _unsortedTransactions[hash];
-                    if (unsortedTx.Tx.Signers.Select(s => s.Account).Contains(author))
+                    if (ContainsAccount(unsortedTx.Tx.Signers, author))
                         conflictsFeeSum += unsortedTx.Tx.NetworkFee;
                     conflictsList.Add(unsortedTx);
                 }
@@ -420,7 +420,7 @@ namespace Neo.Ledger
             {
                 if (_unsortedTransactions.TryGetValue(hash, out var unsortedTx))
                 {
-                    if (!tx.Signers.Select(p => p.Account).Intersect(unsortedTx.Tx.Signers.Select(p => p.Account)).Any()) return false;
+                    if (!HasCommonSigner(tx.Signers, unsortedTx.Tx.Signers)) return false;
                     conflictsFeeSum += unsortedTx.Tx.NetworkFee;
                     conflictsList.Add(unsortedTx);
                 }
@@ -535,26 +535,27 @@ namespace Neo.Ledger
                 foreach (Transaction tx in block.Transactions)
                 {
                     if (!TryRemoveVerified(tx.Hash, out _)) TryRemoveUnVerified(tx.Hash, out _);
-                    var conflictingSigners = tx.Signers.Select(s => s.Account);
                     foreach (var h in tx.GetAttributes<Conflicts>().Select(a => a.Hash))
                     {
-                        if (conflicts.TryGetValue(h, out var signersList))
+                        if (!conflicts.TryGetValue(h, out var signersList))
                         {
-                            signersList.AddRange(conflictingSigners);
-                            continue;
+                            signersList = new List<UInt160>(tx.Signers.Length);
+                            conflicts.Add(h, signersList);
                         }
-                        signersList = conflictingSigners.ToList();
-                        conflicts.Add(h, signersList);
+                        for (int i = 0; i < tx.Signers.Length; i++)
+                            signersList.Add(tx.Signers[i].Account);
                     }
                 }
 
                 // Then remove the transactions conflicting with the accepted ones.
                 // No need to modify VerificationContext as it will be reset afterwards.
-                var persisted = block.Transactions.Select(t => t.Hash);
+                var persisted = new HashSet<UInt256>(block.Transactions.Length);
+                foreach (var t in block.Transactions)
+                    persisted.Add(t.Hash);
                 var stale = new List<UInt256>();
                 foreach (var item in _sortedTransactions)
                 {
-                    if ((conflicts.TryGetValue(item.Tx.Hash, out var signersList) && signersList.Intersect(item.Tx.Signers.Select(s => s.Account)).Any()) || item.Tx.GetAttributes<Conflicts>().Select(a => a.Hash).Intersect(persisted).Any())
+                    if ((conflicts.TryGetValue(item.Tx.Hash, out var signersList) && HasCommonAccount(signersList, item.Tx.Signers)) || ContainsPersistedConflict(item.Tx, persisted))
                     {
                         stale.Add(item.Tx.Hash);
                         conflictingItems.Add(item.Tx);
@@ -711,6 +712,50 @@ namespace Neo.Ledger
             }
 
             return _unverifiedTransactions.Count > 0;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool ContainsAccount(Signer[] signers, UInt160 account)
+        {
+            for (int i = 0; i < signers.Length; i++)
+            {
+                if (signers[i].Account.Equals(account))
+                    return true;
+            }
+            return false;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool HasCommonSigner(Signer[] left, Signer[] right)
+        {
+            for (int i = 0; i < left.Length; i++)
+            {
+                if (ContainsAccount(right, left[i].Account))
+                    return true;
+            }
+            return false;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool HasCommonAccount(List<UInt160> accounts, Signer[] signers)
+        {
+            for (int i = 0; i < accounts.Count; i++)
+            {
+                if (ContainsAccount(signers, accounts[i]))
+                    return true;
+            }
+            return false;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool ContainsPersistedConflict(Transaction tx, HashSet<UInt256> persisted)
+        {
+            foreach (var attr in tx.GetAttributes<Conflicts>())
+            {
+                if (persisted.Contains(attr.Hash))
+                    return true;
+            }
+            return false;
         }
 
         // This method is only for test purpose

--- a/src/Neo/Ledger/MemoryPool.cs
+++ b/src/Neo/Ledger/MemoryPool.cs
@@ -715,7 +715,7 @@ namespace Neo.Ledger
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static bool ContainsAccount(Signer[] signers, UInt160 account)
+        internal static bool ContainsAccount(Signer[] signers, UInt160 account)
         {
             for (int i = 0; i < signers.Length; i++)
             {
@@ -726,7 +726,7 @@ namespace Neo.Ledger
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static bool HasCommonSigner(Signer[] left, Signer[] right)
+        internal static bool HasCommonSigner(Signer[] left, Signer[] right)
         {
             for (int i = 0; i < left.Length; i++)
             {
@@ -737,7 +737,7 @@ namespace Neo.Ledger
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static bool HasCommonAccount(List<UInt160> accounts, Signer[] signers)
+        internal static bool HasCommonAccount(List<UInt160> accounts, Signer[] signers)
         {
             for (int i = 0; i < accounts.Count; i++)
             {
@@ -748,7 +748,7 @@ namespace Neo.Ledger
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static bool ContainsPersistedConflict(Transaction tx, HashSet<UInt256> persisted)
+        internal static bool ContainsPersistedConflict(Transaction tx, HashSet<UInt256> persisted)
         {
             foreach (var attr in tx.GetAttributes<Conflicts>())
             {

--- a/tests/Neo.UnitTests/Ledger/UT_MemoryPool.cs
+++ b/tests/Neo.UnitTests/Ledger/UT_MemoryPool.cs
@@ -1142,5 +1142,142 @@ namespace Neo.UnitTests.Ledger
             var verifiedTxs = _unit.GetSortedVerifiedTransactions();
             VerifyTransactionsSortedDescending(verifiedTxs);
         }
+
+        [TestMethod]
+        public void TryAdd_ConflictWithoutSharedSigner_Rejected()
+        {
+            var snapshot = GetSnapshot();
+            var poolTx = CreateTransaction(100000);
+            Assert.AreEqual(VerifyResult.Succeed, _unit.TryAdd(poolTx, snapshot));
+
+            var outsider = CreateTransaction(200000);
+            outsider.Signers = [new Signer { Account = new UInt160(Crypto.Hash160([9, 9, 9])), Scopes = WitnessScope.None }];
+            outsider.Attributes = [new Conflicts { Hash = poolTx.Hash }];
+
+            Assert.AreEqual(VerifyResult.HasConflicts, _unit.TryAdd(outsider, snapshot));
+            Assert.IsTrue(_unit.ContainsKey(poolTx.Hash));
+            Assert.IsFalse(_unit.ContainsKey(outsider.Hash));
+        }
+
+        [TestMethod]
+        public void TryAdd_ConflictSharesLastSigner_Replaces()
+        {
+            var snapshot = GetSnapshot();
+            var first = senderAccount;
+            var last = new UInt160(Crypto.Hash160([1, 2, 3]));
+
+            var poolTx = CreateTransaction(100000);
+            poolTx.Signers =
+            [
+                new Signer { Account = first, Scopes = WitnessScope.None },
+                new Signer { Account = last, Scopes = WitnessScope.None }
+            ];
+            Assert.AreEqual(VerifyResult.Succeed, _unit.TryAdd(poolTx, snapshot));
+
+            var replacement = CreateTransaction(200000);
+            replacement.Signers = [new Signer { Account = last, Scopes = WitnessScope.None }];
+            replacement.Attributes = [new Conflicts { Hash = poolTx.Hash }];
+
+            Assert.AreEqual(VerifyResult.Succeed, _unit.TryAdd(replacement, snapshot));
+            Assert.IsTrue(_unit.ContainsKey(replacement.Hash));
+            Assert.IsFalse(_unit.ContainsKey(poolTx.Hash));
+        }
+
+        [TestMethod]
+        public void UpdatePoolForBlockPersisted_ConflictSharesSecondarySigner()
+        {
+            var snapshot = GetSnapshot();
+            var primary = senderAccount;
+            var secondary = new UInt160(Crypto.Hash160([7, 7, 7]));
+
+            var mempooled = CreateTransaction(1000);
+            mempooled.Signers = [new Signer { Account = secondary, Scopes = WitnessScope.None }];
+            Assert.AreEqual(VerifyResult.Succeed, _unit.TryAdd(mempooled, snapshot));
+
+            var blockTx = CreateTransaction(1000);
+            blockTx.Signers =
+            [
+                new Signer { Account = primary, Scopes = WitnessScope.None },
+                new Signer { Account = secondary, Scopes = WitnessScope.None }
+            ];
+            blockTx.Attributes = [new Conflicts { Hash = mempooled.Hash }];
+
+            _unit.UpdatePoolForBlockPersisted(new Block
+            {
+                Header = new Header
+                {
+                    PrevHash = null!,
+                    MerkleRoot = null!,
+                    NextConsensus = null!,
+                    Witness = null!
+                },
+                Transactions = [blockTx]
+            }, snapshot);
+
+            Assert.IsFalse(_unit.ContainsKey(mempooled.Hash));
+        }
+
+        [TestMethod]
+        public void UpdatePoolForBlockPersisted_MempoolConflictsPersistedTx()
+        {
+            var snapshot = GetSnapshot();
+            var persisted = CreateTransaction(1000);
+            var mempooled = CreateTransaction(1000);
+            mempooled.Attributes = [new Conflicts { Hash = persisted.Hash }];
+            Assert.AreEqual(VerifyResult.Succeed, _unit.TryAdd(mempooled, snapshot));
+
+            var removed = new List<Transaction>();
+            _unit.TransactionRemoved += (_, e) =>
+            {
+                if (e.Reason == TransactionRemovalReason.Conflict)
+                    removed.AddRange(e.Transactions);
+            };
+
+            _unit.UpdatePoolForBlockPersisted(new Block
+            {
+                Header = new Header
+                {
+                    PrevHash = null!,
+                    MerkleRoot = null!,
+                    NextConsensus = null!,
+                    Witness = null!
+                },
+                Transactions = [persisted]
+            }, snapshot);
+
+            Assert.IsFalse(_unit.ContainsKey(mempooled.Hash));
+            Assert.Contains(mempooled, removed);
+        }
+
+        [TestMethod]
+        public void UpdatePoolForBlockPersisted_TwoBlockTxsAccumulateSigners()
+        {
+            var snapshot = GetSnapshot();
+            var mempooled = CreateTransaction(1000);
+            Assert.AreEqual(VerifyResult.Succeed, _unit.TryAdd(mempooled, snapshot));
+
+            var otherSender = new UInt160(Crypto.Hash160([4, 5, 6]));
+            var first = CreateTransaction(1000);
+            first.Signers = [new Signer { Account = otherSender, Scopes = WitnessScope.None }];
+            first.Attributes = [new Conflicts { Hash = mempooled.Hash }];
+
+            var second = CreateTransaction(1000);
+            second.Signers = [new Signer { Account = senderAccount, Scopes = WitnessScope.None }];
+            second.Attributes = [new Conflicts { Hash = mempooled.Hash }];
+
+            _unit.UpdatePoolForBlockPersisted(new Block
+            {
+                Header = new Header
+                {
+                    PrevHash = null!,
+                    MerkleRoot = null!,
+                    NextConsensus = null!,
+                    Witness = null!
+                },
+                Transactions = [first, second]
+            }, snapshot);
+
+            Assert.IsFalse(_unit.ContainsKey(mempooled.Hash));
+        }
     }
 }

--- a/tests/Neo.UnitTests/Ledger/UT_MemoryPool_SignerIntersect.cs
+++ b/tests/Neo.UnitTests/Ledger/UT_MemoryPool_SignerIntersect.cs
@@ -1,0 +1,109 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// UT_MemoryPool_SignerIntersect.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.Cryptography;
+using Neo.Ledger;
+using Neo.Network.P2P.Payloads;
+using System.Collections.Generic;
+
+namespace Neo.UnitTests.Ledger
+{
+    [TestClass]
+    public class UT_MemoryPool_SignerIntersect
+    {
+        private static UInt160 Account(byte seed)
+        {
+            return new UInt160(Crypto.Hash160([seed]));
+        }
+
+        private static Signer[] Signers(params UInt160[] accounts)
+        {
+            var signers = new Signer[accounts.Length];
+            for (int i = 0; i < accounts.Length; i++)
+                signers[i] = new Signer { Account = accounts[i] };
+            return signers;
+        }
+
+        private static Transaction TxWithConflicts(params UInt256[] hashes)
+        {
+            var attributes = new TransactionAttribute[hashes.Length];
+            for (int i = 0; i < hashes.Length; i++)
+                attributes[i] = new Conflicts { Hash = hashes[i] };
+            return new Transaction
+            {
+                Signers = [new Signer { Account = UInt160.Zero }],
+                Attributes = attributes,
+                Script = new byte[] { 0x41 },
+                Witnesses = [Witness.Empty]
+            };
+        }
+
+        [TestMethod]
+        public void ContainsAccount_Empty_IsFalse()
+        {
+            Assert.IsFalse(MemoryPool.ContainsAccount([], Account(1)));
+        }
+
+        [TestMethod]
+        public void ContainsAccount_MatchesFirstAndLast()
+        {
+            var a = Account(1);
+            var b = Account(2);
+            var c = Account(3);
+            var signers = Signers(a, b, c);
+
+            Assert.IsTrue(MemoryPool.ContainsAccount(signers, a));
+            Assert.IsTrue(MemoryPool.ContainsAccount(signers, b));
+            Assert.IsTrue(MemoryPool.ContainsAccount(signers, c));
+            Assert.IsFalse(MemoryPool.ContainsAccount(signers, Account(9)));
+        }
+
+        [TestMethod]
+        public void HasCommonSigner_OverlapOnLastSigner()
+        {
+            var a = Account(1);
+            var b = Account(2);
+            var c = Account(3);
+            var d = Account(4);
+
+            Assert.IsFalse(MemoryPool.HasCommonSigner([], Signers(a)));
+            Assert.IsFalse(MemoryPool.HasCommonSigner(Signers(a), []));
+            Assert.IsFalse(MemoryPool.HasCommonSigner(Signers(a, b), Signers(c, d)));
+            Assert.IsTrue(MemoryPool.HasCommonSigner(Signers(a, b), Signers(c, b)));
+            Assert.IsTrue(MemoryPool.HasCommonSigner(Signers(b), Signers(a, b)));
+        }
+
+        [TestMethod]
+        public void HasCommonAccount_OverlapOnSecondary()
+        {
+            var a = Account(1);
+            var b = Account(2);
+            var c = Account(3);
+
+            Assert.IsFalse(MemoryPool.HasCommonAccount([], Signers(a)));
+            Assert.IsFalse(MemoryPool.HasCommonAccount([a, c], Signers(b)));
+            Assert.IsTrue(MemoryPool.HasCommonAccount([a, b], Signers(c, b)));
+        }
+
+        [TestMethod]
+        public void ContainsPersistedConflict_HitsAndMisses()
+        {
+            var hit = UInt256.Zero;
+            var miss = UInt256.Parse("0x0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20");
+            var persisted = new HashSet<UInt256> { hit };
+
+            Assert.IsFalse(MemoryPool.ContainsPersistedConflict(TxWithConflicts(), persisted));
+            Assert.IsFalse(MemoryPool.ContainsPersistedConflict(TxWithConflicts(miss), persisted));
+            Assert.IsTrue(MemoryPool.ContainsPersistedConflict(TxWithConflicts(miss, hit), persisted));
+        }
+    }
+}


### PR DESCRIPTION
Conflict checks walk tiny `Signer` arrays. `Select`/`Intersect`/`Contains` allocated enumerators and hash sets on every mempool insert and block persist.

## Change
- Nested loops for shared-signer tests
- `HashSet` of persisted transaction hashes when dropping conflicts after a block
- Same conflict rules as before

Independent of other PRs. Node-side mempool only; not consensus-critical.