### PR TITLE
fix(Mnemonic): look up BIP-39 word indices in the selected wordlist

### DIFF
--- a/src/Neo/Wallets/Mnemonic.cs
+++ b/src/Neo/Wallets/Mnemonic.cs
@@ -33,7 +33,6 @@ namespace Neo.Wallets
     public class Mnemonic : IReadOnlyList<string>
     {
         static readonly Dictionary<string, string[]> s_wordlists = new();
-        static readonly Dictionary<string, int> s_wordlistsReverseIndex = new();
         readonly string[] words;
 
         /// <summary>
@@ -59,8 +58,6 @@ namespace Neo.Wallets
                 string value = (string)res.Value!;
                 string[] wordlist = value.Split(['\n', '\r'], StringSplitOptions.RemoveEmptyEntries);
                 s_wordlists.Add(key[7..], wordlist);
-                for (int i = 0; i < wordlist.Length; i++)
-                    s_wordlistsReverseIndex[wordlist[i]] = i;
             }
         }
 
@@ -102,9 +99,12 @@ namespace Neo.Wallets
             int entropyBytes = entropyBits / 8;
             byte[] entropy = new byte[entropyBytes];
             Span<byte> checksum = stackalloc byte[(checksumBits + 7) / 8];
+            var reverseIndex = new Dictionary<string, int>(wordlist.Length);
+            for (int i = 0; i < wordlist.Length; i++)
+                reverseIndex[wordlist[i]] = i;
             for (int i = 0; i < wordCount; i++)
             {
-                if (!s_wordlistsReverseIndex.TryGetValue(words[i], out int index))
+                if (!reverseIndex.TryGetValue(words[i], out int index))
                     throw new ArgumentException($"The word '{words[i]}' is not in the BIP-0039 wordlist.", nameof(words));
                 for (int j = 0; j < 11; j++)
                 {

--- a/tests/Neo.UnitTests/Wallets/UT_Mnemonic.cs
+++ b/tests/Neo.UnitTests/Wallets/UT_Mnemonic.cs
@@ -269,5 +269,21 @@ namespace Neo.UnitTests.Wallets
             Assert.AreEqual(expectedMnemonic, Mnemonic.Parse(expectedMnemonic).ToString());
             Assert.AreSequenceEqual(seed, mnemonic.DeriveSeed(passphrase));
         }
+
+        [TestMethod]
+        public void Parse_RoundTrip_AllCultures()
+        {
+            // Shared words such as English/French "abandon" live at different
+            // indices. Parse must use the selected wordlist, not a merged map.
+            byte[] entropy = Convert.FromHexString("00000000000000000000000000000000");
+            string[] cultures = ["en", "fr", "es", "it", "cs", "pt", "zh", "ja", "ko", "zh-Hant"];
+            foreach (var name in cultures)
+            {
+                var created = Mnemonic.Create(entropy, new CultureInfo(name));
+                var parsed = Mnemonic.Parse(created.ToString());
+                Assert.AreEqual(created.ToString(), parsed.ToString(), name);
+                Assert.AreSequenceEqual(created.DeriveSeed(), parsed.DeriveSeed());
+            }
+        }
     }
 }


### PR DESCRIPTION
`Parse` already picks a language wordlist, but the constructor then resolved each word against a **single global reverse index**. Later wordlists overwrote shared words such as English/French `abandon` (English index 0, French index 1), so a valid mnemonic could fail checksum or decode to the wrong entropy.

## Change
Build the reverse map from the wordlist that `Parse` selected. Add a round-trip test for every bundled culture (`en`, `fr`, `es`, `it`, `cs`, `pt`, `zh`, `ja`, `ko`, `zh-Hant`).

Independent of other PRs. Off-chain wallet helper only; not consensus-critical.